### PR TITLE
Quickstarts: servlet-filterlistener and servlet-async

### DIFF
--- a/dist/src/main/assembly/README.md
+++ b/dist/src/main/assembly/README.md
@@ -10,6 +10,7 @@ The Getting Started Developing Applications Guide -
 contains tutorials for:
 
 * `helloworld` - CDI + Servlet
+* `servlet-async` - CDI + Asynchronous Servlet + Asynchronous EJB 
 * `numberguess` - CDI + JSF
 * `login` - CDI + JSF + JPA + EJB + JTA
 * `kitchensink` - CDI + JSF + JPA + EJB + JPA + JAX-RS + BV

--- a/dist/src/main/assembly/README.md
+++ b/dist/src/main/assembly/README.md
@@ -11,6 +11,7 @@ contains tutorials for:
 
 * `helloworld` - CDI + Servlet
 * `servlet-async` - CDI + Asynchronous Servlet + Asynchronous EJB 
+* `servlet-filterlistener` - Servlet Filter and Listener
 * `numberguess` - CDI + JSF
 * `login` - CDI + JSF + JPA + EJB + JTA
 * `kitchensink` - CDI + JSF + JPA + EJB + JPA + JAX-RS + BV

--- a/servlet-async/README.md
+++ b/servlet-async/README.md
@@ -1,0 +1,57 @@
+jboss-as-serlvet-async
+========================
+
+What is it?
+-----------
+
+This is a sample project showing the use of asynchronous servlets.
+
+It shows how to detach the execution of a resource intensive task from the request 
+processing thread, so the thread is free to serve other client requests. 
+The resource intensive tasks are executed using a dedicated thread pool and 
+create the client response asynchronously.
+
+System requirements
+-------------------
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven
+3.0 or better.
+
+The application this project produces is designed to be run on a JBoss AS 7. 
+ 
+NOTE:
+This project retrieves artifacts from the JBoss Community Maven repository, a
+superset of the Maven central repository.
+
+With the prerequisites out of the way, you're ready to build and deploy.
+
+Deploying the application
+-------------------------
+ 
+First you need to start JBoss AS 7. To do this, run
+  
+    $JBOSS_HOME/bin/standalone.sh
+  
+or if you are using windows
+ 
+    $JBOSS_HOME/bin/standalone.bat
+
+To deploy the application, you first need to produce the archive to deploy using
+the following Maven goal:
+
+    mvn package
+
+You can now deploy the artifact to JBoss AS by executing the following command:
+
+    mvn jboss-as:deploy
+
+This will deploy `target/jboss-as-servlet-async.war`.
+ 
+The application will be running at the following URL <http://localhost:8080/jboss-as-servlet-async/>.
+
+To undeploy from JBoss AS, run this command:
+
+    mvn jboss-as:undeploy
+
+You can also start JBoss AS 7 and deploy the project using Eclipse. See the JBoss AS 7
+Getting Started Guide for Developers for more information.

--- a/servlet-async/pom.xml
+++ b/servlet-async/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <groupId>org.jboss.as.quickstarts</groupId>
+   <artifactId>jboss-as-servlet-async</artifactId>
+   <version>7.0.2-SNAPSHOT</version>
+   <packaging>war</packaging>
+   <name>JBoss AS Quickstarts: Asynchronous Servlet</name>
+
+   <url>http://jboss.org/jbossas</url>
+   <licenses>
+      <license>
+         <name>Apache License, Version 2.0</name>
+         <distribution>repo</distribution>
+         <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+      </license>
+   </licenses>
+
+   <properties>
+      <!-- Explicitly declaring the source encoding eliminates the following 
+         message: -->
+      <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
+         resources, i.e. build is platform dependent! -->
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+   </properties>
+
+   <dependencyManagement>
+      <dependencies>
+         <!-- Define the version of JBoss' Java EE 6 APIs we want to use -->
+         <!-- JBoss distributes a complete set of Java EE 6 APIs including 
+            a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or 
+            a collection) of artifacts. We use this here so that we always get the correct 
+            versions of artifacts. Here we use the jboss-javaee-web-6.0 stack (you can 
+            read this as the JBoss stack of the Java EE 6 Web Profile APIs), and we use 
+            version 2.0.0.Beta1 which is the latest release of the stack. You can actually 
+            use this stack with any version of JBoss AS that implements Java EE 6, not 
+            just JBoss AS 7! -->
+         <dependency>
+            <groupId>org.jboss.spec</groupId>
+            <artifactId>jboss-javaee-web-6.0</artifactId>
+            <version>2.0.0.Final</version>
+            <type>pom</type>
+            <scope>import</scope>
+         </dependency>
+      </dependencies>
+   </dependencyManagement>
+
+   <dependencies>
+
+      <!-- Import the CDI API, we use provided scope as the API is included 
+         in JBoss AS 7 -->
+      <dependency>
+         <groupId>javax.enterprise</groupId>
+         <artifactId>cdi-api</artifactId>
+         <scope>provided</scope>
+      </dependency>
+
+      <!-- Import the Common Annotations API (JSR-250), we use provided scope 
+         as the API is included in JBoss AS 7 -->
+      <dependency>
+         <groupId>org.jboss.spec.javax.annotation</groupId>
+         <artifactId>jboss-annotations-api_1.1_spec</artifactId>
+         <scope>provided</scope>
+      </dependency>
+
+      <!-- Import the Servlet API, we use provided scope as the API is included 
+         in JBoss AS 7 -->
+      <dependency>
+         <groupId>org.jboss.spec.javax.servlet</groupId>
+         <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      
+       <!-- Import the EJB API, we use provided scope as the API is included 
+         in JBoss AS 7 -->
+      <dependency>
+         <groupId>org.jboss.spec.javax.ejb</groupId>
+         <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+         <scope>provided</scope>
+      </dependency>
+   </dependencies>
+
+   <build>
+      <!-- Set the name of the war, used as the context root when the app 
+         is deployed -->
+      <finalName>jboss-as-servlet-async</finalName>
+      <plugins>
+         <plugin>
+            <artifactId>maven-war-plugin</artifactId>
+            <version>2.1.1</version>
+            <configuration>
+               <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
+                  up! -->
+               <failOnMissingWebXml>false</failOnMissingWebXml>
+            </configuration>
+         </plugin>
+         <!-- JBoss AS plugin to deploy war -->
+         <plugin>
+            <groupId>org.jboss.as.plugins</groupId>
+            <artifactId>jboss-as-maven-plugin</artifactId>
+            <version>7.0.2.Final</version>
+         </plugin>
+         <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
+            annotation processors -->
+         <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>2.3.1</version>
+            <configuration>
+               <source>1.6</source>
+               <target>1.6</target>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+
+</project>

--- a/servlet-async/src/main/java/org/jboss/as/quickstarts/servlet/async/AsynchronousServlet.java
+++ b/servlet-async/src/main/java/org/jboss/as/quickstarts/servlet/async/AsynchronousServlet.java
@@ -1,0 +1,45 @@
+package org.jboss.as.quickstarts.servlet.async;
+
+import javax.inject.Inject;
+import javax.servlet.AsyncContext;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * <p>
+ * A simple asynchronous servlet taking advantage of features added in 3.0.
+ * </p>
+ * 
+ * <p>
+ * The servlet is registered and mapped to /AsynchronousServlet using the {@link WebServlet}
+ * annotation. The {@link LongRunningService} is injected by CDI.
+ * </p>
+ * 
+ * <p>
+ * It shows how to detach the execution of a resource intensive task from the 
+ * request processing thread, so the thread is free to serve other client requests. 
+ * The resource intensive tasks are executed using a dedicated thread pool and 
+ * create the client response asynchronously using the {@link AsyncContext}.
+ * </p>
+ * 
+ * @author Christian Sadilek <csadilek@redhat.com>
+ */
+@SuppressWarnings("serial")
+@WebServlet(value="/AsynchronousServlet", asyncSupported=true)
+public class AsynchronousServlet extends HttpServlet {
+
+   @Inject
+   private LongRunningService longRunningService;
+
+   @Override
+   protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+       // Here the request is put in asynchronous mode
+       AsyncContext asyncContext = req.startAsync();
+       
+       // This method will return immediately when invoked, 
+       // the actual execution will run in a separate thread.
+       longRunningService.readData(asyncContext);
+   }
+}

--- a/servlet-async/src/main/java/org/jboss/as/quickstarts/servlet/async/LongRunningService.java
+++ b/servlet-async/src/main/java/org/jboss/as/quickstarts/servlet/async/LongRunningService.java
@@ -1,0 +1,47 @@
+package org.jboss.as.quickstarts.servlet.async;
+
+import java.io.PrintWriter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ejb.Asynchronous;
+import javax.ejb.Stateless;
+import javax.servlet.AsyncContext;
+
+/**
+ * A simple service to simulate a long running task.
+ * 
+ * @author Christian Sadilek <csadilek@redhat.com>
+ */
+@Stateless
+public class LongRunningService {
+
+  private Logger logger = Logger.getLogger(LongRunningService.class.getName());
+  
+  /**
+   * The use of {@link Asynchronous} causes this EJB method to be executed
+   * asynchronously, by a different thread from a dedicated, container managed
+   * thread pool.
+   * 
+   * @param asyncContext
+   *          the context for a suspended Servlet request that this EJB will
+   *          complete later.
+   */
+   @Asynchronous
+   public void readData(AsyncContext asyncContext) {
+       try {
+           // This is just to simulate a long running operation.
+           Thread.sleep(5000);
+      
+           PrintWriter writer = asyncContext.getResponse().getWriter();
+           writer.println(new SimpleDateFormat("HH:mm:ss").format(new Date()));
+           writer.close();
+           
+           asyncContext.complete();
+       } catch (Exception e) {
+           logger.log(Level.SEVERE, e.getMessage(), e);
+       }
+   }
+}

--- a/servlet-async/src/main/webapp/WEB-INF/beans.xml
+++ b/servlet-async/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<!-- Marker file indicating CDI should be enabled -->
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee 
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/servlet-async/src/main/webapp/index.html
+++ b/servlet-async/src/main/webapp/index.html
@@ -1,0 +1,46 @@
+<html>
+<head>
+    <title>JBOSS AS 7 - Asynchronous Servlet demo</title>
+</head>
+
+<body>
+    <div>
+        This simple demo client continuously sends requests to <i>/AsynchronousServlet</i><br /> 
+        to invoke a resource intensive task which asynchronously generates a response.
+    </div>
+    <br />
+    Last response received at:
+    <div id="response">
+        <i>(no response yet)</i>
+    </div>
+
+    <script type="text/javascript">
+        function requestData() {
+            var request;
+            try {
+                if (window.XMLHttpRequest) {
+                    request = new XMLHttpRequest();
+                } else {
+                    request = new ActiveXObject("Microsoft.XMLHTTP");
+                }
+            } catch (e) {
+                alert("Your browser does not support XMLHttpRequest!");
+            }
+
+            request.open("GET", "AsynchronousServlet", true);
+            request.onreadystatechange = function() {
+                if (request.readyState == 4) {
+                    if (request.status == 200) {
+                        document.getElementById("response").innerHTML = request.responseText;
+                        requestData();
+                    } else {
+                        console.log("Unexpected response received from server:"+request.status)
+                    }
+                }
+            }
+            request.send(null);
+        }
+        requestData();
+    </script>
+</body>
+</html>

--- a/servlet-filterlistener/README.md
+++ b/servlet-filterlistener/README.md
@@ -1,0 +1,52 @@
+jboss-as-serlvet-filterlistener
+===============================
+
+What is it?
+-----------
+
+This is a sample project showing the use of servlet filters and listeners.
+
+System requirements
+-------------------
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven
+3.0 or better.
+
+The application this project produces is designed to be run on a JBoss AS 7. 
+ 
+NOTE:
+This project retrieves artifacts from the JBoss Community Maven repository, a
+superset of the Maven central repository.
+
+With the prerequisites out of the way, you're ready to build and deploy.
+
+Deploying the application
+-------------------------
+ 
+First you need to start JBoss AS 7. To do this, run
+  
+    $JBOSS_HOME/bin/standalone.sh
+  
+or if you are using windows
+ 
+    $JBOSS_HOME/bin/standalone.bat
+
+To deploy the application, you first need to produce the archive to deploy using
+the following Maven goal:
+
+    mvn package
+
+You can now deploy the artifact to JBoss AS by executing the following command:
+
+    mvn jboss-as:deploy
+
+This will deploy `target/jboss-as-servlet-filterlistener.war`.
+ 
+The application will be running at the following URL <http://localhost:8080/jboss-as-servlet-filterlistener/>.
+
+To undeploy from JBoss AS, run this command:
+
+    mvn jboss-as:undeploy
+
+You can also start JBoss AS 7 and deploy the project using Eclipse. See the JBoss AS 7
+Getting Started Guide for Developers for more information.

--- a/servlet-filterlistener/pom.xml
+++ b/servlet-filterlistener/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <groupId>org.jboss.as.quickstarts</groupId>
+   <artifactId>jboss-as-servlet-filterlistener</artifactId>
+   <version>7.0.2-SNAPSHOT</version>
+   <packaging>war</packaging>
+   <name>JBoss AS Quickstarts: Servlet Filter and Listener</name>
+
+   <url>http://jboss.org/jbossas</url>
+   <licenses>
+      <license>
+         <name>Apache License, Version 2.0</name>
+         <distribution>repo</distribution>
+         <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+      </license>
+   </licenses>
+
+   <properties>
+      <!-- Explicitly declaring the source encoding eliminates the following 
+         message: -->
+      <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
+         resources, i.e. build is platform dependent! -->
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+   </properties>
+
+   <dependencyManagement>
+      <dependencies>
+         <!-- Define the version of JBoss' Java EE 6 APIs we want to use -->
+         <!-- JBoss distributes a complete set of Java EE 6 APIs including 
+            a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or 
+            a collection) of artifacts. We use this here so that we always get the correct 
+            versions of artifacts. Here we use the jboss-javaee-web-6.0 stack (you can 
+            read this as the JBoss stack of the Java EE 6 Web Profile APIs), and we use 
+            version 2.0.0.Beta1 which is the latest release of the stack. You can actually 
+            use this stack with any version of JBoss AS that implements Java EE 6, not 
+            just JBoss AS 7! -->
+         <dependency>
+            <groupId>org.jboss.spec</groupId>
+            <artifactId>jboss-javaee-web-6.0</artifactId>
+            <version>2.0.0.Final</version>
+            <type>pom</type>
+            <scope>import</scope>
+         </dependency>
+      </dependencies>
+   </dependencyManagement>
+
+   <dependencies>
+
+      <!-- Import the CDI API, we use provided scope as the API is included 
+         in JBoss AS 7 -->
+      <dependency>
+         <groupId>javax.enterprise</groupId>
+         <artifactId>cdi-api</artifactId>
+         <scope>provided</scope>
+      </dependency>
+
+      <!-- Import the Common Annotations API (JSR-250), we use provided scope 
+         as the API is included in JBoss AS 7 -->
+      <dependency>
+         <groupId>org.jboss.spec.javax.annotation</groupId>
+         <artifactId>jboss-annotations-api_1.1_spec</artifactId>
+         <scope>provided</scope>
+      </dependency>
+
+      <!-- Import the Servlet API, we use provided scope as the API is included 
+         in JBoss AS 7 -->
+      <dependency>
+         <groupId>org.jboss.spec.javax.servlet</groupId>
+         <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+         <scope>provided</scope>
+      </dependency>
+
+   </dependencies>
+
+   <build>
+      <!-- Set the name of the war, used as the context root when the app 
+         is deployed -->
+      <finalName>jboss-as-servlet-filterlistener</finalName>
+      <plugins>
+         <plugin>
+            <artifactId>maven-war-plugin</artifactId>
+            <version>2.1.1</version>
+            <configuration>
+               <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
+                  up! -->
+               <failOnMissingWebXml>false</failOnMissingWebXml>
+            </configuration>
+         </plugin>
+         <!-- JBoss AS plugin to deploy war -->
+         <plugin>
+            <groupId>org.jboss.as.plugins</groupId>
+            <artifactId>jboss-as-maven-plugin</artifactId>
+            <version>7.0.2.Final</version>
+         </plugin>
+         <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
+            annotation processors -->
+         <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>2.3.1</version>
+            <configuration>
+               <source>1.6</source>
+               <target>1.6</target>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+
+</project>

--- a/servlet-filterlistener/src/main/java/org/jboss/as/quickstarts/servlet/filterlistener/FilterExampleServlet.java
+++ b/servlet-filterlistener/src/main/java/org/jboss/as/quickstarts/servlet/filterlistener/FilterExampleServlet.java
@@ -1,0 +1,44 @@
+package org.jboss.as.quickstarts.servlet.filterlistener;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A simple servlet that exists as a target for Servlet Filters and Servlet Listeners.
+ * 
+ * @author Jonathan Fuerth <jfuerth@redhat.com>
+ */
+@SuppressWarnings("serial")
+@WebServlet("/FilterExample")
+public class FilterExampleServlet extends HttpServlet {
+
+   @Override
+   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+      PrintWriter writer = resp.getWriter();
+      writer.println("<!DOCTYPE HTML>");
+      writer.println("<html>");
+      writer.println(" <head>");
+      writer.println("  <title>Servlet filter example</title>");
+      writer.println(" </head>");
+      writer.println(" <body>");
+      writer.println("  <form>");
+      writer.println("   <label for=userInput>Enter some text:</label> <input type=text name=userInput>");
+      writer.println("   <button type=submit>Send</button></form>");
+      writer.println("  </form>");
+      
+      if (req.getParameter("userInput") != null) {
+        writer.println("  <h1>You Typed " + req.getParameter("userInput") + "</h1>");
+      }
+      
+      writer.println(" </body>");
+      writer.println("</html>");
+      writer.close();
+   }
+
+}

--- a/servlet-filterlistener/src/main/java/org/jboss/as/quickstarts/servlet/filterlistener/ParameterDumpingRequestListener.java
+++ b/servlet-filterlistener/src/main/java/org/jboss/as/quickstarts/servlet/filterlistener/ParameterDumpingRequestListener.java
@@ -1,0 +1,42 @@
+package org.jboss.as.quickstarts.servlet.filterlistener;
+
+import java.util.Map;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRequestEvent;
+import javax.servlet.ServletRequestListener;
+import javax.servlet.annotation.WebListener;
+
+/**
+ * A simple request listener that dumps all the parameters of the HTTP requests.
+ * <p>
+ * Because Request Listeners see requests before Filters see them, this listener
+ * sees the original parameter values as sent by the user rather than the
+ * modified ones passed down the filter chain by {@link VowelRemoverFilter}.
+ * 
+ * @author Jonathan Fuerth <jfuerth@redhat.com>
+ */
+@WebListener
+public class ParameterDumpingRequestListener implements ServletRequestListener {
+
+  @Override
+  public void requestInitialized(ServletRequestEvent sre) {
+    Map<String, String[]> paramMap = sre.getServletRequest().getParameterMap();
+    ServletContext servletContext = sre.getServletContext();
+    
+    // to see log messages at runtime, check the terminal window where you started JBoss AS.
+    servletContext
+        .log("ParameterDumpingRequestListener: request has been initialized. It has " + paramMap.size() + " parameters:");
+    for (Map.Entry<String, String[]> entry : paramMap.entrySet()) {
+      for (String val : entry.getValue()) {
+        servletContext.log("  " + entry.getKey() + "=" + val);
+      }
+    }
+  }
+
+  @Override
+  public void requestDestroyed(ServletRequestEvent sre) {
+    sre.getServletContext().log("ParameterDumpingRequestListener: request has been destroyed");
+  }
+
+}

--- a/servlet-filterlistener/src/main/java/org/jboss/as/quickstarts/servlet/filterlistener/VowelRemoverFilter.java
+++ b/servlet-filterlistener/src/main/java/org/jboss/as/quickstarts/servlet/filterlistener/VowelRemoverFilter.java
@@ -1,0 +1,151 @@
+package org.jboss.as.quickstarts.servlet.filterlistener;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpSession;
+
+/**
+ * A silly Servlet Filter that removes the letters a, e, i, o, and u (but not
+ * <a href="http://oxforddictionaries.com/page/200">sometimes y</a>) from all
+ * request parameter values. To achieve this, a wrapper is placed around the
+ * request object. This wrapper returns a different set of parameters than
+ * those that the JBoss AS container parsed from the original HTTP request.
+ * <p>
+ * This is just one simple example of what you can do with a filter. In real
+ * life, you will find filters useful for these kinds of things:
+ * <ul>
+ *  <li>Accepting or rejecting requests based on security requirements (by
+ *      calling {@link HttpServletRequest#getUserPrincipal()} or examining attributes
+ *      of the {@link HttpSession} to see if the user is authenticated)
+ *  <li>Logging access to certain resources (this could also be done with a
+ *      Request Listener)
+ *  <li>Caching responses (by wrapping the response's output stream in a
+ *      {@link ByteArrayOutputStream} on cache miss, and replaying saved
+ *      responses on cache hit)
+ *  <li>Performing compression on request or response data (again, by
+ *      wrapping the request's input stream or the response's output stream)
+ * </ul>
+ * <p>
+ * Note that this application also employs a
+ * {@linkplain ParameterDumpingRequestListener Request Listener}, which will see
+ * all requests before this Filter sees them.
+ * 
+ * @author Jonathan Fuerth <jfuerth@redhat.com>
+ */
+@WebFilter("/*")
+public class VowelRemoverFilter implements Filter {
+
+  private ServletContext servletContext;
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    
+    // It is common to save a reference to the ServletContext here in case it is needed
+    // in the destroy() call.
+    servletContext = filterConfig.getServletContext();
+    
+    // To see this log message at run time, check out the terminal window where you started JBoss AS.
+    servletContext.log("VowelRemoverFilter initialized");
+  }
+
+  @Override
+  public void doFilter(
+            ServletRequest request,
+            ServletResponse response,
+            FilterChain chain) throws IOException, ServletException {
+
+    final Map<String, String[]> filteredParams = Collections.unmodifiableMap(removeVowels(request.getParameterMap()));
+    
+    // Here, we wrap the request so that the servlet (and other filters further down the chain)
+    // will see our filteredParams rather than the original request's parameters. Wrappers can be
+    // as benign or as crazy as you like. Use your imagination!
+    HttpServletRequestWrapper wrappedRequest = new HttpServletRequestWrapper((HttpServletRequest) request) {
+      @Override
+      public Map<String, String[]> getParameterMap() {
+        return filteredParams;
+      }
+
+      @Override
+      public String getParameter(String name) {
+        return filteredParams.get(name) == null ? null : filteredParams.get(name)[0];
+      }
+
+      @Override
+      public Enumeration<String> getParameterNames() {
+        return Collections.enumeration(filteredParams.keySet());
+      }
+
+      @Override
+      public String[] getParameterValues(String name) {
+        return filteredParams.get(name);
+      }
+    };
+
+    // Some notes on other filter use cases:
+    // 1. We could have also wrapped the response object if we wanted to capture
+    //    or manipulate the output
+    // 2. If we just wanted to examine the request or session, we could do that in
+    //    a filter or in a Request Listener (see ParameterDumpingRequestListener)
+    // 3. You don't have to wrap the request or response at all if you just want
+    //    to set request or session attributes
+    // 4. You don't have to call chain.doFilter(). The filter can handle the request
+    //    directly (for example, to forward to a login page or send a "403 Forbidden"
+    //    response if the user is not logged in)
+
+    try {
+      servletContext.log("VowelRemoverFilter invoking filter chain...");
+
+      // This is where other filters, and ultimately the servlet or JSP, get a chance to handle the request
+      chain.doFilter(wrappedRequest, response);
+
+    } finally {
+
+      // The try .. finally is important here because another filter or the
+      // servlet itself may throw an exception
+      servletContext.log("VowelRemoverFilter done filtering request");
+    }
+  }
+
+  /**
+   * Performs the vowel removal work of this filter.
+   * 
+   * @param parameterMap
+   *          the map of parameter names and values in the original request.
+   * @return A copy of the original map with all the same keys, but whose values
+   *         do not contain vowels.
+   */
+  private Map<String, String[]> removeVowels(Map<String, String[]> parameterMap) {
+    Map<String, String[]> m = new HashMap<String, String[]>();
+    for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+      String[] orig = entry.getValue();
+      String[] vowelless = new String[orig.length];
+      for (int i = 0; i < orig.length; i++) {
+        vowelless[i] = orig[i].replaceAll("[aeiou]", "");
+      }
+      m.put(entry.getKey(), vowelless);
+    }
+    return m;
+  }
+
+  @Override
+  public void destroy() {
+    servletContext.log("VowelRemoverFilter destroyed");
+    servletContext = null;
+  }
+
+}

--- a/servlet-filterlistener/src/main/webapp/WEB-INF/beans.xml
+++ b/servlet-filterlistener/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<!-- Marker file indicating CDI should be enabled -->
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee 
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/servlet-filterlistener/src/main/webapp/index.html
+++ b/servlet-filterlistener/src/main/webapp/index.html
@@ -1,0 +1,7 @@
+<!-- Plain HTML page that kicks us into the app -->
+
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; URL=FilterExample">
+</head>
+</html>


### PR DESCRIPTION
This pull request contains Jonathan Fuerth's and my quickstarts (servlet-filterlistener and servlet-async).

servlet-async shows how to detach the execution of a resource intensive task from the request processing thread, so the thread is free to serve other client requests. To properly demonstrate this feature, the servlet has to hand off a task to another thread (of a smaller pool) which will generate the response asynchronously. To keep things simple (less code) for the quickstart, we decided against managing our own thread pool/executors and instead also show the use of @Asynchronous EJB invocations, which provide exactly that.

servlet-filterlistener shows the use of a servlet filter to remove vowels from request parameter values and a servlet listener that logs all parameters of HTTP requests.
