### PR TITLE
Corrected the startup instructions for the MDB example

### DIFF
--- a/helloworld-mdb/README.md
+++ b/helloworld-mdb/README.md
@@ -23,13 +23,13 @@ With the prerequisites out of the way, you're ready to build and deploy.
 Deploying the application
 -------------------------
 
-First of all you need to enable the "admin" user from $JBOSS_HOME/standalone/configuration/mgmt-users.properties file, and then start JBoss AS 7.1.0. by running this script
+Start JBoss AS 7.1.0. by running this script
   
-    $JBOSS_HOME/bin/standalone.sh
+    $JBOSS_HOME/bin/standalone.sh -c standalone-full.xml
   
 or if you are using windows
  
-    $JBOSS_HOME/bin/standalone.bat
+    $JBOSS_HOME/bin/standalone.bat -c standalone-full.xml
 
 To deploy the application, you first need to produce the archive to deploy using
 the following Maven goal:


### PR DESCRIPTION
I _may_ be wrong but I couldn't get the helloworld-mdb example to work on my machine. The issue was the the connection factory and queue do not exist in standalone.xml, rather standalone-full.xml, hence my patch (I also didn't need to create the admin user so removed that comment also).

I realise that there isn't a Jira number for this so feel free to reject the pull req. Lets say you do reject it, do we raise Jiras in the main AS7 project for the quickstarts also?

Sorry for the unorthodox method of doing this, but I wasn't sure how we were tackling discovering issues, my main entry into this work being: https://docs.jboss.org/author/display/AS71/Quickstarts

Ta,
Tom
