### PR TITLE
Add automated datasource deployments for mysql and postgresql

### DIFF
--- a/datasource/pom.xml
+++ b/datasource/pom.xml
@@ -9,6 +9,16 @@
     <packaging>pom</packaging>
     <name>JBoss AS Quickstarts: Datasources</name>
 
+    <description>
+        The pom provides example datasource configurations that can be deployed using the jboss-as maven
+        plugin. To deploy a datasource modify the database properties below (or specify them using -D) and
+        run maven with the appropriate profile for the database you wish to connect to. For example, to deploy
+        a postgresql XA datasource you would run:
+
+        mvn install -Ppostgresql-xa
+
+    </description>
+
     <url>http://jboss.org/jbossas</url>
     <licenses>
         <license>
@@ -27,6 +37,7 @@
         <pool.name>myPool</pool.name>
         <!-- Database driver versions-->
         <postgresql.version>8.4-702.jdbc4</postgresql.version>
+        <mysql.version>5.1.15</mysql.version>
     </properties>
 
     <build>
@@ -132,11 +143,116 @@
                                         <xa-data-source-properties>!![("DatabaseName"=>"${database.name}"),("ServerName"=>"${server.name}"),("User"=>"${username}"),("Password"=>"${password}")]</xa-data-source-properties>
                                         <jndi-name>${datasource.name}</jndi-name>
                                         <enabled>true</enabled>
-                                        <xa-datasource-class>org.postgresql.xa.PGXADataSource</xa-datasource-class>
                                         <pool-name>${pool.name}</pool-name>
                                         <security.user>${username}</security.user>
                                         <security.password>${password}</security.password>
                                         <driver-name>postgresql.jar</driver-name>
+                                    </properties>
+                                </configuration>
+                                <goals>
+                                    <goal>add-resource</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+
+        <profile>
+            <id>mysql</id>
+            <dependencies>
+                <dependency>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                    <version>${mysql.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jboss.as.plugins</groupId>
+                        <artifactId>jboss-as-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deploy-driver</id>
+                                <phase>package</phase>
+                                <configuration>
+                                    <groupId>mysql</groupId>
+                                    <artifactId>mysql</artifactId>
+                                    <name>mysql.jar</name>
+                                </configuration>
+                                <goals>
+                                    <goal>deploy-artifact</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>add-datasource</id>
+                                <phase>install</phase>
+                                <configuration>
+                                    <address>subsystem=datasources,data-source=${datasource.name}</address>
+                                    <properties>
+                                        <connection-url>jdbc:mysql://${server.name}/${database.name}</connection-url>
+                                        <jndi-name>${datasource.name}</jndi-name>
+                                        <enabled>true</enabled>
+                                        <pool-name>${pool.name}</pool-name>
+                                        <user-name>${username}</user-name>
+                                        <password>${password}</password>
+                                        <driver-name>mysql.jar</driver-name>
+                                    </properties>
+                                </configuration>
+                                <goals>
+                                    <goal>add-resource</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>mysql-xa</id>
+            <dependencies>
+                <dependency>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                    <version>${mysql.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jboss.as.plugins</groupId>
+                        <artifactId>jboss-as-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deploy-driver</id>
+                                <phase>package</phase>
+                                <configuration>
+                                    <groupId>mysql</groupId>
+                                    <artifactId>mysql</artifactId>
+                                    <name>mysql.jar</name>
+                                </configuration>
+                                <goals>
+                                    <goal>deploy-artifact</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>add-datasource</id>
+                                <phase>install</phase>
+                                <configuration>
+                                    <address>subsystem=datasources,xa-data-source=${datasource.name}</address>
+                                    <properties>
+                                        <xa-data-source-class>com.mysql.jdbc.jdbc2.optional.MysqlXADataSource</xa-data-source-class>
+                                        <xa-data-source-properties>!![("DatabaseName"=>"${database.name}"),("ServerName"=>"${server.name}"),("User"=>"${username}"),("Password"=>"${password}")]</xa-data-source-properties>
+                                        <jndi-name>${datasource.name}</jndi-name>
+                                        <enabled>true</enabled>
+                                        <pool-name>${pool.name}</pool-name>
+                                        <security.user>${username}</security.user>
+                                        <security.password>${password}</security.password>
+                                        <driver-name>mysql.jar</driver-name>
                                     </properties>
                                 </configuration>
                                 <goals>

--- a/datasource/pom.xml
+++ b/datasource/pom.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.as.quickstarts</groupId>
+    <artifactId>jboss-as-datasources</artifactId>
+    <version>7.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>JBoss AS Quickstarts: Datasources</name>
+
+    <url>http://jboss.org/jbossas</url>
+    <licenses>
+        <license>
+            <name>GNU Lesser General Public License</name>
+            <url>http://www.gnu.org/copyleft/lesser.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <datasource.name>java:jboss/datasources/MyDatasource</datasource.name>
+        <database.name>myDatabase</database.name>
+        <server.name>localhost</server.name>
+        <username>username</username>
+        <password>password</password>
+        <pool.name>myPool</pool.name>
+        <!-- Database driver versions-->
+        <postgresql.version>8.4-702.jdbc4</postgresql.version>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <!-- TODO move to parent-->
+                    <groupId>org.jboss.as.plugins</groupId>
+                    <artifactId>jboss-as-maven-plugin</artifactId>
+                    <version>7.0.1.Final</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>postgresql</id>
+            <dependencies>
+                <dependency>
+                    <groupId>postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                    <version>${postgresql.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jboss.as.plugins</groupId>
+                        <artifactId>jboss-as-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deploy-driver</id>
+                                <phase>package</phase>
+                                <configuration>
+                                    <groupId>postgresql</groupId>
+                                    <artifactId>postgresql</artifactId>
+                                    <name>postgresql.jar</name>
+                                </configuration>
+                                <goals>
+                                    <goal>deploy-artifact</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>add-datasource</id>
+                                <phase>install</phase>
+                                <configuration>
+                                    <address>subsystem=datasources,data-source=${datasource.name}</address>
+                                    <properties>
+                                        <connection-url>jdbc:postgresql://${server.name}/${database.name}</connection-url>
+                                        <jndi-name>${datasource.name}</jndi-name>
+                                        <enabled>true</enabled>
+                                        <pool-name>${pool.name}</pool-name>
+                                        <user-name>${username}</user-name>
+                                        <password>${password}</password>
+                                        <driver-name>postgresql.jar</driver-name>
+                                    </properties>
+                                </configuration>
+                                <goals>
+                                    <goal>add-resource</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>postgresql-xa</id>
+            <dependencies>
+                <dependency>
+                    <groupId>postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                    <version>${postgresql.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jboss.as.plugins</groupId>
+                        <artifactId>jboss-as-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deploy-driver</id>
+                                <phase>package</phase>
+                                <configuration>
+                                    <groupId>postgresql</groupId>
+                                    <artifactId>postgresql</artifactId>
+                                    <name>postgresql.jar</name>
+                                </configuration>
+                                <goals>
+                                    <goal>deploy-artifact</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>add-datasource</id>
+                                <phase>install</phase>
+                                <configuration>
+                                    <address>subsystem=datasources,xa-data-source=${datasource.name}</address>
+                                    <properties>
+                                        <xa-data-source-class>org.postgresql.xa.PGXADataSource</xa-data-source-class>
+                                        <xa-data-source-properties>!![("DatabaseName"=>"${database.name}"),("ServerName"=>"${server.name}"),("User"=>"${username}"),("Password"=>"${password}")]</xa-data-source-properties>
+                                        <jndi-name>${datasource.name}</jndi-name>
+                                        <enabled>true</enabled>
+                                        <xa-datasource-class>org.postgresql.xa.PGXADataSource</xa-datasource-class>
+                                        <pool-name>${pool.name}</pool-name>
+                                        <security.user>${username}</security.user>
+                                        <security.password>${password}</security.password>
+                                        <driver-name>postgresql.jar</driver-name>
+                                    </properties>
+                                </configuration>
+                                <goals>
+                                    <goal>add-resource</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
+
+
+</project>

--- a/kitchensink/src/main/java/org/jboss/as/quickstarts/kitchensink/rest/MemberResourceRESTService.java
+++ b/kitchensink/src/main/java/org/jboss/as/quickstarts/kitchensink/rest/MemberResourceRESTService.java
@@ -14,7 +14,7 @@ import org.jboss.as.quickstarts.kitchensink.model.Member;
 
 /**
  * JAX-RS Example
- * 
+ *
  * This class produces a RESTful service to read the contents of the members table.
  */
 @Path("/members")
@@ -37,10 +37,4 @@ public class MemberResourceRESTService {
       return results;
    }
 
-   @GET
-   @Path("/{id:[0-9][0-9]*}")
-   @Produces("text/xml")
-   public Member lookupMemberById(@PathParam("id") long id) {
-      return em.find(Member.class, id);
-   }
 }

--- a/login/datasource/pom.xml
+++ b/login/datasource/pom.xml
@@ -29,7 +29,7 @@
     </licenses>
 
     <properties>
-        <datasource.name>java:jboss/datasources/MyDatasource</datasource.name>
+        <datasource.name>java:jboss/datasources/ExampleDS</datasource.name>
         <database.name>myDatabase</database.name>
         <server.name>localhost</server.name>
         <username>username</username>

--- a/login/datasource/pom.xml
+++ b/login/datasource/pom.xml
@@ -180,7 +180,7 @@
                                 <phase>package</phase>
                                 <configuration>
                                     <groupId>mysql</groupId>
-                                    <artifactId>mysql</artifactId>
+                                    <artifactId>mysql-connector-java</artifactId>
                                     <name>mysql.jar</name>
                                 </configuration>
                                 <goals>
@@ -232,7 +232,7 @@
                                 <phase>package</phase>
                                 <configuration>
                                     <groupId>mysql</groupId>
-                                    <artifactId>mysql</artifactId>
+                                    <artifactId>mysql-connector-java</artifactId>
                                     <name>mysql.jar</name>
                                 </configuration>
                                 <goals>
@@ -267,5 +267,20 @@
 
     </profiles>
 
-
+      <pluginRepositories>
+        <pluginRepository>
+          <id>jboss-public-repository-group</id>
+          <name>JBoss Public Maven Repository Group</name>
+          <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
 </project>

--- a/login/pom.xml
+++ b/login/pom.xml
@@ -1,167 +1,128 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-   <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-   <groupId>org.jboss.as.quickstarts</groupId>
-   <artifactId>jboss-as-login</artifactId>
-   <version>7.0.1-SNAPSHOT</version>
-   <packaging>war</packaging>
-   <name>JBoss AS Quickstarts: Login</name>
+    <groupId>org.jboss.as.quickstarts</groupId>
+    <artifactId>jboss-as-login</artifactId>
+    <version>7.0.1-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <name>JBoss AS Quickstarts: Login</name>
 
-   <url>http://jboss.org/jbossas</url>
-   <licenses>
-      <license>
-         <name>Apache License, Version 2.0</name>
-         <distribution>repo</distribution>
-         <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-      </license>
-   </licenses>
+    <url>http://jboss.org/jbossas</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
 
-   <properties>
-      <!-- Explicitly declaring the source encoding eliminates the following 
-         message: -->
-      <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
-         resources, i.e. build is platform dependent! -->
-      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-   </properties>
+    <properties>
+        <!-- Explicitly declaring the source encoding eliminates the following
+       message: -->
+        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
+  resources, i.e. build is platform dependent! -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
-   <!-- Include the JBoss Maven repository so we can access JBoss artifacts -->
-   <repositories>
-      <repository>
-         <id>jboss-public-repository</id>
-         <name>JBoss Repository</name>
-         <url>https://repository.jboss.org/nexus/content/groups/public</url>
-         <releases>
-            <enabled>true</enabled>
-         </releases>
-         <snapshots>
-            <enabled>false</enabled>
-         </snapshots>
-      </repository>
-   </repositories>
+    <!-- Include the JBoss Maven repository so we can access JBoss artifacts -->
+    <repositories>
+        <repository>
+            <id>jboss-public-repository</id>
+            <name>JBoss Repository</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
-   <pluginRepositories>
-      <pluginRepository>
-         <id>jboss-public-repository</id>
-         <name>JBoss Repository</name>
-         <url>https://repository.jboss.org/nexus/content/groups/public</url>
-         <releases>
-            <enabled>true</enabled>
-         </releases>
-         <snapshots>
-            <enabled>false</enabled>
-         </snapshots>
-      </pluginRepository>
-   </pluginRepositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jboss-public-repository</id>
+            <name>JBoss Repository</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
-   <dependencyManagement>
-      <dependencies>
-         <!-- Define the version of JBoss' Java EE 6 APIs we want to import. 
-            Any dependencies from org.jboss.spec will have their version defined by this 
-            BOM -->
-         <!-- JBoss distributes a complete set of Java EE 6 APIs including 
-            a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or 
-            a collection) of artifacts. We use this here so that we always get the correct 
-            versions of artifacts. Here we use the jboss-javaee-web-6.0 stack (you can 
-            read this as the JBoss stack of the Java EE Web Profile 6 APIs), and we use 
-            version 2.0.0.Beta1 which is the latest release of the stack. You can actually 
-            use this stack with any version of JBoss AS that implements Java EE 6, not 
-            just JBoss AS 7! -->
-         <dependency>
+    <dependencyManagement>
+        <dependencies>
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+           Any dependencies from org.jboss.spec will have their version defined by this
+           BOM -->
+            <!-- JBoss distributes a complete set of Java EE 6 APIs including
+        a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+        a collection) of artifacts. We use this here so that we always get the correct
+        versions of artifacts. Here we use the jboss-javaee-web-6.0 stack (you can
+        read this as the JBoss stack of the Java EE Web Profile 6 APIs), and we use
+        version 2.0.0.Beta1 which is the latest release of the stack. You can actually
+        use this stack with any version of JBoss AS that implements Java EE 6, not
+        just JBoss AS 7! -->
+            <dependency>
+                <groupId>org.jboss.spec</groupId>
+                <artifactId>jboss-javaee-web-6.0</artifactId>
+                <version>2.0.0.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+
+        <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-web-6.0</artifactId>
             <version>2.0.0.Final</version>
             <type>pom</type>
-            <scope>import</scope>
-         </dependency>
-      </dependencies>
-   </dependencyManagement>
+            <scope>provided</scope>
+        </dependency>
 
-   <dependencies>
+    </dependencies>
 
-      <!-- Import the CDI API, we use provided scope as the API is included 
-         in JBoss AS 7 -->
-      <dependency>
-         <groupId>javax.enterprise</groupId>
-         <artifactId>cdi-api</artifactId>
-         <scope>provided</scope>
-      </dependency>
-
-      <!-- Import the Common Annotations API (JSR-250), we use provided scope 
-         as the API is included in JBoss AS 7 -->
-      <dependency>
-         <groupId>org.jboss.spec.javax.annotation</groupId>
-         <artifactId>jboss-annotations-api_1.1_spec</artifactId>
-         <scope>provided</scope>
-      </dependency>
-
-      <!-- Import the JSF API, we use provided scope as the API is included 
-         in JBoss AS 7 -->
-      <dependency>
-         <groupId>org.jboss.spec.javax.faces</groupId>
-         <artifactId>jboss-jsf-api_2.0_spec</artifactId>
-         <scope>provided</scope>
-      </dependency>
-
-      <!-- Import the JPA API, we use provided scope as the API is included 
-         in JBoss AS 7 -->
-      <dependency>
-         <groupId>org.hibernate.javax.persistence</groupId>
-         <artifactId>hibernate-jpa-2.0-api</artifactId>
-         <scope>provided</scope>
-      </dependency>
-
-      <!-- Import the JPA API, we use provided scope as the API is included 
-         in JBoss AS 7 -->
-      <dependency>
-         <groupId>org.jboss.spec.javax.transaction</groupId>
-         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
-         <scope>provided</scope>
-      </dependency>
-
-      <!-- Import the EJB API, we use provided scope as the API is included 
-         in JBoss AS 7 -->
-      <dependency>
-         <groupId>org.jboss.spec.javax.ejb</groupId>
-         <artifactId>jboss-ejb-api_3.1_spec</artifactId>
-         <scope>provided</scope>
-      </dependency>
-
-   </dependencies>
-
-   <build>
-      <!-- Set the name of the war, used as the context root when the app 
-         is deployed -->
-      <finalName>jboss-as-login</finalName>
-      <plugins>
-         <plugin>
-            <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
-            <configuration>
-               <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
-                  up! -->
-               <failOnMissingWebXml>false</failOnMissingWebXml>
-            </configuration>
-         </plugin>
-         <!-- JBoss AS plugin to deploy war -->
-         <plugin>
-            <groupId>org.jboss.as.plugins</groupId>
-            <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.0.0.Final</version>
-         </plugin>
-         <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
-            annotation processors -->
-         <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
-            </configuration>
-         </plugin>
-      </plugins>
-   </build>
+    <build>
+        <!-- Set the name of the war, used as the context root when the app
+      is deployed -->
+        <finalName>jboss-as-login</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.1.1</version>
+                <configuration>
+                    <!-- Java EE 6 doesn't require web.xml, Maven needs to catch
+                   up! -->
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+            <!-- JBoss AS plugin to deploy war -->
+            <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <version>7.0.0.Final</version>
+            </plugin>
+            <!-- Compiler plugin enforces Java 1.6 compatibility and activates
+          annotation processors -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>
 

--- a/login/src/main/java/org/jboss/as/quickstarts/login/AuthenticationInterceptor.java
+++ b/login/src/main/java/org/jboss/as/quickstarts/login/AuthenticationInterceptor.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.quickstarts.login;
+
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+/**
+ * Interceptor that only allows a logged in user access to restful resources
+ *
+ * @author Stuart Douglas
+ */
+@Interceptor
+@AuthenticationRequired
+public class AuthenticationInterceptor {
+
+    @Inject
+    private Login login;
+
+    @AroundInvoke
+    public Object interceptor(final  InvocationContext context) throws Exception {
+        if(login.getCurrentUser() == null) {
+            throw new RuntimeException("You must be authenticated to use this resource");
+        }
+        return context.proceed();
+    }
+
+}

--- a/login/src/main/java/org/jboss/as/quickstarts/login/AuthenticationRequired.java
+++ b/login/src/main/java/org/jboss/as/quickstarts/login/AuthenticationRequired.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.quickstarts.login;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+/**
+ * @author Stuart Douglas
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@InterceptorBinding
+public @interface AuthenticationRequired {
+}

--- a/login/src/main/java/org/jboss/as/quickstarts/login/Login.java
+++ b/login/src/main/java/org/jboss/as/quickstarts/login/Login.java
@@ -8,6 +8,7 @@ import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.xml.bind.annotation.XmlRootElement;
 
 @SessionScoped
 @Named

--- a/login/src/main/java/org/jboss/as/quickstarts/login/User.java
+++ b/login/src/main/java/org/jboss/as/quickstarts/login/User.java
@@ -2,8 +2,13 @@ package org.jboss.as.quickstarts.login;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Table;
 
+/**
+ * The user entity. As user is a reserved word in some databases we change the table name in the database
+ */
 @Entity
+@Table(name = "person")
 public class User {
    @Id
    private String username;

--- a/login/src/main/java/org/jboss/as/quickstarts/login/User.java
+++ b/login/src/main/java/org/jboss/as/quickstarts/login/User.java
@@ -3,12 +3,14 @@ package org.jboss.as.quickstarts.login;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * The user entity. As user is a reserved word in some databases we change the table name in the database
  */
 @Entity
 @Table(name = "person")
+@XmlRootElement
 public class User {
    @Id
    private String username;

--- a/login/src/main/java/org/jboss/as/quickstarts/login/rest/JaxRsActivator.java
+++ b/login/src/main/java/org/jboss/as/quickstarts/login/rest/JaxRsActivator.java
@@ -1,0 +1,18 @@
+package org.jboss.as.quickstarts.login.rest;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * A class extending {@link Application} and annotated with @ApplicationPath is the Java EE 6
+ * "no XML" approach to activating JAX-RS.
+ *
+ * <p>
+ * Resources are served relative to the servlet path specified in the {@link ApplicationPath}
+ * annotation.
+ * </p>
+ */
+@ApplicationPath("/rest")
+public class JaxRsActivator extends Application {
+   /* class body intentionally left blank */
+}

--- a/login/src/main/java/org/jboss/as/quickstarts/login/rest/LoginResourceRESTService.java
+++ b/login/src/main/java/org/jboss/as/quickstarts/login/rest/LoginResourceRESTService.java
@@ -2,42 +2,57 @@ package org.jboss.as.quickstarts.login.rest;
 
 import java.util.List;
 
-import javax.enterprise.context.RequestScoped;
+import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 
 import org.jboss.as.quickstarts.login.AuthenticationRequired;
-import org.jboss.as.quickstarts.login.Login;
 import org.jboss.as.quickstarts.login.User;
 
 /**
  * JAX-RS Example
- *
+ * <p/>
  * This class produces a RESTful service to read the contents of the members table.
  */
 @Path("/logins")
-@RequestScoped
 @AuthenticationRequired
+@Stateless
 public class LoginResourceRESTService {
-   @Inject
-   private EntityManager em;
+    @Inject
+    private EntityManager em;
 
-   @GET
-   @Produces("text/xml")
-   public List<User> listAllMembers() {
-      @SuppressWarnings("unchecked")
-      final List<User> results = em.createQuery("select u from User u order by u.username").getResultList();
-      return results;
-   }
+    @GET
+    @Produces("text/xml")
+    public List<User> listAllMembers() {
+        @SuppressWarnings("unchecked")
+        final List<User> results = em.createQuery("select u from User u order by u.username").getResultList();
+        return results;
+    }
 
-   @GET
-   @Path("/{id:\\w*}")
-   @Produces("text/xml")
-   public User lookupUserByUsername(@PathParam("id") String id) {
-      return em.find(User.class, id);
-   }
+    @GET
+    @Path("/{id:\\w*}")
+    @Produces("text/xml")
+    public User lookupUserByUsername(@PathParam("id") String id) {
+        return em.find(User.class, id);
+    }
+
+    //This should really be @POST
+    //but for the sake of easy demoing we are using @GET
+    @GET
+    @Path("/add/{username}")
+    @Produces("text/xml")
+    public User addUser(@PathParam("username") String username, @QueryParam("name") String name, @QueryParam("password") String password) {
+        final User user = new User();
+        user.setName(name);
+        user.setPassword(password);
+        user.setUsername(username);
+        em.persist(user);
+        return user;
+    }
+
 }

--- a/login/src/main/java/org/jboss/as/quickstarts/login/rest/LoginResourceRESTService.java
+++ b/login/src/main/java/org/jboss/as/quickstarts/login/rest/LoginResourceRESTService.java
@@ -1,0 +1,41 @@
+package org.jboss.as.quickstarts.login.rest;
+
+import java.util.List;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+import org.jboss.as.quickstarts.login.Login;
+import org.jboss.as.quickstarts.login.User;
+
+/**
+ * JAX-RS Example
+ *
+ * This class produces a RESTful service to read the contents of the members table.
+ */
+@Path("/logins")
+@RequestScoped
+public class LoginResourceRESTService {
+   @Inject
+   private EntityManager em;
+
+   @GET
+   @Produces("text/xml")
+   public List<User> listAllMembers() {
+      @SuppressWarnings("unchecked")
+      final List<User> results = em.createQuery("select u from User u order by u.username").getResultList();
+      return results;
+   }
+
+   @GET
+   @Path("/{id:\\w*}")
+   @Produces("text/xml")
+   public User lookupUserByUsername(@PathParam("id") String id) {
+      return em.find(User.class, id);
+   }
+}

--- a/login/src/main/java/org/jboss/as/quickstarts/login/rest/LoginResourceRESTService.java
+++ b/login/src/main/java/org/jboss/as/quickstarts/login/rest/LoginResourceRESTService.java
@@ -10,6 +10,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 
+import org.jboss.as.quickstarts.login.AuthenticationRequired;
 import org.jboss.as.quickstarts.login.Login;
 import org.jboss.as.quickstarts.login.User;
 
@@ -20,6 +21,7 @@ import org.jboss.as.quickstarts.login.User;
  */
 @Path("/logins")
 @RequestScoped
+@AuthenticationRequired
 public class LoginResourceRESTService {
    @Inject
    private EntityManager em;

--- a/login/src/main/resources/import.sql
+++ b/login/src/main/resources/import.sql
@@ -1,1 +1,1 @@
-insert into User (username, name, password) values ('demo', 'Demo User', 'demo') 
+insert into person (username, name, password) values ('demo', 'Demo User', 'demo')

--- a/login/src/main/webapp/WEB-INF/beans.xml
+++ b/login/src/main/webapp/WEB-INF/beans.xml
@@ -1,11 +1,10 @@
 <!-- Marker file indicating CDI should be enabled -->
 <beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee 
+      http://java.sun.com/xml/ns/javaee
       http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
 
-      <!-- Uncomment this alternative to see EJB declarative transactions in use -->
-<!--       <alternatives> -->
-<!--          <class>org.jboss.as.quickstarts.login.EJBUserManager</class> -->
-<!--       </alternatives> -->
+    <interceptors>
+        <class>org.jboss.as.quickstarts.login.AuthenticationInterceptor</class>
+    </interceptors>
 </beans>


### PR DESCRIPTION
I have added a feature to the jboss-as maven plugin that allows it to automatically deploy datasources. I think it would be a good idea to have a sample of this functionality in the quickstarts, to enable people to get started with a custom datasource quickly on AS7.

This pull request has an example pom that can automatically add mysql and postgresql datasources (and xa-datasources). 
