### PR TITLE
Add quickstarts to JBoss Tools

### DIFF
--- a/.project_example.xml
+++ b/.project_example.xml
@@ -1,0 +1,2289 @@
+<projects>
+
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-helloworld</name>
+		<priority>1</priority>
+		<included-projects>jboss-as-helloworld</included-projects>
+		<shortDescription>Helloworld</shortDescription>
+		<description>
+This example demonstrates the use of CDI 1.0 and Servlet 3 in JBoss AS 7.1.1
+The example can be deployed using Maven from the command line or from Eclipse using JBoss Tools.
+		</description>
+		<size>8192</size>
+		<url>helloworld</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>bean-validation</name>
+		<priority>2</priority>
+		<included-projects>bean-validation</included-projects>
+		<shortDescription>Bean Validation</shortDescription>
+		<description>
+This project demonstrates how to use CDI 1.0, JPA 2.0 and Bean Validation 1.0. It includes a persistence unit and some sample persistence code to introduce you to database access in enterprise Java. 
+
+This quickstart does not contain a user interface layer. The purpose of this project is to show you how to test bean validation with Arquillian. If you want to see an example of how to test bean validation with a user interface, look at the kitchensink example.
+		</description>
+		<size>27700</size>
+		<url>bean-validation</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-bmt</name>
+		<priority>3</priority>
+		<included-projects>jboss-as-bmt</included-projects>
+		<shortDescription>Bean Managed Transactions</shortDescription>
+		<description>
+On occasion, the application developer requires finer grained control over the lifecycle of JTA transactions and JPA Entity Managers than the defaults provided by the Java EE container. This example shows how the developer can override these defaults and take control of aspects of the lifecycle of JPA and transactions.
+
+This example demonstrates how to manually manage transaction demarcation while accessing JPA entities in JBoss AS 7.
+		</description>
+		<size>34129</size>
+		<url>bmt</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-cdi-injection</name>
+		<priority>4</priority>
+		<included-projects>jboss-as-cdi-injection</included-projects>
+		<shortDescription>CDI-Injection</shortDescription>
+		<description>
+This example demonstrates the use of *CDI 1.0 Injection and Qualifiers* in *JBoss AS 7* with JSF as the front-end client.
+
+		</description>
+		<size>20996</size>
+		<url>cdi-injection</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-cmt</name>
+		<priority>5</priority>
+		<included-projects>jboss-as-cmt</included-projects>
+		<shortDescription>Container Managed Transactions</shortDescription>
+		<description>
+This quickstart demonstrates using transactions managed by the container. It is a fairly typical scenario of updating a database and sending a JMS message in the same transaction. A simple MDB is provided that prints out the message sent but this is not a transactional MDB and is purely provided for debugging purposes.		
+		</description>
+		<size>40584</size>
+		<url>cmt</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-ejb-in-ear</name>
+		<priority>6</priority>
+		<included-projects>jboss-as-ejb-in-ear,jboss-as-ejb-in-ear-ear,jboss-as-ejb-in-ear-ejb,jboss-as-ejb-in-ear-web</included-projects>
+		<shortDescription>EJB and War in an Ear</shortDescription>
+		<description>
+his example demonstrates the deployment of an EAR artifact. The EAR contains: *JSF 2.0* WAR and an *EJB 3.1* JAR.
+
+The example is composed of three maven projects, each with a shared parent. 
+		</description>
+		<size>30901</size>
+		<url>ejb-in-ear</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-ejb-in-war</name>
+		<priority>7</priority>
+		<included-projects>jboss-as-ejb-in-war</included-projects>
+		<shortDescription> EJB in a War</shortDescription>
+		<description>
+This example demonstrates the deployment of an *EJB 3.1* bean bundled in a war archive for deployment to *JBoss AS 7*. The project also includes a set of Aquillian tests for the managed bean and EJB.
+
+The example follows the common "Hello World" pattern. 		
+		</description>
+		<size>27881</size>
+		<url>ejb-in-war</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>ejb-remote</name>
+		<priority>8</priority>
+		<included-projects>jboss-as-ejb-remote-parent,jboss-as-ejb-remote-client,jboss-as-ejb-remote-server-side</included-projects>
+		<shortDescription>Remote EJB and Java client</shortDescription>
+		<description>
+This example shows how to access an EJB from a remote Java client application. It demonstrates the use of *EJB 3.1* and *JNDI* in *JBoss *JBoss AS 7*.		
+		</description>
+		<size>27881</size>
+		<url>ejb-remote</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-ejb-security</name>
+		<priority>9</priority>
+		<included-projects>jboss-as-ejb-security</included-projects>
+		<shortDescription> EJB Security</shortDescription>
+		<description>
+This example demonstrates the use of Java EE declarative security to control access to EJB3 and Security in *JBoss AS 7*.
+		</description>
+		<size>17625</size>
+		<url>ejb-security</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-greeter</name>
+		<priority>10</priority>
+		<included-projects>jboss-as-greeter</included-projects>
+		<shortDescription>Greeter</shortDescription>
+		<description>
+This example demonstrates the use of *CDI 1.0*, *JPA 2.0*, *JTA 1.1*, *EJB 3.1* and *JSF 2.0* in *JBoss AS 7*.
+		</description>
+		<size>32838</size>
+		<url>greeter</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-helloworld-errai</name>
+		<priority>11</priority>
+		<included-projects>jboss-as-helloworld-errai</included-projects>
+		<shortDescription>Errai Hello World</shortDescription>
+		<description>
+This example demonstrates the use of *CDI 1.0* and *JAX-RS* in *JBoss AS 7* with a GWT front-end client.
+
+GWT is basically a typesafe, statically checked programming model for producing HTML5+CSS3+JavaScript front-ends. In this example, we use RESTful services on the backend. The client communicates with the backend using stubs that are generated based on the JAX-RS resources when the application is compiled.
+		</description>
+		<size>32936</size>
+		<url>helloworld-errai</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-helloworld-gwt</name>
+		<priority>12</priority>
+		<included-projects>jboss-as-helloworld-gwt</included-projects>
+		<shortDescription>Hello World with GWT front-end client</shortDescription>
+		<description>
+This example demonstrates the use of *CDI 1.0* and *JAX-RS* in *JBoss AS 7* with a GWT front-end client.
+
+GWT is basically a typesafe, statically checked programming model for producing HTML5+CSS3+JavaScript front-ends. 
+In this example, we use RESTful services on the backend. The client communicates with the backend using stubs that are generated based on the JAX-RS resources when the application is compiled.
+		</description>
+		<size>28348</size>
+		<url>helloworld-gwt</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-helloworld-html5</name>
+		<priority>13</priority>
+		<included-projects>jboss-as-helloworld-html5</included-projects>
+		<shortDescription>POH5 Helloworld</shortDescription>
+		<description>
+This example demonstrates the use of *CDI 1.0* and *JAX-RS* in *JBoss AS 7* using the POH5 architecture.
+POH5 is basically a smart, HTML5+CSS3+JavaScript front-end using RESTful services on the backend.
+		</description>
+		<size>29899</size>
+		<url>helloworld-html5</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-helloworld-jms</name>
+		<priority>14</priority>
+		<included-projects>jboss-as-helloworld-jms</included-projects>
+		<shortDescription>Helloworld JMS external producer/consumer client</shortDescription>
+		<description>
+This quickstart demonstrates the use of external JMS clients with JBoss AS 7.
+
+It contains the following:
+1. A message producer that sends messages to a JMS destination deployed to a JBoss AS 7 server.
+2. A message consumer that receives message from a JMS destination deployed to a JBoss AS 7 server. 
+		</description>
+		<size>19955</size>
+		<url>helloworld-jms</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-helloworld-jsf</name>
+		<priority>15</priority>
+		<included-projects>jboss-as-helloworld-jsf</included-projects>
+		<shortDescription>Hello world JSF</shortDescription>
+		<description>
+This project demonstrates how to create a Java EE 6 compliant application using JSF 2.0, CDI 1.0, and RichFaces 4.1.  
+
+In this example, a standard JSF `h:inputText` component is AJAX enabled using the RichFaces `a4j:ajax tag`. This triggers the application server to re-render only a subsection of the page on a browser event.
+		</description>
+		<size>17123</size>
+		<url>helloworld-jsf</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-helloworld-mdb</name>
+		<priority>16</priority>
+		<included-projects>jboss-as-helloworld-mdb</included-projects>
+		<shortDescription>Helloworld Message-Driven Bean with Servlet 3.0 as client</shortDescription>
+		<description>
+This example demonstrates the use of *JMS 1.1* and *EJB 3.1 Message-Driven Bean* in JBoss AS 7.1.0.
+
+This project creates a queue named `HELLOWORLDMDBQueue` which is bound in JNDI as `java:/queue/HELLOWORLDMDBQueue`.
+
+		</description>
+		<size>32155</size>
+		<url>helloworld-mdb</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<welcome type="cheatsheets" url="/jboss-as-helloworld-mdb/cheatsheets/helloworld-mdb.xml"/>
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-helloworld-osgi</name>
+		<priority>17</priority>
+		<included-projects>jboss-as-helloworld-osgi</included-projects>
+		<shortDescription>Helloworld OSGi</shortDescription>
+		<description>
+This example demonstrates the use of *OSGi* in *JBoss AS 7*.
+		
+		</description>
+		<size>9017</size>
+		<url>helloworld-osgi</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-helloworld-rs</name>
+		<priority>18</priority>
+		<included-projects>jboss-as-helloworld-rs</included-projects>
+		<shortDescription>Helloworld using JAX-RS</shortDescription>
+		<description>
+This example demonstrates the use of *CDI 1.0* and *JAX-RS* in *JBoss AS 7*.
+		
+		</description>
+		<size>20092</size>
+		<url>helloworld-rs</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-helloworld-singleton</name>
+		<priority>19</priority>
+		<included-projects>jboss-as-helloworld-singleton</included-projects>
+		<shortDescription>Helloworld Singleton Session Bean with JSF 2.0 as client</shortDescription>
+		<description>
+This quickstart demonstrates the use of an *EJB 3.1 Singleton Bean* in JBoss AS 7.
+		
+		</description>
+		<size>14724</size>
+		<url>helloworld-singleton</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-hibernate3</name>
+		<priority>20</priority>
+		<included-projects>jboss-as-hibernate3</included-projects>
+		<shortDescription>Hibernate 3</shortDescription>
+		<description>
+Example that uses Hibernate 3 for database access. Compare the code in this quickstart to the _hibernate4_ quickstart to see the changes needed to upgrade to Hibernate 4.
+		
+		</description>
+		<size>91848</size>
+		<url>hibernate3</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-hibernate4</name>
+		<priority>21</priority>
+		<included-projects>jboss-as-hibernate4</included-projects>
+		<shortDescription>Application that uses Hibernate 4</shortDescription>
+		<description>
+This quickstart is based upon the kitchensink example, but demonstrates how to use Hibernate ORM 4 over JPA in JBoss AS 7.
+
+This project is setup to allow you to create a compliant Java EE 6 application using JSF 2.0, CDI 1.0, EJB 3.1, JPA 2.0 , Hibernate-Core and Hibernate Bean Validation.  It includes a persistence unit associated with Hibernate session and some sample persistence and transaction code to help you with database access in enterprise Java. 
+
+You can compare this quickstart to the `hibernate3` quickstart to see the code differences between Hibernate 3 and Hibernate 4.
+		
+		</description>
+		<size>119804</size>
+		<url>hibernate4</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-jax-rs-client</name>
+		<priority>22</priority>
+		<included-projects>jboss-as-jax-rs-client</included-projects>
+		<shortDescription>JAX-RS Client</shortDescription>
+		<description>
+This example demonstrates an external JAX-RS RestEasy client which interacts with a JAX-RS Web service that uses *CDI 1.0* and *JAX-RS* 
+in *JBoss AS 7*.  
+
+This client "calls" the HelloWorld JAX-RS Web Service that was created in the `Helloworld using JAX-RS` quickstart. See the **Prerequisite** section below for details on how to build and deploy the `helloworld-rs` quickstart.
+		
+		</description>
+		<size>18013</size>
+		<url>jax-rs-client</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-jta-crash-rec</name>
+		<priority>23</priority>
+		<included-projects>jboss-as-jta-crash-rec</included-projects>
+		<shortDescription>XA and JTA Crash Recovery</shortDescription>
+		<description>
+This quickstart demonstrates how to code distributed or XA (eXtended Architecture) transactions so that the ACID properties are preserved across participating resources after a server crash. An XA transaction is one in which multiple resources, such as MDBs and databases, participate within the same transaction. It ensures all operations are performed as a single entity of work. ACID is a set of 4 properties that guarantee the resources are processed in the following manner:
+
+* Atomic - if any part of the transaction fails, all resources remain unchanged. 
+* Consistent - the state will be consistent across resources after a commit
+* Isolated - the execution of the transaction for each resource is isolated from each others
+* Durable - the data will persist after the transaction is committed
+		
+		</description>
+		<size>49710</size>
+		<url>jta-crash-rec</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-jts</name>
+		<priority>24</priority>
+		<included-projects>jboss-as-jts-parent,jboss-as-jts-application-component-1,jboss-as-jts-application-component-2</included-projects>
+		<shortDescription>Java Transaction Service</shortDescription>
+		<description>
+This example demonstrates how to perform distributed transactions in an application. A distributed transaction is a set of operations performed by two or more nodes, participating in an activity coordinated as a single entity of work, and fulfilling the properties of an ACID transaction. 
+
+ACID is a set of 4 properties that guarantee the resources are processed in the following manner:
+
+* Atomic - if any part of the transaction fails, all resources remain unchanged. 
+* Consistent - the state will be consistent across resources after a commit
+* Isolated - the execution of the transaction for each resource is isolated from each others
+* Durable - the data will persist after the transaction is committed
+		
+		</description>
+		<size>57281</size>
+		<url>jts</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-kitchensink</name>
+		<priority>25</priority>
+		<included-projects>jboss-as-kitchensink</included-projects>
+		<shortDescription>Kitchensink</shortDescription>
+		<description>
+This is your project! It is a sample, deployable Maven 3 project to help you get your foot in the door developing with Java EE 6 on JBoss AS 7. 
+
+This project is setup to allow you to create a compliant Java EE 6 application using JSF 2.0, CDI 1.0, EJB 3.1, JPA 2.0 and Bean Validation 1.0. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java. 
+		
+		</description>
+		<size>139562</size>
+		<url>kitchensink</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-kitchensink-ear</name>
+		<priority>26</priority>
+		<included-projects>jboss-as-kitchensink-ear,jboss-as-kitchensink-ear-ear,jboss-as-kitchensink-ear-ejb,jboss-as-kitchensink-ear-web</included-projects>
+		<shortDescription>Kitchensink EAR</shortDescription>
+		<description>
+This is your project! It is a sample, deployable Maven 3 project to help you get your foot in the door developing with Java EE 6 on JBoss AS 7. 
+
+This project is setup to allow you to create a compliant Java EE 6 application using JSF 2.0, CDI 1.0, EJB 3.1, JPA 2.0 and Bean Validation 1.0. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java. 		
+		</description>
+		<size>152608</size>
+		<url>kitchensink-ear</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-kitchensink-html5-mobile</name>
+		<priority>27</priority>
+		<included-projects>jboss-as-kitchensink-html5-mobile</included-projects>
+		<shortDescription>AeroGear HTML5/Mobile</shortDescription>
+		<description>
+This is your project! It's a deployable Maven 3 project to help you
+get your foot in the door developing HTML5 based desktop/mobile web applications with Java EE 6
+on JBoss. This project is setup to allow you to create a basic Java EE 6 application
+using HTML5, jQuery Mobile, JAX-RS, CDI 1.0, EJB 3.1, JPA 2.0 and Bean Validation 1.0. It includes
+a persistence unit and some sample persistence and transaction code to help 
+you get your feet wet with database access in enterprise Java.
+
+This application is built using a technique called Plain Old HTML5 (POH5).  This uses a pure HTML
+client that interacts with with the application server via restful end-points (JAX-RS).  This
+application also uses some of the latest HTML5 features and advanced JAX-RS. And since testing
+is just as important with POH5 as it is server side, this application uses QUnit to show
+you how to unit test your JavaScript.
+		
+		</description>
+		<size>538949</size>
+		<url>kitchensink-html5-mobile</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-kitchensink-jsp</name>
+		<priority>28</priority>
+		<included-projects>jboss-as-kitchensink-jsp</included-projects>
+		<shortDescription>Kitchensink with JSP front end</shortDescription>
+		<description>
+This quickstart is a deployable Maven 3 project to help you get your foot in the door developing with Java EE 6 on JBoss AS 7. 
+
+This project is setup to allow you to create a compliant Java EE 6 application using *JSP 2.0* *EL 2.0* *JSTL 1.2* *CDI 1.0*, *EJB 3.1*, *JPA 2.0* and Bean Validation 1.0. 
+
+This project recreates the presentation tier of the `kitchensink` quickstart using JSP and JSTL instead of JSF features. It reuses all other components from the Member Registration template. It also reuses the persistence unit and some sample persistence and transaction code to help you with database access in enterprise Java. 
+		
+		</description>
+		<size>100477</size>
+		<url>kitchensink-jsp</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-log4j</name>
+		<priority>29</priority>
+		<included-projects>jboss-as-log4j</included-projects>
+		<shortDescription>Logging using log4j</shortDescription>
+		<description>
+Demonstrates how to use modules to control class loading for 3rd party logging frameworks. 
+		
+		</description>
+		<size>16325</size>
+		<url>log4j</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-logging-tools</name>
+		<priority>30</priority>
+		<included-projects>jboss-as-logging-tools</included-projects>
+		<shortDescription>Logging using JAX-RS</shortDescription>
+		<description>
+This quick start demonstrates the use of JBoss Logging Tools to create internationalized loggers, exceptions, and generic messages; and then provide localizations for them. This is done using a simple JAX-RS service. Translations in French(fr-FR), German(de-DE), and Swedish (sv-SE) are provided courtesy of &lt;http://translate.google.com&gt; for demonstration. My apologies if they are less than ideal translations. 
+		
+		</description>
+		<size>48870</size>
+		<url>logging-tools</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-mail</name>
+		<priority>31</priority>
+		<included-projects>jboss-as-mail</included-projects>
+		<shortDescription>Mail</shortDescription>
+		<description>
+This example demonstrates sending email with the use of *CDI 1.0* and *JSF 2.0* in *JBoss AS 7*.
+
+The example uses the default Mail provider that comes out of the box with *JBoss AS 7*.  
+It uses your local mail relay and the default SMTP port of 25. 
+		
+		</description>
+		<size>17513</size>
+		<url>mail</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-numberguess</name>
+		<priority>32</priority>
+		<included-projects>jboss-as-numberguess</included-projects>
+		<shortDescription>Numberguess</shortDescription>
+		<description>
+This example demonstrates the use of *CDI 1.0* and *JSF 2.0* in *JBoss AS 7*. 
+		
+		</description>
+		<size>24268</size>
+		<url>numberguess</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-payment-cdi-event</name>
+		<priority>33</priority>
+		<included-projects>jboss-as-payment-cdi-event</included-projects>
+		<shortDescription>CDI-Event</shortDescription>
+		<description>
+This quickstart demonstrates how to use *CDI 1.0 Events* in *JBoss AS 7*.
+
+The JSF front-end client allows you to create both credit and debit operation events. 
+		
+		</description>
+		<size>80021</size>
+		<url>payment-cdi-event</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-richfaces-validation</name>
+		<priority>34</priority>
+		<included-projects>jboss-as-richfaces-validation</included-projects>
+		<shortDescription>RichFaces Bean Validation</shortDescription>
+		<description>
+This quickstart demonstrates how to use JSF 2.0, RichFaces 4.2, CDI 1.0, JPA 2.0 and Bean Validation 1.0. 
+
+It consists of one entity, `Member`, which is annotated with JSR-303 (Bean Validation) constraints. In typical applications, these constraints are checked in several places:
+
+* As database constraints
+* In the persistence layer
+* In the view layer (using JSF / Bean Validation integration)
+* On the client (using RichFaces 4.2 - Client Side Validation) 
+		
+		</description>
+		<size>49566</size>
+		<url>richfaces-validation</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-servlet-async</name>
+		<priority>35</priority>
+		<included-projects>jboss-as-servlet-async</included-projects>
+		<shortDescription>Asynchronous Servlet</shortDescription>
+		<description>
+This is a sample project showing the use of asynchronous servlets.
+
+It shows how to detach the execution of a resource intensive task from the request processing thread, so the thread is free to serve other client requests. The resource intensive tasks are executed using a dedicated thread pool and create the client response asynchronously. 
+		
+		</description>
+		<size>16768</size>
+		<url>servlet-async</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-servlet-filterlistener</name>
+		<priority>36</priority>
+		<included-projects>jboss-as-servlet-filterlistener</included-projects>
+		<shortDescription>Servlet Filter and Listener</shortDescription>
+		<description>
+This is a sample project showing the use of servlet filters and listeners. 
+		
+		</description>
+		<size>21894</size>
+		<url>servlet-filterlistener</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-servlet-security</name>
+		<priority>37</priority>
+		<included-projects>jboss-as-servlet-security</included-projects>
+		<shortDescription>Servlet Security</shortDescription>
+		<description>
+This example demonstrates the use of Java EE declarative security to control access to Servlets and Security in JBoss Enterprise Application Platform 6 and  JBoss AS7.
+
+This quickstart takes the following steps to implement Servlet security:
+
+1. Define a security domain in the `standalone.xml` configuration file.
+2. Add an application user with access rights to the application.
+3. Add a security domain reference to `WEB-INF/jboss-web.xml`.
+4. Add a security constraint to the `WEB-INF/web.xml` .
+5. Add a security annotation to the EJB declaration. 
+		
+		</description>
+		<size>16850</size>
+		<url>servlet-security</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-shoppingcart</name>
+		<priority>38</priority>
+		<included-projects>jboss-as-shoppingcart-parent,jboss-as-shoppingcart-client,jboss-as-shoppingcart-server</included-projects>
+		<shortDescription>EJB Stateful Session Bean</shortDescription>
+		<description>
+In this example, you will learn how to deploy and run a simple Java EE 6 application named `shopping-cart` that uses a stateful session bean. The shopping-cart allows customers to buy, checkout and view their cart contents. 
+
+The shopping-cart application consists of the following:
+
+1. A server side component:
+
+    This standalone Java EE module is a JAR containing EJBs. It is responsible for managing the shopping cart.
+2. A Java client:
+
+    This simple Java client is launched using a "main" method. The remote client looks up a reference to the server module's API, via JNDI. It then uses this API to perform the operations the customer requests. 
+		
+		</description>
+		<size>29047</size>
+		<url>shopping-cart</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<welcome type="editor" url="/jboss-as-shoppingcart/README.md"/>
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-tasks</name>
+		<priority>39</priority>
+		<included-projects>jboss-as-tasks</included-projects>
+		<shortDescription>Tasks</shortDescription>
+		<description>
+This project demonstrates how to use JPA 2.0 in JBoss AS 7. 
+
+It includes a persistence unit and some sample persistence code to introduce you database access in enterprise Java. 
+
+It does not contain an user interface layer. The purpose of the project is to show you how to test JPA with Arquillian. 
+		
+		</description>
+		<size>42601</size>
+		<url>tasks</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-tasks-jsf</name>
+		<priority>40</priority>
+		<included-projects>jboss-as-tasks-jsf</included-projects>
+		<shortDescription>Tasks JSF</shortDescription>
+		<description>
+This project demonstrates how to use JPA 2.0 persistence with JSF 2.0 as view layer.
+
+The theme of this application is simple Task management with simple log in. The project contains two entities - a user and a task.
+
+This sample includes a persistence unit and some sample persistence code to introduce you to database access in enterprise Java.
+
+Persistence code is covered by tests to help you write business logic without the need to use any view layer.
+
+JSF 2.0 is used to present user two views - authentication form and task view.
+
+The task view is contains a task list, a task detail and a task addition form. The task view uses AJAX. 
+		
+		</description>
+		<size>82756</size>
+		<url>tasks-jsf</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-tasks-rs</name>
+		<priority>41</priority>
+		<included-projects>jboss-as-tasks-rs</included-projects>
+		<shortDescription>Tasks JAX-RS</shortDescription>
+		<description>
+This project demonstrates how to implement a JAX-RS service that uses JPA 2.0 persistence.
+
+* The client uses HTTP to interact with the service. It builds on the *tasks* quickstarts which provide simple Task management with secure login.
+
+* The service interface is implemented using JAX-RS. The SecurityContext JAX-RS annotation is used to inject the security details into each REST method.
+
+The application manages User and Task JPA entities. A user represents an authenticated principal and is associated with zero or more Tasks. Service methods validate that there is an authenticated principal and the first time a principal is seen, a JPA User entity is created to correspond to the principal. JAX-RS annotated methods are provided for associating Tasks with this User and for listing and removing Tasks.
+		
+		</description>
+		<size>47119</size>
+		<url>tasks-rs</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-temperature-converter</name>
+		<priority>42</priority>
+		<included-projects>jboss-as-temperature-converter</included-projects>
+		<shortDescription>Temperature Converter</shortDescription>
+		<description>
+This example demonstrates the use of an *EJB 3.1 Stateless Session Bean* and *CDI* to access it via a *JSF*.
+Deployment occurs via a war archive for deployment to *JBoss AS 7*.
+
+These are the steps that occur:
+
+1. The user interface is a JSF page that asks for a temperature and a scale (Fahrenheit or Celsius).
+2. When you click on `Convert`, the temperature string is passed to the TemperatureConverter controller (managed) bean.
+3. The managed bean then invokes the `convert()` method of the injected TemperatureConvertEJB (notice the field annotated with @Inject).
+4. The response from TemperatureConvertEJB is stored in the `temperature` field of the managed bean.
+5. The managed bean is annotated as @SessionScoped, so the same managed bean instance is used for the entire session.
+		
+		</description>
+		<size>22948</size>
+		<url>temperature-converter</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-wicket-ear</name>
+		<priority>43</priority>
+		<included-projects>jboss-as-wicket-ear-parent,jboss-as-wicket-ear-ear,jboss-as-wicket-ear-ejb,jboss-as-wicket-ear-war</included-projects>
+		<shortDescription>Wicket EAR</shortDescription>
+		<description>
+This is an example of how to use Wicket Framework 1.5 with JBoss AS, leveraging features of Java EE 6, using the Wicket-Stuff Java EE integration.
+
+Features used:
+
+* Injection of `@PersistenceContext`
+* Injection of a value from `web.xml` using `@Resource`
+* Injection of a stateless session bean using `@EJB`
+		
+		</description>
+		<size>51489</size>
+		<url>wicket-ear</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+		<welcome type="editor" url="/jboss-as-wicket-ear/README.md"/>
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-wicket-war</name>
+		<priority>44</priority>
+		<included-projects>jboss-as-wicket-war</included-projects>
+		<shortDescription>Wicket WAR</shortDescription>
+		<description>
+This is an example of how to use Wicket Framework 1.5 with JBoss AS, leveraging features of Java EE 6, using the Wicket-Stuff Java EE integration.
+
+Features used:
+
+ * Injection of `@PersistenceContext`
+ * Injection of a value from `web.xml` using `@Resource`
+ * Injection of a stateless session bean using `@EJB`
+ 		
+		</description>
+		<size>41276</size>
+		<url>wicket-war</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-wsat-simple</name>
+		<priority>45</priority>
+		<included-projects>jboss-as-wsat-simple</included-projects>
+		<shortDescription>Simple WS-AT Web service</shortDescription>
+		<description>
+This example demonstrates the deployment of a WS-AT (WS-AtomicTransaction) enabled JAX-WS Web service bundled in a WAR archive for deployment to *JBoss AS 7*.
+
+The Web service is offered by a Restaurant for making bookings. The Service allows bookings to be made within an Atomic Transaction.
+ 		
+		</description>
+		<size>73264</size>
+		<url>wsat-simple</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-wsba-coordinator-completion-simple</name>
+		<priority>46</priority>
+		<included-projects>jboss-as-wsba-coordinator-completion-simple</included-projects>
+		<shortDescription>Simple WS-BA with Coordinator Driven Completion</shortDescription>
+		<description>
+This example demonstrates the deployment of a WS-BA (WS Business Activity) enabled JAX-WS Web service bundled in a WAR archive for deployment to *JBoss AS 7*.
+
+The Web service exposes a simple 'set' collection as a service. The Service allows items to be added to the set within a Business Activity.
+ 		
+		</description>
+		<size>58369</size>
+		<url>wsba-coordinator-completion-simple</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-wsba-participant-completion-simple</name>
+		<priority>47</priority>
+		<included-projects>jboss-as-wsba-participant-completion-simple</included-projects>
+		<shortDescription>Simple WS-BA with Participant Driven Completion</shortDescription>
+		<description>
+This example demonstrates the deployment of a WS-BA (WS Business Activity) enabled JAX-WS Web service bundled in a war archive for deployment to *JBoss AS 7*.
+
+The Web service exposes a simple 'set' collection as a service. The Service allows items to be added to the set within a Business Activity.
+ 		
+		</description>
+		<size>56033</size>
+		<url>wsba-participant-completion-simple</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-xml-dom4j</name>
+		<priority>48</priority>
+		<included-projects>jboss-as-xml-dom4j</included-projects>
+		<shortDescription>XML DOM4J</shortDescription>
+		<description>
+This is a simple JSF 2.0, Servlet 3.0 and DOM4J example. Its purpose is to demonstrate how you can use Servlet and JSF to upload an XML file to *JBoss AS7* and parse it using 3rd party XML parsing library.
+
+It shows how to include 3rd part library in deployment.
+ 		
+		</description>
+		<size>42712</size>
+		<url>xml-dom4j</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+	<project>
+		<category>JBoss AS 7.1.1 Quickstarts</category>
+		<name>jboss-as-xml-jaxp</name>
+		<priority>49</priority>
+		<included-projects>jboss-as-xml-jaxp</included-projects>
+		<shortDescription>XML JAXP</shortDescription>
+		<description>
+This is a simple JSF 2.0, Servlet 3.0 and Java EE JAXP example. Its purpose is to demonstrate how you can use Servlet and JSF to upload an XML file to *JBoss AS7* and parse it using DOM or SAX, both of which are built in to Java.
+
+It also shows how to use modules available in JBoss AS.
+ 		
+		</description>
+		<size>47462</size>
+		<url>xml-jaxp</url>
+		<fixes>
+			<fix type="wtpruntime">
+				<property name="allowed-types">org.jboss.ide.eclipse.as.runtime.71</property>
+				<property name="description">works with JBoss 7.1</property>
+				<property name="downloadId">org.jboss.tools.runtime.core.as.711</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.eclipse.m2e.core</property>
+				<property name="versions">[1.0.0,1.2.0)</property>
+				<property name="description">m2e &gt;= 1.0.</property>
+				<property name="connectorIds">org.eclipse.m2e.feature</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.maven.ide.eclipse.wtp</property>
+				<property name="versions">[0.13.1,0.16.0)</property>
+				<property name="description">m2eclipse-wtp &gt;= 0.13.1.</property>
+				<property name="connectorIds">org.maven.ide.eclipse.wtp</property>
+			</fix>
+			<fix type="plugin">
+				<property name="id">org.jboss.tools.maven.core</property>
+				<property name="versions">[1.3.0,1.4.0)</property>
+				<property name="description">JBoss Maven Tools</property>
+				<property name="connectorIds">org.jboss.tools.maven.feature,org.jboss.tools.maven.cdi.feature,org.jboss.tools.maven.hibernate.feature,org.jboss.tools.maven.jaxrs.feature, org.jboss.tools.maven.portlet.feature,org.jboss.tools.maven.seam.feature</property>
+			</fix>
+		</fixes>
+		<importType>maven</importType>
+		<importTypeDescription>The project example requires the m2eclipse, m2eclipse-wtp and JBoss Maven Project Examples feature.</importTypeDescription>
+
+		<!-- <tags>central</tags> -->
+        <icon path="icons/jboss.png" />        
+	</project>
+	
+</projects>

--- a/helloworld-mdb/cheatsheets/helloworld-mdb.xml
+++ b/helloworld-mdb/cheatsheets/helloworld-mdb.xml
@@ -54,7 +54,7 @@ For sending message uses this url <b>http://localhost:8080//jboss-as-helloworld-
 		<action
 			pluginId="org.jboss.tools.project.examples.cheatsheet"
 			class="org.jboss.tools.project.examples.cheatsheet.actions.OpenFileInEditor"
-			param1="/jboss-as-helloworld/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldMDB.java"/>
+			param1="/jboss-as-helloworld-mdb/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldMDB.java"/>
 	  </subitem>
   </item>  
   <item


### PR DESCRIPTION
The .project_example.xml file defines quickstarts so that they can be automatically imported to JBoss Tools.
See https://issues.jboss.org/browse/JBIDE-11727 for more details.
I have also fixed a typing error in the helloworld-mdb cheatsheet that causes the HelloWorldMDB.java file to throw an exception.
