### PR TITLE
missing ul and remove exec env warnings by setting java compiler to 1.6 f

### DIFF
--- a/quickstarts/helloworld-osgi/pom.xml
+++ b/quickstarts/helloworld-osgi/pom.xml
@@ -106,6 +106,18 @@
                <filename>${project.build.finalName}.jar</filename>
             </configuration>
          </plugin>
+         
+         <!-- Compiler plugin enforces Java 1.6 compatibility to remove
+         unnecessary warnings about execution environment in IDE -->
+         <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>2.3.1</version>
+            <configuration>
+               <source>1.6</source>
+               <target>1.6</target>
+            </configuration>
+         </plugin>
+         
       </plugins>
    </build>
 </project>

--- a/quickstarts/kitchensink/src/main/webapp/WEB-INF/templates/default.xhtml
+++ b/quickstarts/kitchensink/src/main/webapp/WEB-INF/templates/default.xhtml
@@ -14,11 +14,13 @@
          <div id="sidebar">
             <h3>Find out more</h3>
             <p>Learn about JBoss AS 7.</p>
+            <ul>
             <li><a
                href="https://docs.jboss.org/author/display/AS7/Getting+Started+Developing+Applications+Guide">JBoss
                   AS 7 Getting Started Developing Applications Guide</a></li>
             <li><a href="jboss.org/jbossas">JBoss AS 7 project
                   site</a></li>
+            </ul>
             <p>Learn about the Java EE 6 platform and the component
                model it provides.</p>
             <ul>


### PR DESCRIPTION
missing ul and remove exec env warnings by setting java compiler to 1.6 for compiler
