### PR TITLE
AS7-3836 - update to ejb-remote quick start to only depend on business interfaces

### DIFF
--- a/ejb-remote/README.html
+++ b/ejb-remote/README.html
@@ -35,15 +35,13 @@ The following instructions target JBoss AS 7, but they also apply to JBoss EAP 6
 
 <pre><code> $JBOSS_HOME/bin/standalone.sh
 </code></pre></li>
-<li><p>Build and install the server side component and the client interfaces jar into your local Maven repository.  </p>
+<li><p>Build and install the server side component.  </p>
 
 <pre><code> cd server-side/
  mvn clean install
 </code></pre>
 
-<p>This will compile and package the EJB JAR and client interfaces JAR
-(<code>jboss-as-ejb-remote-app.jar</code> and <code>jboss-as-ejb-remote-app-client.jar</code>) and copy them to 
-<code>~.m2/repository/org/jboss/as/quickstarts/jboss-as-ejb-remote-server-side/7.0.2-SNAPSHOT/</code>.</p></li>
+<p>This will build the EJB and client interfaces JARs, and install them in your local Maven repository.</p></li>
 <li><p>Deploy the EJB JAR to your server</p>
 
 <pre><code> mvn jboss-as:deploy

--- a/ejb-remote/README.html
+++ b/ejb-remote/README.html
@@ -1,60 +1,146 @@
 <h1>ejb-remote: Remote EJB Client Example</h1>
+
 <p>Authors: Jaikiran Pai and Mike Musgrove</p>
+
 <h2>What is it?</h2>
+
 <p>This example shows how to access an EJB from a remote Java client program. It
 demonstrates the use of <em>EJB 3.1</em> and <em>JNDI</em> in <em>JBoss AS 7</em>.</p>
+
 <p>There are two parts to the example: a server side component and a remote client program
 that accesses it. Each part is in its own standalone Maven module, however the quickstart
 does provide a top level module to simplify the packaging of the artifacts.</p>
-<p>The server component is comprised of a stateful and a stateless EJB. The client program looks
-up the stateless and stateful beans via JNDI and invokes methods on them.</p>
+
+<p>The server component is comprised of a stateful and a stateless EJB. It provides both an EJB JAR
+that is deployed to the server and a JAR file containing the remote business interfaces required
+by the remote client application.</p>
+
+<p>The remote client application depends on the remote business interfaces from the server component.
+This program looks up the stateless and stateful beans via JNDI and invokes a number of methods on
+them.</p>
+
 <h2>System requirements</h2>
+
 <p>All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.</p>
+
 <p>The application this project produces is designed to be run on a JBoss AS 7 or EAP 6.
 The following instructions target JBoss AS 7, but they also apply to JBoss EAP 6.</p>
+
 <h2>Building and deploying the application</h2>
-<p>Start JBoss AS 7 (or EAP 6):</p>
-<pre><code>    $JBOSS_HOME/bin/standalone.sh
+
+<p>Follow these steps to build, deploy and run the quickstart.</p>
+
+<ol>
+<li><p>Start JBoss AS 7 (or EAP 6):</p>
+
+<pre><code> $JBOSS_HOME/bin/standalone.sh
+</code></pre></li>
+<li><p>Build and install the server side component and the client interfaces jar into your local Maven repository.  </p>
+
+<pre><code> cd server-side/
+ mvn clean install
 </code></pre>
-<p>To build both the server side component and a remote client program change into the
-examples quickstart directory and type:</p>
-<pre><code>    mvn clean install
+
+<p>This will compile and package the EJB JAR and client interfaces JAR
+(<code>jboss-as-ejb-remote-app.jar</code> and <code>jboss-as-ejb-remote-app-client.jar</code>) and copy them to 
+<code>~.m2/repository/org/jboss/as/quickstarts/jboss-as-ejb-remote-server-side/7.0.2-SNAPSHOT/</code>.</p></li>
+<li><p>Deploy the EJB JAR to your server</p>
+
+<pre><code> mvn jboss-as:deploy
 </code></pre>
-<p>The server side component is packaged as a jar and needs deploying to the AS you just started:</p>
-<pre><code>    cd server-side
-    mvn jboss-as:deploy
+
+<p>This maven goal will deploy <code>server-side/target/jboss-as-ejb-remote-app.jar</code>. You can check the AS
+console to see information messages regarding the deployment.</p></li>
+<li><p>Build and run the client application</p>
+
+<pre><code> cd ../client
+ mvn clean compile
+ mvn exec:exec
 </code></pre>
-<p>This maven goal will deploy server-side/target/jboss-as-ejb-remote-app.jar. You can check the AS
-console to see information messages regarding the deployment.</p>
+
+<p>This will compile and execute the client application within Maven.  Refer to <code>The Output</code> below.</p>
+
 <p>Note that you can also start JBoss AS 7 and deploy the project using Eclipse. See the JBoss AS 7
 <a href="https://docs.jboss.org/author/display/AS71/Getting+Started+Developing+Applications+Guide" title="Getting Started Developing Applications Guide">Getting Started Developing Applications Guide</a> 
-for more information.</p>
-<p>Now start a client that will access the beans you just deployed:</p>
-<pre><code>    cd ../client
-    mvn exec:exec
+for more information.</p></li>
+</ol>
+
+<h2>The Output</h2>
+
+<p>When the client application runs, it performs the following steps:</p>
+
+<ol>
+<li>Obtains a stateless session bean instance.</li>
+<li>Sends method invocations to the stateless bean to add two numbers, and then displays the result.</li>
+<li>Sends a second invocation to the stateless bean subtract two numbers, and then displays the result.</li>
+<li>Obtains a stateful session bean instance.</li>
+<li>Sends several method invocations to the stateful bean to increment a field in the bean, displaying the result each time.</li>
+<li>Sends several method invocations to the stateful bean to decrement a field in the bean, displaying the result each time.</li>
+</ol>
+
+<p>The output in the terminal window  will look like the following:</p>
+
+<pre><code>  Obtained a remote stateless calculator for invocation
+  Adding 204 and 340 via the remote stateless calculator deployed on the server
+  Remote calculator returned sum = 544
+  Subtracting 2332 from 3434 via the remote stateless calculator deployed on the server
+  Remote calculator returned difference = 1102
+  Obtained a remote stateful counter for invocation
+  Counter will now be incremented 5 times
+  Incrementing counter
+  Count after increment is 1
+  Incrementing counter
+  Count after increment is 2
+  Incrementing counter
+  Count after increment is 3
+  Incrementing counter
+  Count after increment is 4
+  Incrementing counter
+  Count after increment is 5
+  Counter will now be decremented 5 times
+  Decrementing counter
+  Count after decrement is 4
+  Decrementing counter
+  Count after decrement is 3
+  Decrementing counter
+  Count after decrement is 2
+  Decrementing counter
+  Count after decrement is 1
+  Decrementing counter
+  Count after decrement is 0
 </code></pre>
-<p>You should see output showing:</p>
-<ul>
-<li>
-<p>the client sending a method invocation to the stateless bean to add
-two numbers and then a second invocation to subtract two numbers.</p>
-</li>
-<li>
-<p>the client sends a method invocation to the statful bean asking it to increment a counter
-followed by a request to get the current value of the counter. To demonstrate that the bean
-is stateful it performs the same two invocations a number of times proving that the bean
-is maintaining the state of the counter between invocations.</p>
-</li>
-</ul>
+
+<p>Logging statements have been removed from this output here to make it clearer.</p>
+
+<h2>Undeploy the Application</h2>
+
 <p>To undeploy the server side component from JBoss AS:</p>
-<pre><code>    cd ../server-side
-    mvn jboss-as:undeploy
+
+<pre><code>  cd ../server-side
+  mvn jboss-as:undeploy
 </code></pre>
-<h1>Downloading the sources and Javadocs</h1>
+
+<h2>Build Executable JAR</h2>
+
+<p>The remote client application can also be built as a standalone executable JAR with all of it&#8217;s 
+dependencies.</p>
+
+<pre><code>  cd client
+  mvn clean assembly:assembly
+</code></pre>
+
+<p>You can then run the executable JAR using <code>java -jar</code>:</p>
+
+<pre><code>  java -jar target/jboss-as-quickstarts-ejb-remote-client-7.0.2-SNAPSHOT-jar-with-dependencies.jar
+</code></pre>
+
+<h2>Downloading the sources and Javadocs</h2>
+
 <p>If you want to be able to debug into the source code or look at the Javadocs
 of any library in the project, you can run either of the following two
 commands to pull them into your local repository. The IDE should then detect
 them.</p>
-<pre><code>    mvn dependency:sources
-    mvn dependency:resolve -Dclassifier=javadoc
+
+<pre><code>  mvn dependency:sources
+  mvn dependency:resolve -Dclassifier=javadoc
 </code></pre>

--- a/ejb-remote/README.md
+++ b/ejb-remote/README.md
@@ -1,9 +1,8 @@
-ejb-remote: Remote EJB Client Example
-=====================================
+# ejb-remote: Remote EJB Client Example
+
 Authors: Jaikiran Pai and Mike Musgrove
 
-What is it?
------------
+## What is it?
 
 This example shows how to access an EJB from a remote Java client program. It
 demonstrates the use of *EJB 3.1* and *JNDI* in *JBoss AS 7*.
@@ -12,69 +11,132 @@ There are two parts to the example: a server side component and a remote client 
 that accesses it. Each part is in its own standalone Maven module, however the quickstart
 does provide a top level module to simplify the packaging of the artifacts.
 
-The server component is comprised of a stateful and a stateless EJB. The client program looks
-up the stateless and stateful beans via JNDI and invokes methods on them.
+The server component is comprised of a stateful and a stateless EJB. It provides both an EJB JAR
+that is deployed to the server and a JAR file containing the remote business interfaces required
+by the remote client application.
 
-System requirements
--------------------
+The remote client application depends on the remote business interfaces from the server component.
+This program looks up the stateless and stateful beans via JNDI and invokes a number of methods on
+them.
+
+
+## System requirements
 
 All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
 
 The application this project produces is designed to be run on a JBoss AS 7 or EAP 6.
 The following instructions target JBoss AS 7, but they also apply to JBoss EAP 6.
 
-Building and deploying the application
--------------------------
+## Building and deploying the application
 
-Start JBoss AS 7 (or EAP 6):
+Follow these steps to build, deploy and run the quickstart.
 
-        $JBOSS_HOME/bin/standalone.sh
+1. Start JBoss AS 7 (or EAP 6):
 
-To build both the server side component and a remote client program change into the
-examples quickstart directory and type:
+         $JBOSS_HOME/bin/standalone.sh
 
-        mvn clean install
+2. Build and install the server side component and the client interfaces jar into your local Maven repository.  
 
-The server side component is packaged as a jar and needs deploying to the AS you just started:
+         cd server-side/
+         mvn clean install
 
-        cd server-side
-        mvn jboss-as:deploy
+   This will compile and package the EJB JAR and client interfaces JAR
+   (`jboss-as-ejb-remote-app.jar` and `jboss-as-ejb-remote-app-client.jar`) and copy them to 
+   `~.m2/repository/org/jboss/as/quickstarts/jboss-as-ejb-remote-server-side/7.0.2-SNAPSHOT/`.
 
-This maven goal will deploy server-side/target/jboss-as-ejb-remote-app.jar. You can check the AS
-console to see information messages regarding the deployment.
+3. Deploy the EJB JAR to your server
 
-Note that you can also start JBoss AS 7 and deploy the project using Eclipse. See the JBoss AS 7
-<a href="https://docs.jboss.org/author/display/AS71/Getting+Started+Developing+Applications+Guide" title="Getting Started Developing Applications Guide">Getting Started Developing Applications Guide</a> 
-for more information.
+         mvn jboss-as:deploy
 
-Now start a client that will access the beans you just deployed:
+  This maven goal will deploy `server-side/target/jboss-as-ejb-remote-app.jar`. You can check the AS
+  console to see information messages regarding the deployment.
 
-        cd ../client
-        mvn exec:exec
+4. Build and run the client application
 
-You should see output showing:
+         cd ../client
+         mvn clean compile
+         mvn exec:exec
+   
+   This will compile and execute the client application within Maven.  Refer to `The Output` below.
+  
+   Note that you can also start JBoss AS 7 and deploy the project using Eclipse. See the JBoss AS 7
+   <a href="https://docs.jboss.org/author/display/AS71/Getting+Started+Developing+Applications+Guide" title="Getting Started Developing Applications Guide">Getting Started Developing Applications Guide</a> 
+   for more information.
 
-* the client sending a method invocation to the stateless bean to add
-two numbers and then a second invocation to subtract two numbers.
+## The Output
 
-* the client sends a method invocation to the statful bean asking it to increment a counter
-followed by a request to get the current value of the counter. To demonstrate that the bean
-is stateful it performs the same two invocations a number of times proving that the bean
-is maintaining the state of the counter between invocations.
+When the client application runs, it performs the following steps:
+
+1. Obtains a stateless session bean instance.
+2. Sends method invocations to the stateless bean to add two numbers, and then displays the result.
+3. Sends a second invocation to the stateless bean subtract two numbers, and then displays the result.
+4. Obtains a stateful session bean instance.
+5. Sends several method invocations to the stateful bean to increment a field in the bean, displaying the result each time.
+6. Sends several method invocations to the stateful bean to decrement a field in the bean, displaying the result each time.
+
+
+
+The output in the terminal window  will look like the following:
+
+      Obtained a remote stateless calculator for invocation
+      Adding 204 and 340 via the remote stateless calculator deployed on the server
+      Remote calculator returned sum = 544
+      Subtracting 2332 from 3434 via the remote stateless calculator deployed on the server
+      Remote calculator returned difference = 1102
+      Obtained a remote stateful counter for invocation
+      Counter will now be incremented 5 times
+      Incrementing counter
+      Count after increment is 1
+      Incrementing counter
+      Count after increment is 2
+      Incrementing counter
+      Count after increment is 3
+      Incrementing counter
+      Count after increment is 4
+      Incrementing counter
+      Count after increment is 5
+      Counter will now be decremented 5 times
+      Decrementing counter
+      Count after decrement is 4
+      Decrementing counter
+      Count after decrement is 3
+      Decrementing counter
+      Count after decrement is 2
+      Decrementing counter
+      Count after decrement is 1
+      Decrementing counter
+      Count after decrement is 0
+
+Logging statements have been removed from this output here to make it clearer.
+
+## Undeploy the Application
 
 To undeploy the server side component from JBoss AS:
 
-        cd ../server-side
-        mvn jboss-as:undeploy
+      cd ../server-side
+      mvn jboss-as:undeploy
 
-Downloading the sources and Javadocs
-====================================
+
+## Build Executable JAR
+
+The remote client application can also be built as a standalone executable JAR with all of it's 
+dependencies.
+
+      cd client
+      mvn clean assembly:assembly
+      
+You can then run the executable JAR using `java -jar`:
+      
+      java -jar target/jboss-as-quickstarts-ejb-remote-client-7.0.2-SNAPSHOT-jar-with-dependencies.jar
+
+
+## Downloading the sources and Javadocs
 
 If you want to be able to debug into the source code or look at the Javadocs
 of any library in the project, you can run either of the following two
 commands to pull them into your local repository. The IDE should then detect
 them.
 
-        mvn dependency:sources
-        mvn dependency:resolve -Dclassifier=javadoc
+      mvn dependency:sources
+      mvn dependency:resolve -Dclassifier=javadoc
 

--- a/ejb-remote/README.md
+++ b/ejb-remote/README.md
@@ -35,14 +35,12 @@ Follow these steps to build, deploy and run the quickstart.
 
          $JBOSS_HOME/bin/standalone.sh
 
-2. Build and install the server side component and the client interfaces jar into your local Maven repository.  
+2. Build and install the server side component.  
 
          cd server-side/
          mvn clean install
 
-   This will compile and package the EJB JAR and client interfaces JAR
-   (`jboss-as-ejb-remote-app.jar` and `jboss-as-ejb-remote-app-client.jar`) and copy them to 
-   `~.m2/repository/org/jboss/as/quickstarts/jboss-as-ejb-remote-server-side/7.0.2-SNAPSHOT/`.
+  This will build the EJB and client interfaces JARs, and install them in your local Maven repository.
 
 3. Deploy the EJB JAR to your server
 

--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -84,13 +84,13 @@
          <scope>runtime</scope>
       </dependency>
 
-       <!-- We depend on the server side EJBs of this application -->
-       <dependency>
-          <groupId>org.jboss.as.quickstarts</groupId>
-          <artifactId>jboss-as-ejb-remote-server-side</artifactId>
-          <version>${project.version}</version>
-       </dependency>
-
+      <!-- We depend on the EJB remote business interfaces  of this application -->
+      <dependency>
+         <groupId>org.jboss.as.quickstarts</groupId>
+         <artifactId>jboss-as-ejb-remote-server-side</artifactId>
+         <type>ejb-client</type>
+         <version>${project.version}</version>
+      </dependency>
        <!-- JBoss EJB client API jar. We use runtime scope because the EJB client API
         isn't directly used in this example. We just need it in our runtime classpath -->
        <dependency>
@@ -141,6 +141,7 @@
    </dependencies>
 
    <build>
+
       <plugins>
          <!-- Enforce Java 1.6  -->
          <plugin>
@@ -158,39 +159,55 @@
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.2.1</version>
             <executions>
-              <execution>
+               <execution>
                   <goals>
                      <goal>exec</goal>
                   </goals>
-              </execution>
+               </execution>
             </executions>
             <configuration>
-              <executable>java</executable>
-              <workingDirectory>${project.build.directory}/exec-working-directory</workingDirectory>
-              <arguments>
-                <!-- automatically creates the classpath using all project dependencies,
-                     also adding the project build directory -->
-                <argument>-classpath</argument>
-                <classpath>
-                </classpath>
-                <argument>org.jboss.as.quickstarts.ejb.remote.client.RemoteEJBClient</argument>
-              </arguments>
+               <executable>java</executable>
+               <workingDirectory>${project.build.directory}/exec-working-directory</workingDirectory>
+               <arguments>
+                  <!-- automatically creates the classpath using all project dependencies,
+                       also adding the project build directory -->
+                  <argument>-classpath</argument>
+                  <classpath>
+                  </classpath>
+                  <argument>org.jboss.as.quickstarts.ejb.remote.client.RemoteEJBClient</argument>
+               </arguments>
             </configuration>
-        </plugin>
-            <!-- The JBoss AS plugin deploys your apps to a local JBoss AS 
-               container -->
-            <!-- Disabling it here means that we don't try to deploy this POM! -->
-            <plugin>
-               <groupId>org.jboss.as.plugins</groupId>
-               <artifactId>jboss-as-maven-plugin</artifactId>
-               <version>7.1.0.Final</version>
-               <inherited>true</inherited>
-               <configuration>
-                  <skip>true</skip>
-               </configuration>
-            </plugin>
+         </plugin>
+
+         <!-- build standalone exe jar -->
+         <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <configuration>
+               <descriptorRefs>
+                  <descriptorRef>jar-with-dependencies</descriptorRef>
+               </descriptorRefs>
+               <archive>
+                  <manifest>
+                     <mainClass>org.jboss.as.quickstarts.ejb.remote.client.RemoteEJBClient</mainClass>
+                  </manifest>
+               </archive>
+            </configuration>
+         </plugin>
+        
+         <!-- The JBoss AS plugin deploys your apps to a local JBoss AS container -->
+         <!-- Disabling it here means that we don't try to deploy this POM! -->
+         <plugin>
+            <groupId>org.jboss.as.plugins</groupId>
+            <artifactId>jboss-as-maven-plugin</artifactId>
+            <version>7.1.0.Final</version>
+            <inherited>true</inherited>
+            <configuration>
+               <skip>true</skip>
+            </configuration>
+         </plugin>
       </plugins>
 
    </build>
 
 </project>
+   

--- a/ejb-remote/client/src/main/java/org/jboss/as/quickstarts/ejb/remote/client/RemoteEJBClient.java
+++ b/ejb-remote/client/src/main/java/org/jboss/as/quickstarts/ejb/remote/client/RemoteEJBClient.java
@@ -96,7 +96,7 @@ public class RemoteEJBClient {
         final RemoteCounter statefulRemoteCounter = lookupRemoteStatefulCounter();
         System.out.println("Obtained a remote stateful counter for invocation");
         // invoke on the remote counter bean
-        final int NUM_TIMES = 20;
+        final int NUM_TIMES = 5;
         System.out.println("Counter will now be incremented " + NUM_TIMES + " times");
         for (int i = 0; i < NUM_TIMES; i++) {
             System.out.println("Incrementing counter");

--- a/ejb-remote/client/src/main/java/org/jboss/as/quickstarts/ejb/remote/client/RemoteEJBClient.java
+++ b/ejb-remote/client/src/main/java/org/jboss/as/quickstarts/ejb/remote/client/RemoteEJBClient.java
@@ -28,9 +28,7 @@ import javax.naming.NamingException;
 import java.security.Security;
 import java.util.Hashtable;
 
-import org.jboss.as.quickstarts.ejb.remote.stateful.CounterBean;
 import org.jboss.as.quickstarts.ejb.remote.stateful.RemoteCounter;
-import org.jboss.as.quickstarts.ejb.remote.stateless.CalculatorBean;
 import org.jboss.as.quickstarts.ejb.remote.stateless.RemoteCalculator;
 import org.jboss.sasl.JBossSaslProvider;
 
@@ -114,65 +112,73 @@ public class RemoteEJBClient {
         }
     }
 
-    /**
-     * Looks up and returns the proxy to remote stateless calculator bean
-     *
-     * @return
-     * @throws NamingException
-     */
-    private static RemoteCalculator lookupRemoteStatelessCalculator() throws NamingException {
-        final Hashtable jndiProperties = new Hashtable();
-        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
-        final Context context = new InitialContext(jndiProperties);
-        // The app name is the application name of the deployed EJBs. This is typically the ear name
-        // without the .ear suffix. However, the application name could be overridden in the application.xml of the
-        // EJB deployment on the server.
-        // Since we haven't deployed the application as a .ear, the app name for us will be an empty string
-        final String appName = "";
-        // This is the module name of the deployed EJBs on the server. This is typically the jar name of the
-        // EJB deployment, without the .jar suffix, but can be overridden via the ejb-jar.xml
-        // In this example, we have deployed the EJBs in a jboss-as-ejb-remote-app.jar, so the module name is
-        // jboss-as-ejb-remote-app
-        final String moduleName = "jboss-as-ejb-remote-app";
-        // AS7 allows each deployment to have an (optional) distinct name. We haven't specified a distinct name for
-        // our EJB deployment, so this is an empty string
-        final String distinctName = "";
-        // The EJB name which by default is the simple class name of the bean implementation class
-        final String beanName = CalculatorBean.class.getSimpleName();
-        // the remote view fully qualified class name
-        final String viewClassName = RemoteCalculator.class.getName();
-        // let's do the lookup
-        return (RemoteCalculator) context.lookup("ejb:" + appName + "/" + moduleName + "/" + distinctName + "/" + beanName + "!" + viewClassName);
-    }
+   /**
+   * Looks up and returns the proxy to remote stateless calculator bean
+   *
+   * @return
+   * @throws NamingException
+   */
+   private static RemoteCalculator lookupRemoteStatelessCalculator() throws NamingException {
+      final Hashtable jndiProperties = new Hashtable();
+      jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+      final Context context = new InitialContext(jndiProperties);
 
-    /**
-     * Looks up and returns the proxy to remote stateful counter bean
-     *
-     * @return
-     * @throws NamingException
-     */
-    private static RemoteCounter lookupRemoteStatefulCounter() throws NamingException {
-        final Hashtable jndiProperties = new Hashtable();
-        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
-        final Context context = new InitialContext(jndiProperties);
-        // The app name is the application name of the deployed EJBs. This is typically the ear name
-        // without the .ear suffix. However, the application name could be overridden in the application.xml of the
-        // EJB deployment on the server.
-        // Since we haven't deployed the application as a .ear, the app name for us will be an empty string
-        final String appName = "";
-        // This is the module name of the deployed EJBs on the server. This is typically the jar name of the
-        // EJB deployment, without the .jar suffix, but can be overridden via the ejb-jar.xml
-        // In this example, we have deployed the EJBs in a jboss-as-ejb-remote-app.jar, so the module name is
-        // jboss-as-ejb-remote-app
-        final String moduleName = "jboss-as-ejb-remote-app";
-        // AS7 allows each deployment to have an (optional) distinct name. We haven't specified a distinct name for
-        // our EJB deployment, so this is an empty string
-        final String distinctName = "";
-        // The EJB name which by default is the simple class name of the bean implementation class
-        final String beanName = CounterBean.class.getSimpleName();
-        // the remote view fully qualified class name
-        final String viewClassName = RemoteCounter.class.getName();
-        // let's do the lookup (notice the ?stateful string as the last part of the jndi name for stateful bean lookup)
-        return (RemoteCounter) context.lookup("ejb:" + appName + "/" + moduleName + "/" + distinctName + "/" + beanName + "!" + viewClassName + "?stateful");
-    }
+      // The JNDI lookup name for a stateless session bean has the syntax of:
+      // ejb:<appName>/<moduleName>/<distinctName>/<beanName>!<viewClassName>
+      //
+      // <appName> The application name is the name of the EAR that the EJB is deployed in 
+      //           (without the .ear).  If the EJB JAR is not deployed in an EAR then this is
+      //           blank.  The app name can also be specified in the EAR's application.xml
+      //           
+      // <moduleName> By the default the module name is the name of the EJB JAR file (without the
+      //              .jar suffix).  The module name might be overridden in the ejb-jar.xml
+      //
+      // <distinctName> : AS7 allows each deployment to have an (optional) distinct name. 
+      //                  This example does not use this so leave it blank.
+      //
+      // <beanName>     : The name of the session been to be invoked.
+      //
+      // <viewClassName>: The fully qualified classname of the remote interface.  Must include
+      //                  the whole package name.
+
+      // let's do the lookup
+      return (RemoteCalculator) context.lookup(
+         "ejb:/jboss-as-ejb-remote-app/CalculatorBean!" + RemoteCalculator.class.getName()
+      );
+   }
+
+   /**
+   * Looks up and returns the proxy to remote stateful counter bean
+   *
+   * @return
+   * @throws NamingException
+   */
+   private static RemoteCounter lookupRemoteStatefulCounter() throws NamingException {
+      final Hashtable jndiProperties = new Hashtable();
+      jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+      final Context context = new InitialContext(jndiProperties);
+
+      // The JNDI lookup name for a stateful session bean has the syntax of:
+      // ejb:<appName>/<moduleName>/<distinctName>/<beanName>!<viewClassName>?stateful
+      //
+      // <appName> The application name is the name of the EAR that the EJB is deployed in 
+      //           (without the .ear).  If the EJB JAR is not deployed in an EAR then this is
+      //           blank.  The app name can also be specified in the EAR's application.xml
+      //           
+      // <moduleName> By the default the module name is the name of the EJB JAR file (without the
+      //              .jar suffix).  The module name might be overridden in the ejb-jar.xml
+      //
+      // <distinctName> : AS7 allows each deployment to have an (optional) distinct name. 
+      //                  This example does not use this so leave it blank.
+      //
+      // <beanName>     : The name of the session been to be invoked.
+      //
+      // <viewClassName>: The fully qualified classname of the remote interface.  Must include
+      //                  the whole package name.
+
+      // let's do the lookup
+      return (RemoteCounter) context.lookup(
+         "ejb:/jboss-as-ejb-remote-app/CounterBean!" + RemoteCounter.class.getName()+"?stateful"
+      );
+   }
 }

--- a/ejb-remote/server-side/pom.xml
+++ b/ejb-remote/server-side/pom.xml
@@ -6,7 +6,7 @@
    <groupId>org.jboss.as.quickstarts</groupId>
    <artifactId>jboss-as-ejb-remote-server-side</artifactId>
    <version>7.0.2-SNAPSHOT</version>
-   <packaging>jar</packaging>
+   <packaging>ejb</packaging>
    <name>JBoss AS Quickstarts: Server side of remote EJB</name>
 
    <url>http://jboss.org/jbossas</url>
@@ -89,6 +89,17 @@
                <target>1.6</target>
             </configuration>
          </plugin>
+      <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-ejb-plugin</artifactId>
+            <version>2.3</version>
+            <configuration>
+               <ejbVersion>3.1</ejbVersion>
+               <!-- this is false by default -->
+               <generateClient>true</generateClient>
+            </configuration>
+         </plugin>
+
       </plugins>
    </build>
 


### PR DESCRIPTION
I've updated the ejb-remote quick start with the following changes:

1 - build with the ejb plugin so a client jar gets generated with the remote interfaces
2 - the remote client application only depends on the jar with the remote interfaces
3 - neated up the ejb naming comments
4 - added maven-assembly-plugin so it can build a complete executable jar as the remote client
