### PR TITLE
[AS7-3887] Use the 7.1.1.Final version of the jboss-as-maven-plugin

### DIFF
--- a/helloworld-errai/pom.xml
+++ b/helloworld-errai/pom.xml
@@ -116,7 +116,7 @@
       <plugin>
         <groupId>org.jboss.as.plugins</groupId>
         <artifactId>jboss-as-maven-plugin</artifactId>
-        <version>7.1.0.CR1</version>
+        <version>7.1.1.Final</version>
       </plugin>
 
       <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->

--- a/jta-crash-rec/pom.xml
+++ b/jta-crash-rec/pom.xml
@@ -131,7 +131,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.0.CR1</version>
+                <version>7.1.1.Final</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->

--- a/kitchensink-html5-mobile/pom.xml
+++ b/kitchensink-html5-mobile/pom.xml
@@ -186,7 +186,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.0.Final</version>
+                <version>7.1.1.Final</version>
             </plugin>
             
             <plugin>

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -92,7 +92,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.0.Beta1b</version>
+            <version>7.1.1.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/payment-cdi-event/pom.xml
+++ b/payment-cdi-event/pom.xml
@@ -104,7 +104,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.0.Beta1b</version>
+            <version>7.1.1.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->


### PR DESCRIPTION
Update a few poms to use the current version of the jboss-as-maven-plugin
