### PR TITLE
Fix build errors. 

### DIFF
--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -59,7 +59,7 @@
       <dependency>
          <groupId>org.jboss.as</groupId>
          <artifactId>jboss-as-naming</artifactId>
-         <version>7.1.0.CR1-SNAPSHOT</version>
+         <version>7.1.0.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
          <groupId>org.jboss.spec.javax.jms</groupId>
@@ -70,7 +70,7 @@
       <dependency>
          <groupId>org.jboss.as</groupId>
          <artifactId>jboss-as-messaging</artifactId>
-         <version>7.1.0.CR1-SNAPSHOT</version>
+         <version>7.1.0.Final-SNAPSHOT</version>
       </dependency>
    </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,6 @@
       <module>payment-cdi-event</module>
       <module>servlet-async</module>
       <module>servlet-filterlistener</module>
-      <module>wsba-coordinator-completion-simple</module>
-      <module>wsba-participant-completion-simple</module>
    </modules>
 
    <scm>


### PR DESCRIPTION
Change the helloworld-jms quickstart pom verion number for jboss-as-messaging and jboss-as-naming from 7.1.0.CR1-SNAPSHOT to 7.1.0.Final-SNAPSHOT.
Remove ws\* quickstart modules from the main pom since they are tests only.
