### PR TITLE
JAX-RS Tasks Quickstart No 33 (and 34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Quickstarts with tutorials in the [Getting Started Developing Applications Guide
 | [servlet-security](servlet-security/README.md "servlet-security") | Servlet, Security | Demonstrates how to use Java EE declarative security to control access to Servlet 3 | begiiner | greeter |
 | [shopping-cart](shopping-cart/README.md "shopping-cart") | Stateful Session Bean | Demonstrates a stateful session bean | begiiner | greeter |
 | [tasks](tasks/README.md "servlet-filterlistener") | Arquillian, JPA | Demonstrates testing JPA using Arquillian | Intermediate | greeter |
+| [tasks-rs](tasks-rs/README.md "tasks-rs") | JAX-RS, JPA | Demonstrates how to use JAX-RS and JPA together | Intermediate | None |
 | [wicket-ear](wicket-ear/README.md "wicket-ear") | Apache Wicket, CRUD, JPA | Demonstrates how to use the Wicket Framework 1.5 with the JBoss server using the Wicket-Stuff Java EE integration, packaged as an EAR  | Intermediate | None |
 | [wicket-war](wicket-war/README.md "wicket-war") | Apache Wicket, CRUD, JPA | Demonstrates how to use the Wicket Framework 1.5 with the JBoss server using the Wicket-Stuff Java EE integration packaged as a WAR  | Intermediate | None |
 | [wsat-simple](wsat-simple/README.md "wsat-simple") | WS-AT, Web service, JAX-WS | Deployment of a WS-AT (WS-AtomicTransaction) enabled JAX-WS Web service bundled in a WAR archive  | Intermediate | None |

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
                 <module>servlet-security</module>
                 <module>tasks</module>
                 <module>tasks-jsf</module>
+                <module>tasks-rs</module>
                 <module>wicket-ear</module>
                 <module>wicket-war</module>
                 <module>xml-jaxp</module>

--- a/tasks-rs/README.md
+++ b/tasks-rs/README.md
@@ -8,14 +8,12 @@ What is it?
 -----------
 
 This project demonstrates how to implement a JAX-RS service that uses JPA 2.0 persistence.
-The client uses HTTP to interact with the service. It builds on the *tasks* quickstarts which
-provide simple Task management with secure log in.
 
-The service interface is implemented using JAX-RS. The SecurityContext JAX-RS annotation
-is used to inject the security details into each REST method.
+* The client uses HTTP to interact with the service. It builds on the *tasks* quickstarts which provide simple Task management with secure login.
 
-The application manages User and Task JPA entities. A user represents an authenticated principal and is associated with zero or more Tasks. Service methods validate that there is an authenticated principal and the first
-time a principal is seen a JPA User entity is created to correspond to the principal. JAX-RS methods are provided for associating Tasks with this User and for listing and removing Tasks.
+* The service interface is implemented using JAX-RS. The SecurityContext JAX-RS annotation is used to inject the security details into each REST method.
+
+The application manages User and Task JPA entities. A user represents an authenticated principal and is associated with zero or more Tasks. Service methods validate that there is an authenticated principal and the first time a principal is seen, a JPA User entity is created to correspond to the principal. JAX-RS annotated methods are provided for associating Tasks with this User and for listing and removing Tasks.
 
 
 System requirements
@@ -32,11 +30,11 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#mavenconfiguration) before testing the quickstarts.
 
 
-Add At Least One Application User
+
+Add an Application User
 ---------------
 
-This quickstart uses a secured management interface and requires that you create an application user to access the running application. Instructions to set up an Application user can be found here:  [Add an Application User](../README.md#addapplicationuser). After following those instructions you should have created a user
-called quickstartUser with password quickstartUser (and belonging to the guest role).
+This quickstart uses a secured management interface and requires that you create an application user to access the running application. Instructions to set up an Application user can be found here:  [Add an Application User](../README.md#addapplicationuser).  After following these instructions. you should have created a user called `quickstartUser` with password `quickstartPassword`, belonging to the `guest` role.
 
 
 Start JBoss Enterprise Application Platform 6 or JBoss AS 7 with the Web Profile
@@ -63,63 +61,95 @@ _NOTE: The following build command assumes you have configured your Maven user s
 4. This will deploy `target/jboss-as-tasks-rs.war` to the running instance of the server.
 
 
-Access application resources
+Access the Application Resources
 ---------------------
 
-Application resources are prefixed with the URL http://localhost:8080/jboss-as-tasks-rs/ and
-can be accessed by an HTTP client. For methods that accept GET a web browser can be used otherwise
-use a command line tool that supports HTTP POST and DELETE methods (for example curl) must be used.
+Application resources for this quickstart are prefixed with the URL http://localhost:8080/jboss-as-tasks-rs/ and can be accessed by an HTTP client. 
 
-To associate a task called task1 with the user quickstartUser, authenticate as user quickstartUser
-and send an HTTP POST request to the url
+* For methods that accept *GET*, a web browser can be used.
+* Otherwise, you must use cURL or some other command line tool that supports HTTP *POST* and *DELETE* methods.
 
-    http://localhost:8080/jboss-as-tasks-rs/task/task1
+Below you will find instructions to create, display, and delete tasks.
 
-The "Location" header of the response contains the URI of the resource representing the newly created
-task. To delete this task, again authenticate as pricipal quickstartUser whilst sending an HTTP DELETE
-request to this task URI.  Similary, to get an XML representation of the resource just created issue
-a GET request on the task URI.
+### Create a Task
 
-To obtain a list all resources for user quickstartUser in XML format, authenticate as user quickstartUser and send an HTTP GET request (with accept header application/xml) to the url
+To associate a task called `task1` with the user `quickstartUser`, you must authenticate as user `quickstartUser` and send an HTTP *POST* request to the url 'http://localhost:8080/jboss-as-tasks-rs/task/task1'. 
 
-    http://localhost:8080/jboss-as-tasks-rs/tasks
+To issue the *POST* command using cURL, type the following command:
 
-For example, if you type the previous url into a browser then you will be challenged to enter valid authentication credentials and if successful the browser will display an XML document containing all the tasks belonging to the user that was just validated.
+    curl -i -u "quickstartUser:quickstartPassword" -H "Content-Length: 0" -X POST http://localhost:8080/jboss-as-tasks-rs/task/task1
 
-Here are some example commands to achieve the above using a tool called curl:
+You will see the following response:
 
-Create a task with title task1 and associate it with user quickstartUser:
-
-    curl -i -u "quickstartUser:quickstartPassword" -X POST http://localhost:8080/jboss-as-tasks-rs/task/task1
     HTTP/1.1 201 Created
     Server: Apache-Coyote/1.1
     Location: http://localhost:8080/jboss-as-tasks-rs/task/1
     Content-Length: 0
     Date: Sun, 15 Apr 2012 22:46:26 GMT
 
-The -i flag tells curl to print the returned headers. Notice that the Location header contains the URI of the resource corresponding to the new Task you have just created.
+This is what happens when the command is issued:
 
-The -u flag provides the authentication information for the request.
+* The `-i` flag tells cURL to print the returned headers. Notice that the `Location` header contains the URI of the resource corresponding to the new task you have just created.
+* The `-u` flag provides the authentication information for the request.
+* The `-H` flag adds a header to the outgoing request.
+* The `-X` flag tells cURL which HTTP method to use. The HTTP *POST* is used to create resources.
+* The `Location` header of the response contains the URI of the resource representing the newly created task. 
 
-The -X flag tells curl which HTTP method to use (POST is used to create resources).
+The final argument to cURL determines the title of the task. Note that this approach is perhaps not very restful but it simplifies this quickstart. A better approach would be to *POST* to "http://localhost:8080/jboss-as-tasks-rs/task" passing the task title in the body of the request.
 
-The final argument to curl determines the title of the task. An alternative (and more restful) approach would be to POST to http://localhost:8080/jboss-as-tasks-rs/task passing the task title in the body of the request. Certainly a real task would contain more that just a title so it would make sense to include the title in the body.
 
-To see an XML representation of the task perform a GET on URI that was returned in the Location header:
+### Display the XML Representation of a Task
 
-    curl --header "Accept: application/xml" -u "quickstartUser:quickstartPassword" -X GET http://localhost:8080/jboss-as-tasks-rs/task/1
-    <?xml version="1.0" encoding="UTF-8" standalone="yes"?><task id="1" ownerName="quickstartUser"><title>task1</title></task>
+To display the XML representation of the newly created resource, issue a *GET* request on the task URI returned in the `Location` header during the create.
 
-The --header flag tells the server that the client wishes to accept XML content.
+1. To issue a *GET* using a browser, open a browser and access the URI. You will be challenged to enter valid authentication credentials.
 
-To list all tasks associated with the user quickstartUser type:
+    <http://localhost:8080/jboss-as-tasks-rs/task/1>
+2. To issue a *GET* using cURL, type the following command: 
 
-    curl --header "Accept: application/xml" -u "quickstartUser:quickstartPassword" -X GET http://localhost:8080/jboss-as-tasks-rs/tasks
-    <?xml version="1.0" encoding="UTF-8" standalone="yes"?><collection><task id="1" ownerName="quickstartUser"><title>task1</title></task></collection>
+    `curl -H "Accept: application/xml" -u "quickstartUser:quickstartPassword" -X GET http://localhost:8080/jboss-as-tasks-rs/task/1`
 
-To delete the task with id 1:
+    The `-H flag tells the server that the client wishes to accept XML content.
+
+Using either of the above *GET* methods, you should see the following XML:
+
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <task id="1" ownerName="quickstartUser">
+        <title>task1</title>
+    </task>
+
+
+### Display the XML Representation of all Tasks for a User
+
+To obtain a list of all tasks for user `quickstartUser` in XML format, authenticate as user `quickstartUser` and send an HTTP `GET` request to the resource `tasks` URL.
+
+1. To issue a *GET* using a browser, open a browser and access the following URL. You will be challenged to enter valid authentication credentials.
+
+    <http://localhost:8080/jboss-as-tasks-rs/tasks>
+
+2. To list all tasks associated with the user `quickstartUser` using cURL, type:
+
+    curl -H "Accept: application/xml" -u "quickstartUser:quickstartPassword" -X GET http://localhost:8080/jboss-as-tasks-rs/tasks
+
+Using either of the above *GET* methods, you should see the following XML:
+
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <collection>
+        <task id="1" ownerName="quickstartUser">
+        <title>task1</title>
+        </task>
+    </collection>
+
+### Delete a Task
+
+To delete a task, again authenticate as principal `quickstartUser` and send an HTTP *DELETE* request to the URI that represents the task.  
+
+To delete the task with id `1`:
 
     curl -i -u "quickstartUser:quickstartPassword" -X DELETE http://localhost:8080/jboss-as-tasks-rs/task/1
+
+You will see this response:
+
     HTTP/1.1 204 No Content
     Server: Apache-Coyote/1.1
     Pragma: No-cache
@@ -127,34 +157,55 @@ To delete the task with id 1:
     Expires: Thu, 01 Jan 1970 01:00:00 GMT
     Date: Sun, 15 Apr 2012 22:51:56 GMT
 
-Now if you list all tasks associated with user quickstartUser you should get back an empty collection:
+Now list all tasks associated with user `quickstartUser`:
 
     curl -u "quickstartUser:quickstartPassword" -X GET http://localhost:8080/jboss-as-tasks-rs/tasks
-    <?xml version="1.0" encoding="UTF-8" standalone="yes"?><collection/>
 
-Modifying the quickstart to support JSON representations of tasks
+You will see a response with an empty collection:
+
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <collection/>
+
+
+Modify this Quickstart to Support JSON Representations of Tasks
 -----------------------------------------------------------------
 
-JSON is not part of the JAX-RS standard but most JAX-RS implementations do support it. The quickstart
-can be modified to suport JSON by uncommenting a few lines (look for lines beginning with "// JSON:":
+JSON is not part of the JAX-RS standard but most JAX-RS implementations do support it. This quickstart can be modified to support JSON by uncommenting a few lines. Look for lines beginning with "// JSON:":
 
-1. Open the file src/org/jboss/as/quickstarts/tasksrs/model/Task.java and uncomment the two lines
+1. Open the file src/org/jboss/as/quickstarts/tasksrs/model/Task.java and remove the comments from the following two lines.
 
-    import org.codehaus.jackson.annotate.JsonIgnore;
+        // import org.codehaus.jackson.annotate.JsonIgnore;
+        
+        // @JsonIgnore
 
-    @JsonIgnore
+2. Open the file src/org/jboss/as/quickstarts/tasksrs/service/TaskResource.java and make sure the *GET* methods produce "application/json" as well as "application/xml". Again, look for lines beginning with "// JSON:".
+    * Remove comments from these lines: 
 
-2. Open the file src/org/jboss/as/quickstarts/tasksrs/service/TaskResource.java and make sure the GET
-methods produce "application/json" (look for lines beginning with "// JSON:") 
+        //@Produces({ "application/xml", "application/json" })        
+    * Add comments to these lines:
+   
+        @Produces({ "application/xml" })
+3. Open pom.xml and remove the comments from the dependency with artifactId `resteasy-jackson-provider`
 
-3. Open pom.xml and uncomment the dependency with artifactId resteasy-jackson-provider
+        <!--
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson-provider</artifactId>
+            <version>2.3.1.GA</version>
+            <scope>provided</scope>
+        </dependency>
+        -->
 
-Rebuild and redeploy the quickstart.
 
-Now you can view task resources in JSON media type by specifying the correct Accept header. For example
-using the curl tool:
+4. Rebuild and redeploy the quickstart.
 
-    curl --header "Accept: application/json" -u "quickstartUser:quickstartPassword" -X GET http://localhost:8080/jboss-as-tasks-rs/task/1
+
+Now you can view task resources in JSON media type by specifying the correct Accept header. For example, using the cURL tool, type the following command:
+
+    curl -H "Accept: application/json" -u "quickstartUser:quickstartPassword" -X GET http://localhost:8080/jboss-as-tasks-rs/task/1
+
+You will see the following response:
+
     {"id":1,"title":"task1","ownerName":"quickstartUser"}
 
 

--- a/tasks-rs/README.md
+++ b/tasks-rs/README.md
@@ -1,0 +1,182 @@
+tasks-rs: JAX-RS, JPA quickstart
+==============================
+
+Author: [Mike Musgrove](https://community.jboss.org/people/mmusgrov)
+
+
+What is it?
+-----------
+
+This project demonstrates how to implement a JAX-RS service that uses JPA 2.0 persistence.
+The client uses HTTP to interact with the service. It builds on the *tasks* quickstarts which
+provide simple Task management with secure log in.
+
+The service interface is implemented using JAX-RS. The SecurityContext JAX-RS annotation
+is used to inject the security details into each REST method.
+
+The application manages User and Task JPA entities. A user represents an authenticated principal and is associated with zero or more Tasks. Service methods validate that there is an authenticated principal and the first
+time a principal is seen a JPA User entity is created to correspond to the principal. JAX-RS methods are provided for associating Tasks with this User and for listing and removing Tasks.
+
+
+System requirements
+-------------------
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
+
+The application this project produces is designed to be run on JBoss Enterprise Application Platform 6 or JBoss AS 7. 
+
+
+Configure Maven 
+-------------
+
+If you have not yet done so, you must [Configure Maven](../README.md#mavenconfiguration) before testing the quickstarts.
+
+
+Add At Least One Application User
+---------------
+
+This quickstart uses a secured management interface and requires that you create an application user to access the running application. Instructions to set up an Application user can be found here:  [Add an Application User](../README.md#addapplicationuser). After following those instructions you should have created a user
+called quickstartUser with password quickstartUser (and belonging to the guest role).
+
+
+Start JBoss Enterprise Application Platform 6 or JBoss AS 7 with the Web Profile
+-------------------------
+
+1. Open a command line and navigate to the root of the JBoss server directory.
+2. The following shows the command line to start the server with the web profile:
+
+        For Linux:   JBOSS_HOME/bin/standalone.sh
+        For Windows: JBOSS_HOME\bin\standalone.bat
+
+
+Build and Deploy the Quickstart
+-------------------------
+
+_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See [Build and Deploy the Quickstarts](../README.md#buildanddeploy) for complete instructions and additional options._
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. Type this command to build and deploy the archive:
+
+        mvn clean package jboss-as:deploy
+
+4. This will deploy `target/jboss-as-tasks-rs.war` to the running instance of the server.
+
+
+Access application resources
+---------------------
+
+Application resources are prefixed with the URL http://localhost:8080/jboss-as-tasks-rs/ and
+can be accessed by an HTTP client. For methods that accept GET a web browser can be used otherwise
+use a command line tool that supports HTTP POST and DELETE methods (for example curl) must be used.
+
+To associate a task called task1 with the user quickstartUser, authenticate as user quickstartUser
+and send an HTTP POST request to the url
+
+    http://localhost:8080/jboss-as-tasks-rs/task/task1
+
+The "Location" header of the response contains the URI of the resource representing the newly created
+task. To delete this task, again authenticate as pricipal quickstartUser whilst sending an HTTP DELETE
+request to this task URI.  Similary, to get an XML representation of the resource just created issue
+a GET request on the task URI.
+
+To obtain a list all resources for user quickstartUser in XML format, authenticate as user quickstartUser and send an HTTP GET request (with accept header application/xml) to the url
+
+    http://localhost:8080/jboss-as-tasks-rs/tasks
+
+For example, if you type the previous url into a browser then you will be challenged to enter valid authentication credentials and if successful the browser will display an XML document containing all the tasks belonging to the user that was just validated.
+
+Here are some example commands to achieve the above using a tool called curl:
+
+Create a task with title task1 and associate it with user quickstartUser:
+
+    curl -i -u "quickstartUser:quickstartPassword" -X POST http://localhost:8080/jboss-as-tasks-rs/task/task1
+    HTTP/1.1 201 Created
+    Server: Apache-Coyote/1.1
+    Location: http://localhost:8080/jboss-as-tasks-rs/task/1
+    Content-Length: 0
+    Date: Sun, 15 Apr 2012 22:46:26 GMT
+
+The -i flag tells curl to print the returned headers. Notice that the Location header contains the URI of the resource corresponding to the new Task you have just created.
+
+The -u flag provides the authentication information for the request.
+
+The -X flag tells curl which HTTP method to use (POST is used to create resources).
+
+The final argument to curl determines the title of the task. An alternative (and more restful) approach would be to POST to http://localhost:8080/jboss-as-tasks-rs/task passing the task title in the body of the request. Certainly a real task would contain more that just a title so it would make sense to include the title in the body.
+
+To see an XML representation of the task perform a GET on URI that was returned in the Location header:
+
+    curl --header "Accept: application/xml" -u "quickstartUser:quickstartPassword" -X GET http://localhost:8080/jboss-as-tasks-rs/task/1
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?><task id="1" ownerName="quickstartUser"><title>task1</title></task>
+
+The --header flag tells the server that the client wishes to accept XML content.
+
+To list all tasks associated with the user quickstartUser type:
+
+    curl --header "Accept: application/xml" -u "quickstartUser:quickstartPassword" -X GET http://localhost:8080/jboss-as-tasks-rs/tasks
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?><collection><task id="1" ownerName="quickstartUser"><title>task1</title></task></collection>
+
+To delete the task with id 1:
+
+    curl -i -u "quickstartUser:quickstartPassword" -X DELETE http://localhost:8080/jboss-as-tasks-rs/task/1
+    HTTP/1.1 204 No Content
+    Server: Apache-Coyote/1.1
+    Pragma: No-cache
+    Cache-Control: no-cache
+    Expires: Thu, 01 Jan 1970 01:00:00 GMT
+    Date: Sun, 15 Apr 2012 22:51:56 GMT
+
+Now if you list all tasks associated with user quickstartUser you should get back an empty collection:
+
+    curl -u "quickstartUser:quickstartPassword" -X GET http://localhost:8080/jboss-as-tasks-rs/tasks
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?><collection/>
+
+Modifying the quickstart to support JSON representations of tasks
+-----------------------------------------------------------------
+
+JSON is not part of the JAX-RS standard but most JAX-RS implementations do support it. The quickstart
+can be modified to suport JSON by uncommenting a few lines (look for lines beginning with "// JSON:":
+
+1. Open the file src/org/jboss/as/quickstarts/tasksrs/model/Task.java and uncomment the two lines
+
+    import org.codehaus.jackson.annotate.JsonIgnore;
+
+    @JsonIgnore
+
+2. Open the file src/org/jboss/as/quickstarts/tasksrs/service/TaskResource.java and make sure the GET
+methods produce "application/json" (look for lines beginning with "// JSON:") 
+
+3. Open pom.xml and uncomment the dependency with artifactId resteasy-jackson-provider
+
+Rebuild and redeploy the quickstart.
+
+Now you can view task resources in JSON media type by specifying the correct Accept header. For example
+using the curl tool:
+
+    curl --header "Accept: application/json" -u "quickstartUser:quickstartPassword" -X GET http://localhost:8080/jboss-as-tasks-rs/task/1
+    {"id":1,"title":"task1","ownerName":"quickstartUser"}
+
+
+Undeploy the Archive
+--------------------
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. When you are finished testing, type this command to undeploy the archive:
+
+        mvn jboss-as:undeploy
+
+
+Run the Quickstart in JBoss Developer Studio or Eclipse
+-------------------------------------
+You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see [Use JBoss Developer Studio or Eclipse to Run the Quickstarts](../README.md#useeclipse) 
+
+
+Debug the Application
+---------------------
+
+If you want to debug the source code or look at the Javadocs of any library in the project, run either of the following commands to pull them into your local repository. The IDE should then detect them.
+
+        mvn dependency:sources
+        mvn dependency:resolve -Dclassifier=javadoc

--- a/tasks-rs/pom.xml
+++ b/tasks-rs/pom.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.as.quickstarts</groupId>
+    <artifactId>jboss-as-tasks-rs</artifactId>
+    <version>7.1.1-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <name>JBoss AS Quickstarts: Tasks JAX-RS</name>
+    <description>JBoss AS Quickstarts: Tasks JSFJAX-RS</description>
+    
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <!-- Explicitly declaring the source encoding eliminates the following
+            message: -->
+        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
+            resources, i.e. build is platform dependent! -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Timestamp format for the maven.build.timestamp property -->
+        <!-- You can reference property in pom.xml or filtered resources (must
+            enable third-party plugin if using Maven < 2.1) -->
+        <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
+
+        <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want to import.  -->
+        <javaee6.with.tools.version>1.0.0.M7</javaee6.with.tools.version>
+        <!-- Alternatively, comment out the above line, and un-comment the line below to
+        use version 1.0.0.M7-redhat-1 which is a release certified
+        to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 maven repository. -->
+        <!--
+        <javaee6.spec.version>1.0.0.M7-redhat-1</javaee6.spec.version>
+        -->
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- JBoss distributes a complete set of Java EE 6 APIs including a Bill
+        of Materials (BOM). A BOM specifies the versions of a "stack" (or a collection)
+        of artifacts. We use this here so that we always get the correct versions
+        of artifacts. Here we use the jboss-javaee-6.0-with tools stack (you can read this as
+        the JBoss stack of the Java EE 6 APIs, with some extras tools for your project, such
+        as Arquillian for testing) -->
+            <dependency>
+                <groupId>org.jboss.bom</groupId>
+                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
+                <version>${javaee6.with.tools.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Import the CDI API, we use provided scope as the API is included 
+         in JBoss AS 7 -->
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Import the JPA API, we use provided scope as the API is included
+            in JBoss AS 7 -->
+        <dependency>
+            <groupId>org.hibernate.javax.persistence</groupId>
+            <artifactId>hibernate-jpa-2.0-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Import the JAX-RS API, we use provided scope as the API is included 
+            in JBoss AS 7 -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_1.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- JSON: uncomment to include json support (note json is not part of the JAX-RS standard)
+            -->
+	    <!--
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson-provider</artifactId>
+            <version>2.3.1.GA</version>
+            <scope>provided</scope>
+        </dependency>
+	-->
+
+        <!-- Import the EJB API, we use provided scope as the API is included
+            in JBoss AS 7 -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+
+    <build>
+        <!-- Maven will append the version to the finalName (which is the name
+            given to the generated war, and hence the context root) -->
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.1.1</version>
+                <configuration>
+                    <!-- Java EE 6 doesn't require web.xml, Maven needs to catch
+                        up! -->
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+            <!-- Compiler plugin enforces Java 1.6 compatibility and activates
+                annotation processors -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <!-- Surefire plugin is responsible for running tests
+                as part of project build -->
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.4.3</version>
+            </plugin>
+            <!-- The JBoss AS plugin deploys your war to a local JBoss
+                AS container -->
+            <!-- To use, run: mvn package jboss-as:deploy -->
+            <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <version>7.1.1.Final</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <!-- The default profile skips all tests, though you can tune it
+                to run just unit tests based on a custom pattern -->
+            <!-- Seperate profiles are provided for running all tests, including
+                Arquillian tests that execute in the specified container -->
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+
+        </profile>
+        <profile>
+            <!-- An optional Arquillian testing profile that executes tests
+                in your JBoss AS instance -->
+            <!-- This profile will start a new JBoss AS instance, and execute
+                the test, shutting it down when done -->
+            <!-- Run with: mvn clean test -Parq-jbossas-managed -->
+            <id>arq-jbossas-managed</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-arquillian-container-managed</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <!-- An optional Arquillian testing profile that executes tests
+                in a remote JBoss AS instance -->
+            <!-- Run with: mvn clean test -Parq-jbossas-remote -->
+            <id>arq-jbossas-remote</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-arquillian-container-remote</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+    </profiles>
+</project>

--- a/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/Resources.java
+++ b/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/Resources.java
@@ -1,0 +1,42 @@
+package org.jboss.as.quickstarts.tasksrs.model;
+
+import java.util.logging.Logger;
+
+import javax.ejb.Stateful;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.PersistenceContextType;
+
+/**
+ * This class uses CDI to alias Java EE resources, such as the persistence context, to CDI beans. As it is a stateful bean, it
+ * can produce extended persistence contexts.
+ * 
+ * Example injection on a managed bean field:
+ * 
+ * &#064;Inject private EntityManager em;
+ * 
+ * @author Pete Muir
+ * @author Lukas Fryc
+ * 
+ */
+@Stateful
+@RequestScoped
+public class Resources {
+
+    @PersistenceContext(type = PersistenceContextType.EXTENDED)
+    private EntityManager em;
+
+    @Produces
+    public EntityManager getEm() {
+        return em;
+    }
+
+    @Produces
+    public Logger getLogger(InjectionPoint ip) {
+        String category = ip.getMember().getDeclaringClass().getName();
+        return Logger.getLogger(category);
+    }
+}

--- a/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/Task.java
+++ b/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/Task.java
@@ -1,0 +1,127 @@
+package org.jboss.as.quickstarts.tasksrs.model;
+
+// JSON: uncomment to include json support (note json is not part of the JAX-RS standard)
+//import org.codehaus.jackson.annotate.JsonIgnore;
+
+import static javax.persistence.GenerationType.IDENTITY;
+
+import java.io.Serializable;
+import java.io.StringReader;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.xml.bind.JAXB;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+/**
+ * User's task entity which is marked up with JPA annotations and JAXB for serializing XML
+ * (and JSON if required)
+ *
+ * @author Oliver Kiss and others
+ */
+@SuppressWarnings("serial")
+@Entity
+@XmlRootElement(name = "task")
+public class Task implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private User owner;
+
+    private String title;
+
+    public Task() {
+    }
+
+    public Task(String title) {
+        super();
+        this.title = title;
+    }
+
+    @XmlAttribute
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @XmlTransient
+    // JSON: uncomment to include json support (note json is not part of the JAX-RS standard)
+//    @JsonIgnore
+    public User getOwner() {
+        return owner;
+    }
+
+    @XmlAttribute
+    public String getOwnerName() {
+        return owner.getUsername();
+    }
+
+    public void setOwner(User owner) {
+        this.owner = owner;
+    }
+
+    @XmlElement
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((owner == null) ? 0 : owner.hashCode());
+        result = prime * result + ((title == null) ? 0 : title.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Task other = (Task) obj;
+        if (owner == null) {
+            if (other.owner != null) {
+                return false;
+            }
+        } else if (!owner.equals(other.owner)) {
+            return false;
+        }
+        if (title == null) {
+            if (other.title != null) {
+                return false;
+            }
+        } else if (!title.equals(other.title)) {
+            return false;
+        }
+        return true;
+    }
+
+    public static Task stringToTask(String content) {
+        return JAXB.unmarshal(new StringReader(content), Task.class);
+    }
+}

--- a/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/TaskDao.java
+++ b/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/TaskDao.java
@@ -1,0 +1,25 @@
+package org.jboss.as.quickstarts.tasksrs.model;
+
+import java.util.List;
+
+import javax.ejb.Local;
+
+/**
+ * Basic operations for manipulation of tasks
+ * 
+ * @author Lukas Fryc
+ * 
+ */
+@Local
+public interface TaskDao {
+
+    void createTask(User user, Task task);
+
+    List<Task> getAll(User user);
+
+    List<Task> getRange(User user, int offset, int count);
+
+    List<Task> getForTitle(User user, String title);
+
+    void deleteTask(Task task);
+}

--- a/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/TaskDaoImpl.java
+++ b/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/TaskDaoImpl.java
@@ -1,0 +1,65 @@
+package org.jboss.as.quickstarts.tasksrs.model;
+
+import java.util.List;
+
+import javax.ejb.Stateful;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+
+/**
+ * Provides functionality for manipulation with tasks using the persistence context from {@link Resources}.
+ * 
+ * @author Lukas Fryc
+ * @author Oliver Kiss
+ * 
+ */
+@Stateful
+public class TaskDaoImpl implements TaskDao {
+
+    @Inject
+    private EntityManager em;
+
+    @Override
+    public void createTask(User user, Task task) {
+        if (!em.contains(user)) {
+            user = em.merge(user);
+        }
+        user.getTasks().add(task);
+        task.setOwner(user);
+        em.persist(task);
+    }
+
+    @Override
+    public List<Task> getAll(User user) {
+        TypedQuery<Task> query = querySelectAllTasksFromUser(user);
+        return query.getResultList();
+    }
+
+    @Override
+    public List<Task> getRange(User user, int offset, int count) {
+        TypedQuery<Task> query = querySelectAllTasksFromUser(user);
+        query.setMaxResults(count);
+        query.setFirstResult(offset);
+        return query.getResultList();
+    }
+
+    @Override
+    public List<Task> getForTitle(User user, String title) {
+        String lowerCaseTitle = "%" + title.toLowerCase() + "%";
+        return em.createQuery("SELECT t FROM Task t WHERE t.owner = ? AND LOWER(t.title) LIKE ?", Task.class)
+                .setParameter(1, user).setParameter(2, lowerCaseTitle).getResultList();
+    }
+
+    @Override
+    public void deleteTask(Task task) {
+        if (!em.contains(task)) {
+            task = em.merge(task);
+        }
+        em.remove(task);
+    }
+
+    private TypedQuery<Task> querySelectAllTasksFromUser(User user) {
+        return em.createQuery("SELECT t FROM Task t WHERE t.owner = ?", Task.class).setParameter(1, user);
+    }
+}

--- a/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/User.java
+++ b/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/User.java
@@ -1,0 +1,91 @@
+package org.jboss.as.quickstarts.tasksrs.model;
+
+import static javax.persistence.CascadeType.ALL;
+import static javax.persistence.GenerationType.IDENTITY;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+/**
+ * User entity
+ * 
+ * @author Oliver Kiss
+ */
+@SuppressWarnings("serial")
+@Entity
+public class User implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String username;
+
+    @OneToMany(cascade = ALL, mappedBy = "owner")
+    @Column(updatable = false)
+    private List<Task> tasks = new ArrayList<Task>();
+
+    public User() {
+    }
+
+    public User(String username) {
+        this.username = username;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public List<Task> getTasks() {
+        return tasks;
+    }
+
+    public void setTasks(List<Task> tasks) {
+        this.tasks = tasks;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((username == null) ? 0 : username.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        User other = (User) obj;
+        if (username == null) {
+            if (other.username != null)
+                return false;
+        } else if (!username.equals(other.username))
+            return false;
+        return true;
+    }
+}

--- a/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/UserDao.java
+++ b/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/UserDao.java
@@ -1,0 +1,17 @@
+package org.jboss.as.quickstarts.tasksrs.model;
+
+import javax.ejb.Local;
+
+/**
+ * Basic operations for manipulation with users
+ * 
+ * @author Lukas Fryc
+ * 
+ */
+@Local
+public interface UserDao {
+
+    public User getForUsername(String username);
+
+    public void createUser(User user);
+}

--- a/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/UserDaoImpl.java
+++ b/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/model/UserDaoImpl.java
@@ -1,0 +1,35 @@
+package org.jboss.as.quickstarts.tasksrs.model;
+
+import java.util.List;
+
+import javax.ejb.Stateful;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+/**
+ * Provides functionality for manipulation with users using persistence context from {@link Resources}.
+ * 
+ * @author Lukas Fryc
+ * @author Oliver Kiss
+ * 
+ */
+@Stateful
+public class UserDaoImpl implements UserDao {
+
+    @Inject
+    private EntityManager em;
+
+    public User getForUsername(String username) {
+        List<User> result = em.createQuery("select u from User u where u.username = ?", User.class).setParameter(1, username)
+                .getResultList();
+
+        if (result.isEmpty()) {
+            return null;
+        }
+        return result.get(0);
+    }
+
+    public void createUser(User user) {
+        em.persist(user);
+    }
+}

--- a/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/service/TaskResource.java
+++ b/tasks-rs/src/main/java/org/jboss/as/quickstarts/tasksrs/service/TaskResource.java
@@ -1,0 +1,129 @@
+package org.jboss.as.quickstarts.tasksrs.service;
+
+import org.jboss.as.quickstarts.tasksrs.model.Task;
+import org.jboss.as.quickstarts.tasksrs.model.TaskDao;
+import org.jboss.as.quickstarts.tasksrs.model.User;
+import org.jboss.as.quickstarts.tasksrs.model.UserDao;
+
+import javax.inject.Inject;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
+import java.net.URI;
+import java.security.Principal;
+import java.util.List;
+
+/**
+ * A JAX-RS resource for exposing REST endpoints for Task manipulation
+ */
+@Path("/")
+public class TaskResource {
+    @Inject
+    private UserDao userDao;
+
+    @Inject
+    private TaskDao taskDao;
+
+    @POST
+    @Path("task/{title}")
+    public Response createTask(@Context UriInfo info, @Context SecurityContext context,
+                               @PathParam("title")  @DefaultValue("task") String taskTitle) {
+
+        User user = getUser(context);
+        Task task = new Task(taskTitle);
+
+        taskDao.createTask(user, task);
+
+        // Construct the URI for the newly created resource and put in into the Location header of the response
+        // (assumes that there is only one occurrence of the task title in the request)
+        String rawPath = info.getAbsolutePath().getRawPath().replace(task.getTitle(), task.getId().toString());
+        UriBuilder uriBuilder = info.getAbsolutePathBuilder().replacePath(rawPath);
+        URI uri = uriBuilder.build();
+
+        return Response.created(uri).build();
+    }
+
+    @DELETE
+    @Path("task/{id}")
+    public void deleteTaskById(@Context SecurityContext context, @PathParam("id") Long id) {
+        Task task = getTaskById(context, id);
+
+        taskDao.deleteTask(task);
+    }
+
+    @GET
+    @Path("task/{id}")
+    // JSON: include "application/json" in the @Produces annotation to include json support
+    //@Produces({ "application/xml", "application/json" })
+    @Produces({ "application/xml" })
+    public Task getTaskById(@Context SecurityContext context, @PathParam("id") Long id) {
+        User user = getUser(context);
+
+        return getTask(user, id);
+    }
+
+    @GET
+    @Path("tasks/{title}")
+    // JSON: include "application/json" in the @Produces annotation to include json support
+    //@Produces({ "application/xml", "application/json" })
+    @Produces({ "application/xml" })
+    public List<Task> getTasksByTitle(@Context SecurityContext context, @PathParam("title") String title) {
+        return getTasks(getUser(context), title);
+    }
+
+    @GET
+    @Path("tasks")
+    // JSON: include "application/json" in the @Produces annotation to include json support
+    //@Produces({ "application/xml", "application/json" })
+    @Produces({ "application/xml" })
+    public List<Task> getTasks(@Context SecurityContext context) {
+        return getTasks(getUser(context));
+    }
+
+
+    // Utility Methods
+
+    private List<Task> getTasks(User user, String title) {
+        return taskDao.getForTitle(user, title);
+    }
+
+    private List<Task> getTasks(User user) {
+        return taskDao.getAll(user);
+    }
+
+    private Task getTask(User user, Long id) {
+        for (Task task : taskDao.getAll(user))
+            if (task.getId().equals(id))
+                return task;
+
+        throw new WebApplicationException(Response.Status.NOT_FOUND);
+    }
+
+    private User getUser(SecurityContext context) {
+        Principal principal = null;
+
+        if (context != null)
+            principal = context.getUserPrincipal();
+
+        if (principal == null)
+            throw new WebApplicationException(Response.Status.UNAUTHORIZED);
+
+        return getUser(principal.getName());
+    }
+
+    private User getUser(String username) {
+
+        try {
+            User user = userDao.getForUsername(username);
+
+            if (user == null) {
+                user = new User(username);
+
+                userDao.createUser(user);
+            }
+
+            return user;
+        } catch (Exception e) {
+            throw new WebApplicationException(e);
+        }
+    }
+}

--- a/tasks-rs/src/main/resources/META-INF/persistence.xml
+++ b/tasks-rs/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.0"
+   xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+        http://java.sun.com/xml/ns/persistence
+        http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+   <persistence-unit name="primary">
+      <jta-data-source>java:jboss/datasources/TasksRsQuickstartDS</jta-data-source>
+      <properties>
+         <!-- Properties for Hibernate -->
+         <property name="hibernate.hbm2ddl.auto" value="create-drop" />
+         <property name="hibernate.show_sql" value="false" />
+      </properties>
+   </persistence-unit>
+</persistence>

--- a/tasks-rs/src/main/webapp/WEB-INF/tasks-rs-ds.xml
+++ b/tasks-rs/src/main/webapp/WEB-INF/tasks-rs-ds.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<datasources xmlns="http://www.jboss.org/ironjacamar/schema"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.jboss.org/ironjacamar/schema http://docs.jboss.org/ironjacamar/schema/datasources_1_0.xsd">
+   <!-- The datasource is bound into JNDI at this location. We reference 
+      this in META-INF/persistence.xml -->
+   <datasource jndi-name="java:jboss/datasources/TasksRsQuickstartDS"
+      pool-name="tasks-rs-xml-quickstart" enabled="true"
+      use-java-context="true">
+      <connection-url>jdbc:h2:mem:tasks-rs-xml-quickstart;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+      <driver>h2</driver>
+      <security>
+         <user-name>sa</user-name>
+         <password>sa</password>
+      </security>
+   </datasource>
+</datasources>
+ 

--- a/tasks-rs/src/main/webapp/WEB-INF/web.xml
+++ b/tasks-rs/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,34 @@
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <!-- One of the way of activating REST Services is adding these lines, the server is responsible for adding the corresponding servlet automatically. If the src folder, org.jboss.as.quickstarts.rshelloworld.HelloWorld class has the Annotations to receive REST invocation-->
+    <servlet-mapping>
+        <servlet-name>javax.ws.rs.core.Application</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+
+    <!-- Use HTTP Basic for authentication -->
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>RealmUsersRoles</realm-name>
+    </login-config>
+
+    <context-param>
+      <param-name>resteasy.role.based.security</param-name>
+      <param-value>true</param-value>
+    </context-param>
+
+    <security-constraint>
+      <web-resource-collection>
+        <web-resource-name>Tasks</web-resource-name>
+        <url-pattern>/*</url-pattern>
+      </web-resource-collection>
+      <auth-constraint>
+        <role-name>guest</role-name>
+      </auth-constraint>
+    </security-constraint>
+
+    <security-role>
+      <role-name>guest</role-name>
+    </security-role>
+</web-app>

--- a/tasks-rs/src/test/java/org/jboss/as/quickstarts/tasksrs/DefaultDeployment.java
+++ b/tasks-rs/src/test/java/org/jboss/as/quickstarts/tasksrs/DefaultDeployment.java
@@ -1,0 +1,39 @@
+package org.jboss.as.quickstarts.tasksrs;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * Enables prepare project-specific {@link WebArchive} for deployment.
+ *
+ * @author Lukas Fryc
+ *
+ */
+public class DefaultDeployment {
+
+    private static final String WEBAPP_SRC = "src/main/webapp";
+
+    private WebArchive webArchive;
+
+    public DefaultDeployment() {
+        webArchive = ShrinkWrap.create(WebArchive.class, "test.war").addAsWebInfResource(
+                new File(WEBAPP_SRC, "WEB-INF/beans.xml"));
+    }
+
+    public DefaultDeployment withPersistence() {
+        webArchive = webArchive.addAsResource("META-INF/test-persistence.xml", "META-INF/persistence.xml").addAsWebInfResource(
+                "test-ds.xml", "test-ds.xml");
+        return this;
+    }
+
+    public DefaultDeployment withImportedData() {
+        webArchive = webArchive.addAsResource("import.sql");
+        return this;
+    }
+
+    public WebArchive getArchive() {
+        return webArchive;
+    }
+}

--- a/tasks-rs/src/test/java/org/jboss/as/quickstarts/tasksrs/TaskDaoTest.java
+++ b/tasks-rs/src/test/java/org/jboss/as/quickstarts/tasksrs/TaskDaoTest.java
@@ -1,0 +1,113 @@
+package org.jboss.as.quickstarts.tasksrs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.quickstarts.tasksrs.model.*;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Lukas Fryc
+ * @author Oliver Kiss
+ */
+@RunWith(Arquillian.class)
+public class TaskDaoTest {
+
+    @Deployment
+    public static WebArchive deployment() throws IllegalArgumentException, FileNotFoundException {
+        return new DefaultDeployment().withPersistence().withImportedData().getArchive()
+                .addClasses(Resources.class, User.class, UserDao.class, Task.class, TaskDao.class, TaskDaoImpl.class);
+    }
+
+    @Inject
+    private EntityManager em;
+
+    @Inject
+    private TaskDao taskDao;
+
+    private User detachedUser;
+
+    @Before
+    public void setUp() throws Exception {
+        detachedUser = new User("jdoe");
+        detachedUser.setId(1L);
+    }
+
+    @Test
+    public void user_should_be_created_with_one_task_attached() throws Exception {
+        // given
+        User user = new User("New user");
+        Task task = new Task("New task");
+
+        // when
+        em.persist(user);
+        taskDao.createTask(user, task);
+        List<Task> userTasks = em.createQuery("SELECT t FROM Task t WHERE t.owner = :owner", Task.class)
+                .setParameter("owner", user).getResultList();
+
+        // then
+        assertEquals(1, userTasks.size());
+        assertEquals(task, userTasks.get(0));
+    }
+
+    @Test
+    public void all_tasks_should_be_obtained_from_detachedUser() {
+        // when
+        List<Task> userTasks = taskDao.getAll(detachedUser);
+
+        // then
+        assertEquals(2, userTasks.size());
+    }
+
+    @Test
+    public void range_of_tasks_should_be_provided_by_taskDao() {
+        // when
+        List<Task> headOfTasks = taskDao.getRange(detachedUser, 0, 1);
+        List<Task> tailOfTasks = taskDao.getRange(detachedUser, 1, 1);
+
+        // then
+        assertEquals(1, headOfTasks.size());
+        assertEquals(1, tailOfTasks.size());
+        assertTrue(headOfTasks.get(0).getTitle().contains("first"));
+        assertTrue(tailOfTasks.get(0).getTitle().contains("second"));
+    }
+
+    @Test
+    public void taskDao_should_provide_basic_case_insensitive_full_text_search() {
+        // given
+        String taskTitlePart = "FIRST";
+
+        // when
+        List<Task> titledTasks = taskDao.getForTitle(detachedUser, taskTitlePart);
+
+        // then
+        assertEquals(1, titledTasks.size());
+        assertTrue(titledTasks.get(0).getTitle().contains("first"));
+    }
+
+    @Test
+    public void taskDao_should_remove_task_from_detachedUser() {
+        // given
+        Task task = new Task();
+        task.setId(1L);
+        task.setOwner(detachedUser);
+        assertEquals(2, taskDao.getAll(detachedUser).size());
+
+        // when
+        taskDao.deleteTask(task);
+
+        // then
+        assertEquals(1, taskDao.getAll(detachedUser).size());
+    }
+}

--- a/tasks-rs/src/test/java/org/jboss/as/quickstarts/tasksrs/UserDaoTest.java
+++ b/tasks-rs/src/test/java/org/jboss/as/quickstarts/tasksrs/UserDaoTest.java
@@ -1,0 +1,76 @@
+package org.jboss.as.quickstarts.tasksrs;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.quickstarts.tasksrs.model.*;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Lukas Fryc
+ * @author Oliver Kiss
+ */
+@RunWith(Arquillian.class)
+public class UserDaoTest {
+
+    @Deployment
+    public static WebArchive deployment() throws IllegalArgumentException, FileNotFoundException {
+        return new DefaultDeployment().withPersistence().withImportedData().getArchive()
+                .addClasses(Resources.class, User.class, UserDao.class, Task.class, TaskDao.class, UserDaoImpl.class);
+    }
+
+    @Inject
+    private UserDao userDao;
+
+    @Inject
+    private EntityManager em;
+
+    @Test
+    public void userDao_should_create_user_so_it_could_be_retrieved_from_userDao_by_username() {
+        // given
+        User created = new User("username1");
+
+        // when
+        userDao.createUser(created);
+        User retrieved = userDao.getForUsername("username1");
+
+        // then
+        assertTrue(em.contains(created));
+        assertTrue(em.contains(retrieved));
+        Assert.assertEquals(created, retrieved);
+    }
+
+    @Test
+    public void user_should_be_retrievable_from_userDao_by_username() {
+        // given
+        String username = "jdoe";
+
+        // when
+        User retrieved = userDao.getForUsername(username);
+
+        // then
+        Assert.assertEquals(username, retrieved.getUsername());
+    }
+
+    @Test
+    public void userDao_should_return_null_when_searching_for_non_existent_user() {
+        // given
+        String nonExistent = "nonExistent";
+
+        // when
+        User retrieved = userDao.getForUsername(nonExistent);
+
+        // then
+        assertNull(retrieved);
+    }
+}

--- a/tasks-rs/src/test/resources/META-INF/test-persistence.xml
+++ b/tasks-rs/src/test/resources/META-INF/test-persistence.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.0"
+   xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+        http://java.sun.com/xml/ns/persistence
+        http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+   <persistence-unit name="primary">
+      <!-- We use a different datasource for tests, so as to not overwrite 
+         production data. This is an unmanaged data source, backed by H2, an in memory 
+         database. Production applications should use a managed datasource. -->
+      <!-- The datasource is deployed as WEB-INF/test-ds.xml, 
+         you can find it in the source at src/test/resources/test-ds.xml -->
+      <jta-data-source>java:jboss/datasources/TasksJsfQuickstartTestDS</jta-data-source>
+      <properties>
+         <!-- Properties for Hibernate -->
+         <property name="hibernate.hbm2ddl.auto" value="create-drop" />
+         <property name="hibernate.show_sql" value="false" />
+      </properties>
+   </persistence-unit>
+</persistence>

--- a/tasks-rs/src/test/resources/arquillian.xml
+++ b/tasks-rs/src/test/resources/arquillian.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <!-- Uncomment to have test archives exported to the file system for inspection -->
+    <!-- <engine> -->
+    <!-- <property name="deploymentExportPath">target/</property> -->
+    <!-- </engine> -->
+
+    <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
+    <defaultProtocol type="Servlet 3.0"/>
+
+    <!-- Example configuration for a remote JBoss AS 7 instance -->
+    <container qualifier="jboss" default="true">
+        <!-- If you want to use the JBOSS_HOME environment variable, just delete the jbossHome property -->
+        <configuration>
+            <property name="jbossHome">/path/to/jboss/as</property>
+        </configuration>
+    </container>
+
+
+</arquillian>
+

--- a/tasks-rs/src/test/resources/test-ds.xml
+++ b/tasks-rs/src/test/resources/test-ds.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This is an unmanaged datasource. It should be used for proofs of concept 
+   or testing only. It uses H2, an in memory database that ships with JBoss 
+   AS. -->
+<datasources xmlns="http://www.jboss.org/ironjacamar/schema"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.jboss.org/ironjacamar/schema http://docs.jboss.org/ironjacamar/schema/datasources_1_0.xsd">
+   <!-- The datasource is bound into JNDI at this location. We reference 
+      this in META-INF/test-persistence.xml -->
+   <datasource jndi-name="java:jboss/datasources/TasksJsfQuickstartTestDS"
+      pool-name="tasks-jsf-quickstart-test" enabled="true"
+      use-java-context="true">
+      <connection-url>jdbc:h2:mem:tasks-jsf-quickstart-test;DB_CLOSE_DELAY=-1</connection-url>
+      <driver>h2</driver>
+      <security>
+         <user-name>sa</user-name>
+         <password>sa</password>
+      </security>
+   </datasource>
+</datasources>
+ 


### PR DESCRIPTION
This example takes the jsf tasks quickstart and shows how to replace the service provider with JAX-RS resources and the UI with HTTP methods.

If you have already reviewed the JSF task quickstart then my changes are to replace the controller with TaskResource.java, adding JAXB annotations to Task.java and configuration changes (including configuring authentication in the web.xml - the authenticated user name then becomes the User owner of created Tasks). 

The readme includes a section explaining how to add support for JSON (which is supposed to be quickstart 34). I decided to combine for two reasons:
1. The changes are trivial.
2. Having the changes in quickstart 33 makes it easier for the user to see what it takes to support JSON. I did include a note explaining that JSON support is not part of the standard.

Let me know what you think.
