### PR TITLE
Fix issue 295: remove github URLs from the parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
     <packaging>pom</packaging>
     <name>JBoss AS Quickstarts Parent</name>
     <description>JBoss AS Quickstarts Parent</description>
-    <url>http://github.com/jbossas/quickstart</url>
-
+    <url>http://www.jboss.org/jdf/quickstarts/get-started/</url>
+ 
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -65,8 +65,7 @@
                 <module>helloworld-osgi</module>
                 <module>helloworld-rs</module>
                 <module>helloworld-singleton</module>
-                <!-- Hibernate 3 is broken on AS 7.1.1 - see https://github.com/jbossas/quickstart/issues/186 -->
-                <!-- <module>hibernate3</module> -->
+                <module>hibernate3</module>
                 <module>hibernate4</module>
                 <module>kitchensink</module>
                 <module>kitchensink-ear</module>
@@ -167,12 +166,6 @@
             </modules>
         </profile>
     </profiles>
-
-    <scm>
-        <connection>scm:git://github.com/jbossas/quickstart.git</connection>
-        <developerConnection>scm:git:git@github.com:jbossas/quickstart.git</developerConnection>
-        <url>http://github.com/jbossas/quickstart</url>
-    </scm>
 
     <build>
         <plugins>


### PR DESCRIPTION
Removed obsolete github URLs from POM. Added hbernate3 as issue is resolved.
