### PR TITLE
Added dependency to pom.xml for httpcore

### DIFF
--- a/jax-rs-client/pom.xml
+++ b/jax-rs-client/pom.xml
@@ -29,6 +29,11 @@
     	<artifactId>resteasy-jaxrs</artifactId>
     	<version>2.2.2.GA</version>
     </dependency>
+    <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>4.1.4</version>
+     </dependency>
   </dependencies>
   <build>
        <plugins>


### PR DESCRIPTION
When testing with the JBoss provided Maven repository, an additional dependency was required for this quickstart.  Specifically, the following was added to the POM:

<dependency>
    <groupId>org.apache.httpcomponents</groupId>
    <artifactId>httpcore</artifactId>
    <version>4.1.4</version>
 </dependency>
