### PR TITLE
fixed declaration of JMS state to not be static

### DIFF
--- a/helloworld-mdb/src/main/java/org/jboss/as/quickstarts/servlet/HelloWorldMDBServletClient.java
+++ b/helloworld-mdb/src/main/java/org/jboss/as/quickstarts/servlet/HelloWorldMDBServletClient.java
@@ -38,10 +38,10 @@ public class HelloWorldMDBServletClient extends HttpServlet {
 	private static final int MSG_COUNT = 5;
 
 	@Resource(mappedName = "java:/ConnectionFactory")
-	private static ConnectionFactory connectionFactory;
+	private ConnectionFactory connectionFactory;
 
 	@Resource(mappedName = "java:/queue/test")
-	private static Queue queue;
+	private Queue queue;
 
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp)


### PR DESCRIPTION
Seemed strange that the JMS static was statically declared
