### PR TITLE
Remove dependency on specific version and set the local versions.

### DIFF
--- a/ejb-in-ear/ear/pom.xml
+++ b/ejb-in-ear/ear/pom.xml
@@ -10,6 +10,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-ejb-in-ear-ear</artifactId>
+    <version>7.1.1-SNAPSHOT</version>
     <packaging>ear</packaging>
     <name>JBoss AS Quickstarts: EJB and War in an Ear - EAR</name>
     <description>JBoss AS Quickstarts: EJB and WAR in an EAR - EAR</description>

--- a/ejb-in-ear/ejb/pom.xml
+++ b/ejb-in-ear/ejb/pom.xml
@@ -10,6 +10,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-ejb-in-ear-ejb</artifactId>
+    <version>7.1.1-SNAPSHOT</version>
     <name>JBoss AS Quickstarts: EJB and War in an Ear - EJB</name>
     <description>JBoss AS Quickstarts: EJB and War in an Ear - EJB</description>
 

--- a/ejb-in-ear/web/pom.xml
+++ b/ejb-in-ear/web/pom.xml
@@ -10,6 +10,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-ejb-in-ear-web</artifactId>
+    <version>7.1.1-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: EJB and War in an Ear - WEB</name>
     <description>JBoss AS Quickstarts: EJB and War in an Ear - WEB</description>
@@ -28,7 +29,7 @@
         <dependency>
             <groupId>org.jboss.as.quickstarts</groupId>
             <artifactId>jboss-as-ejb-in-ear-ejb</artifactId>
-            <version>7.1.0.Final</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
After a recent update to the quickstarts in a recently cleaned repo I ended up with a dependency issue as a dependency from one quickstart to another was using a specific version and as I hadn't built that specific version it was not available to satisfy the dependency.

This pull request switches to the current version instead of a specific version.
