### PR TITLE
Convert version numbers to properties

### DIFF
--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -38,6 +38,21 @@
         <!-- You can reference property in pom.xml or filtered resources (must
             enable third-party plugin if using Maven < 2.1) -->
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <hibernate.validator.version>4.2.0.Final</hibernate.validator.version>
+        <hibernate.jpamodelgen.version>1.1.1.Final</hibernate.jpamodelgen.version>
+
+        <!-- other plugin versions -->
+        <surefire.plugin.version>2.10</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -51,7 +66,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>1.0.0.Final</version>
+                <version>${jboss.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -85,7 +100,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>4.2.0.Final</version>
+            <version>${hibernate.validator.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -102,7 +117,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
-            <version>1.1.1.Final</version>
+            <version>${hibernate.jpamodelgen.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -141,7 +156,7 @@
                 <!-- The Maven Surefire plugin tests your application. Here we ensure we are using a version compatible with Arquillian -->
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.10</version>
+                    <version>${surefire.plugin.version}</version>
                 </plugin>
                 <!-- The JBoss AS plugin deploys your war to a local JBoss AS container -->
                 <!-- To use, set the JBOSS_HOME environment variable and run:
@@ -149,7 +164,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>7.1.1.Final</version>
+                    <version>${jboss.as.plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -157,7 +172,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -166,10 +181,10 @@
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/bmt/pom.xml
+++ b/bmt/pom.xml
@@ -34,6 +34,18 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+      <!-- JBoss dependency versions -->
+      <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+      <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+      <!-- other plugin versions -->
+      <war.plugin.version>2.1.1</war.plugin.version>
+      <compiler.plugin.version>2.3.1</compiler.plugin.version>
+
+      <!-- maven-compiler-plugin -->
+      <maven.compiler.target>1.6</maven.compiler.target>
+      <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -49,7 +61,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -114,7 +126,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>${war.plugin.version}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch
                   up! -->
@@ -125,16 +137,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
+            <version>${compiler.plugin.version}</version>
             <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+               <source>${maven.compiler.source}</source>
+               <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>

--- a/cdi-injection/pom.xml
+++ b/cdi-injection/pom.xml
@@ -34,6 +34,18 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+       <!-- other plugin versions -->
+       <war.plugin.version>2.1.1</war.plugin.version>
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -49,7 +61,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -91,7 +103,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>${war.plugin.version}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -102,16 +114,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
+            <version>${compiler.plugin.version}</version>
             <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+               <source>${maven.compiler.source}</source>
+               <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>

--- a/cluster-ha-singleton/client/pom.xml
+++ b/cluster-ha-singleton/client/pom.xml
@@ -57,10 +57,10 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.source}</target>
                 </configuration>
             </plugin>
             <!-- Add the maven exec plugin to allow us to run a java program 
@@ -68,7 +68,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>${exec.plugin.version}</version>
                 <configuration>
                     <executable>java</executable>
                     <arguments>

--- a/cluster-ha-singleton/pom.xml
+++ b/cluster-ha-singleton/pom.xml
@@ -35,6 +35,20 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.version>7.1.1.Final</jboss.as.version>
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <ejb.plugin.version>2.3</ejb.plugin.version>
+        <exec.plugin.version>1.2.1</exec.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
 
@@ -53,14 +67,14 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>3.0.0.Final</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-ejb-client-bom</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -72,16 +86,16 @@
             <!-- Enforce Java 1.6 -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.source}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -89,7 +103,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>${exec.plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/cluster-ha-singleton/service/pom.xml
+++ b/cluster-ha-singleton/service/pom.xml
@@ -56,10 +56,10 @@
             <!-- Enforce Java 1.6 -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.source}</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -67,11 +67,11 @@
                     2.1 to 3.0 -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ejb-plugin</artifactId>
-                <version>2.3</version>
+                <version>${ejb.plugin.version}</version>
                 <configuration>
                     <ejbVersion>3.1</ejbVersion>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.source}</target>
                     <generateClient>true</generateClient>
                     <clientIncludes>
                         <clientInclude>**/ServiceAccess.class</clientInclude>

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -34,6 +34,19 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <surefire.plugin.version>2.10</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -47,7 +60,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>1.0.0.Final</version>
+                <version>${jboss.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -108,16 +121,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -131,7 +144,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/ejb-asynchronous/client/pom.xml
+++ b/ejb-asynchronous/client/pom.xml
@@ -49,14 +49,14 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>3.0.0.Final</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-ejb-client-bom</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -139,7 +139,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>${exec.plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/ejb-asynchronous/ejb/pom.xml
+++ b/ejb-asynchronous/ejb/pom.xml
@@ -35,7 +35,7 @@
 			<plugin>	
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-ejb-plugin</artifactId>
-				<version>2.3</version>
+				<version>${ejb.plugin.version}</version>
 				<configuration>
                     <!-- set the EJB version to 3.1 -->
 					<ejbVersion>3.1</ejbVersion>
@@ -50,7 +50,7 @@
 			<plugin>
 				<groupId>org.jboss.as.plugins</groupId>
 				<artifactId>jboss-as-maven-plugin</artifactId>
-				<version>7.1.1.Final</version>
+				<version>${jboss.as.plugin.version}</version>
 				<configuration>
 					<filename>${project.build.finalName}.jar</filename>
 					<skip>false</skip>

--- a/ejb-asynchronous/pom.xml
+++ b/ejb-asynchronous/pom.xml
@@ -35,6 +35,20 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.version>7.1.1.Final</jboss.as.version>
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <ejb.plugin.version>2.3</ejb.plugin.version>
+        <exec.plugin.version>1.2.1</exec.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
 
@@ -53,14 +67,14 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>3.0.0.Final</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-ejb-client-bom</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.version}</version>
                 <scope>runtime</scope>
                 <type>pom</type>
             </dependency>
@@ -91,16 +105,16 @@
             <!-- Enforce Java 1.6 -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -108,7 +122,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>${exec.plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/ejb-in-ear/ear/pom.xml
+++ b/ejb-in-ear/ear/pom.xml
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>${ear.plugin.version}</version>
                 <!-- configuring the ear plugin -->
                 <configuration>
                     <!-- Specify the artifact name for the EAR -->
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
                 <configuration>
                     <filename>jboss-as-ejb-in-ear.ear</filename>
                     <skip>false</skip>
@@ -93,10 +93,10 @@
           annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/ejb-in-ear/ejb/pom.xml
+++ b/ejb-in-ear/ejb/pom.xml
@@ -72,10 +72,10 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/ejb-in-ear/pom.xml
+++ b/ejb-in-ear/pom.xml
@@ -35,6 +35,21 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
                 resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.version>7.1.1.Final</jboss.as.version>
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <ear.plugin.version>2.3.2</ear.plugin.version>
+        <ejb.plugin.version>2.3</ejb.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -52,7 +67,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>3.0.0.Final</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -64,7 +79,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/ejb-in-ear/web/pom.xml
+++ b/ejb-in-ear/web/pom.xml
@@ -89,7 +89,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -99,10 +99,10 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/ejb-in-war/pom.xml
+++ b/ejb-in-war/pom.xml
@@ -34,6 +34,19 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+
+       <!-- other plugin versions -->
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <surefire.plugin.version>2.10</surefire.plugin.version>
+       <war.plugin.version>2.1.1</war.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -52,7 +65,7 @@
          <dependency>
             <groupId>org.jboss.bom</groupId>
             <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${jboss.bom.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -115,7 +128,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>${war.plugin.version}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -126,16 +139,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>
@@ -154,7 +167,7 @@
             <plugins>
                <plugin>
                   <artifactId>maven-surefire-plugin</artifactId>
-                  <version>2.4.3</version>
+                  <version>${surefire.plugin.version}</version>
                   <configuration>
                      <skip>true</skip>
                   </configuration>

--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -35,6 +35,20 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.version>7.1.1.Final</jboss.as.version>
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+       <!-- other plugin versions -->
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <exec.plugin.version>1.2.1</exec.plugin.version>
+       <war.plugin.version>2.1.1</war.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -50,7 +64,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -58,7 +72,7 @@
          <dependency>
              <groupId>org.jboss.as</groupId>
              <artifactId>jboss-as-ejb-client-bom</artifactId>
-             <version>7.1.1.Final</version>
+             <version>${jboss.as.version}</version>
              <type>pom</type>
              <scope>import</scope>
          </dependency>
@@ -140,10 +154,10 @@
          <!-- Enforce Java 1.6  -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
 
@@ -151,7 +165,7 @@
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>1.2.1</version>
+            <version>${exec.plugin.version}</version>
             <executions>
               <execution>
                   <goals>
@@ -192,7 +206,7 @@
             <plugin>
                <groupId>org.jboss.as.plugins</groupId>
                <artifactId>jboss-as-maven-plugin</artifactId>
-               <version>7.1.1.Final</version>
+               <version>${jboss.as.plugin.version}</version>
                <inherited>true</inherited>
                <configuration>
                   <skip>true</skip>

--- a/ejb-remote/pom.xml
+++ b/ejb-remote/pom.xml
@@ -26,6 +26,11 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
     </licenses>
+    
+    <properties>
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+    </properties>
 
     <!-- This quickstart consists of a server side component and a client that accesses
 	 the server side component. Each component has its own self contain pom. However,
@@ -44,7 +49,7 @@
             <plugin>
                <groupId>org.jboss.as.plugins</groupId>
                <artifactId>jboss-as-maven-plugin</artifactId>
-               <version>7.1.1.Final</version>
+               <version>${jboss.as.plugin.version}</version>
                <inherited>true</inherited>
                <configuration>
                   <skip>true</skip>

--- a/ejb-remote/server-side/pom.xml
+++ b/ejb-remote/server-side/pom.xml
@@ -34,6 +34,18 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+       <!-- other plugin versions -->
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <ejb.plugin.version>2.3</ejb.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -49,7 +61,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -84,7 +96,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
             <configuration>
                 <filename>${project.build.finalName}.jar</filename>
             </configuration>
@@ -93,16 +105,16 @@
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-ejb-plugin</artifactId>
-            <version>2.3</version>
+            <version>${ejb.plugin.version}</version>
             <configuration>
                <ejbVersion>3.1</ejbVersion>
                <!-- this is false by default -->

--- a/ejb-security/pom.xml
+++ b/ejb-security/pom.xml
@@ -34,6 +34,17 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+      <!-- JBoss dependency versions -->
+      <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+      <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+      <!-- other plugin versions -->
+      <compiler.plugin.version>2.3.1</compiler.plugin.version>
+
+      <!-- maven-compiler-plugin -->
+      <maven.compiler.target>1.6</maven.compiler.target>
+      <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -49,7 +60,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -97,16 +108,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>

--- a/greeter/pom.xml
+++ b/greeter/pom.xml
@@ -34,6 +34,18 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+       <!-- other plugin versions -->
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <war.plugin.version>2.1.1</war.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -51,7 +63,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -117,7 +129,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>${war.plugin.version}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -128,16 +140,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>

--- a/helloworld-errai/pom.xml
+++ b/helloworld-errai/pom.xml
@@ -34,6 +34,20 @@
     <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is 
       platform dependent! -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+      <!-- JBoss dependency versions -->
+      <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+      <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+
+      <!-- other plugin versions -->
+      <clean.pluging.version>2.4.1</clean.pluging.version>
+      <compiler.plugin.version>2.3.1</compiler.plugin.version>
+      <gwt.plugin.version>2.4.0</gwt.plugin.version>
+      <war.plugin.version>2.1.1</war.plugin.version>
+
+      <!-- maven-compiler-plugin -->
+      <maven.compiler.target>1.6</maven.compiler.target>
+      <maven.compiler.source>1.6</maven.compiler.source>
   </properties>
 
   <dependencyManagement>
@@ -41,7 +55,7 @@
       <dependency>
         <groupId>org.jboss.bom</groupId>
         <artifactId>jboss-javaee-6.0-with-errai</artifactId>
-        <version>1.0.0.Final</version>
+        <version>${jboss.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -114,7 +128,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>${war.plugin.version}</version>
         <configuration>
           <!-- Exclude client only classes from the deployment. As these classes compile down to JavaScript, 
             they are not needed at runtime. They would only introduce runtime dependencies to GWT development libraries. -->
@@ -126,16 +140,16 @@
       <plugin>
         <groupId>org.jboss.as.plugins</groupId>
         <artifactId>jboss-as-maven-plugin</artifactId>
-        <version>7.1.1.Final</version>
+        <version>${jboss.as.plugin.version}</version>
       </plugin>
 
       <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.1</version>
+        <version>${compiler.plugin.version}</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
         </configuration>
       </plugin>
 
@@ -143,7 +157,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>2.4.0</version>
+        <version>${gwt.plugin.version}</version>
         <configuration>
           <inplace>true</inplace>
           <logLevel>INFO</logLevel>
@@ -172,7 +186,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>2.4.1</version>
+        <version>${clean.pluging.version}</version>
         <configuration>
           <filesets>
             <fileset>

--- a/helloworld-gwt/pom.xml
+++ b/helloworld-gwt/pom.xml
@@ -34,6 +34,22 @@
     <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
       resources, i.e. build is platform dependent! -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+      <!-- JBoss dependency versions -->
+      <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+      <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+      <!-- Other dependency versions -->
+      <gwt.version>2.4.0</gwt.version>
+
+      <!-- other plugin versions -->
+      <compiler.plugin.version>2.3.1</compiler.plugin.version>
+      <gwt.plugin.version>2.4.0</gwt.plugin.version>
+      <war.plugin.version>2.1.1</war.plugin.version>
+
+      <!-- maven-compiler-plugin -->
+      <maven.compiler.target>1.6</maven.compiler.target>
+      <maven.compiler.source>1.6</maven.compiler.source>
   </properties>
 
   <dependencyManagement>
@@ -52,7 +68,7 @@
       <dependency>
         <groupId>org.jboss.spec</groupId>
         <artifactId>jboss-javaee-6.0</artifactId>
-        <version>3.0.0.Final</version>
+        <version>${jboss.javaee6.spec.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -89,7 +105,7 @@
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
-      <version>2.4.0</version>
+      <version>${gwt.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -101,7 +117,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>${war.plugin.version}</version>
         <configuration>
           <!-- Exclude client only classes from the deployment. As these 
             classes compile down to JavaScript, they are not needed at runtime. They 
@@ -114,17 +130,17 @@
       <plugin>
         <groupId>org.jboss.as.plugins</groupId>
         <artifactId>jboss-as-maven-plugin</artifactId>
-        <version>7.1.1.Final</version>
+        <version>${jboss.as.plugin.version}</version>
       </plugin>
 
       <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
         annotation processors -->
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.1</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <version>${compiler.plugin.version}</version>
+          <configuration>
+            <source>${maven.compiler.source}</source>
+            <target>${maven.compiler.target}</target>
         </configuration>
       </plugin>
 
@@ -133,7 +149,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>2.4.0</version>
+        <version>${gwt.plugin.version}</version>
         <configuration>
           <inplace>true</inplace>
           <logLevel>INFO</logLevel>

--- a/helloworld-html5/pom.xml
+++ b/helloworld-html5/pom.xml
@@ -35,9 +35,18 @@
   resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- Define the version of JBoss' Java EE 6 APIs we want to import. Any dependencies from org.jboss.spec will have their
-             version defined by this BOM -->
-        <javaee6.bom.version>1.0.0.Final</javaee6.bom.version>
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <license.pluging.version>1.9.0</license.pluging.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -53,7 +62,7 @@
             <dependency>
                <groupId>org.jboss.bom</groupId>
                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-               <version>${javaee6.bom.version}</version>
+               <version>${jboss.bom.version}</version>
                <type>pom</type>
                <scope>import</scope>
             </dependency>
@@ -94,7 +103,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch
                    up! -->
@@ -105,23 +114,23 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates
           annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>com.mycila.maven-license-plugin</groupId>
                 <artifactId>maven-license-plugin</artifactId>
-                <version>1.9.0</version>
+                <version>${license.pluging.version}</version>
                 <configuration>
                     <header>src/etc/license.txt</header>
                     <includes>

--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -35,13 +35,26 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.version>7.1.1.Final</jboss.as.version>
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+
+       <!-- other plugin versions -->
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <jar.plugin.version>2.2</jar.plugin.version>
+       <exec.plugin.version>1.1.1</exec.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencies>
       <dependency>
          <groupId>org.jboss.as</groupId>
          <artifactId>jboss-as-jms-client-bom</artifactId>
-         <version>7.1.1.Final</version>
+         <version>${jboss.as.version}</version>
          <type>pom</type>
       </dependency>
    </dependencies>
@@ -52,7 +65,7 @@
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>1.1.1</version>
+            <version>${exec.plugin.version}</version>
             <configuration>
                <mainClass>org.jboss.as.quickstarts.jms.HelloWorldJMSClient</mainClass>
                <systemProperties>
@@ -95,7 +108,7 @@
          </plugin>
          <plugin>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>2.2</version>
+            <version>${jar.plugin.version}</version>
             <configuration>
             </configuration>
          </plugin>
@@ -103,7 +116,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
             <configuration>
                <username>admin</username>
                <password>admin</password>
@@ -113,10 +126,10 @@
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>

--- a/helloworld-jsf/pom.xml
+++ b/helloworld-jsf/pom.xml
@@ -34,6 +34,19 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+      <!-- JBoss dependency versions -->
+      <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+       
+      <richfaces.version>4.2.0.Final</richfaces.version>
+
+      <!-- other plugin versions -->
+      <compiler.plugin.version>2.3.1</compiler.plugin.version>
+
+      <!-- maven-compiler-plugin -->
+      <maven.compiler.target>1.6</maven.compiler.target>
+      <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -51,7 +64,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -60,7 +73,7 @@
          <dependency>
               <groupId>org.richfaces</groupId>
               <artifactId>richfaces-bom</artifactId>
-              <version>4.2.0.Final</version>
+              <version>${richfaces.version}</version>
               <type>pom</type>
               <scope>import</scope>
          </dependency>
@@ -115,16 +128,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>

--- a/helloworld-mdb/pom.xml
+++ b/helloworld-mdb/pom.xml
@@ -34,6 +34,18 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -49,7 +61,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>3.0.0.Final</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -83,7 +95,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -94,16 +106,16 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -122,7 +134,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>2.1.1</version>
+                        <version>${war.plugin.version}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
                             <warName>ROOT</warName>

--- a/helloworld-osgi/pom.xml
+++ b/helloworld-osgi/pom.xml
@@ -35,13 +35,27 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+
+        <!-- Other dependency versions -->
+        <osgi.version>4.2.0</osgi.version>
+
+        <!-- other plugin versions -->
+        <apache.felix.plugin.version>2.3.4</apache.felix.plugin.version>
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
-            <version>4.2.0</version>
+            <version>${osgi.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -53,7 +67,7 @@
                     an OSGi Bundle -->
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.4</version>
+                <version>${apache.felix.plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -84,7 +98,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
                 <configuration>
                     <filename>${project.build.finalName}.jar</filename>
                 </configuration>
@@ -94,10 +108,10 @@
                 unnecessary warnings about execution environment in IDE -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
 

--- a/helloworld-rs/pom.xml
+++ b/helloworld-rs/pom.xml
@@ -34,6 +34,18 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+       <!-- other plugin versions -->
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <war.plugin.version>2.1.1</war.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -51,7 +63,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -92,7 +104,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>${war.plugin.version}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -103,16 +115,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>
@@ -129,7 +141,7 @@
           <plugins>
              <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                    <outputDirectory>deployments</outputDirectory>
                    <warName>ROOT</warName>

--- a/helloworld-singleton/pom.xml
+++ b/helloworld-singleton/pom.xml
@@ -34,6 +34,18 @@
 		<!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
 			resources, i.e. build is platform dependent! -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
 	</properties>
 
 	<dependencyManagement>
@@ -48,7 +60,7 @@
 			<dependency>
 				<groupId>org.jboss.spec</groupId>
 				<artifactId>jboss-javaee-6.0</artifactId>
-				<version>3.0.0.Final</version>
+				<version>${jboss.bom.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -79,7 +91,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.1.1</version>
+				<version>${war.plugin.version}</version>
 				<configuration>
 					<!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
 					<failOnMissingWebXml>false</failOnMissingWebXml>
@@ -89,16 +101,16 @@
 			<plugin>
 				<groupId>org.jboss.as.plugins</groupId>
 				<artifactId>jboss-as-maven-plugin</artifactId>
-				<version>7.1.1.Final</version>
+				<version>${jboss.as.plugin.version}</version>
 			</plugin>
 			<!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation 
 				processors -->
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+                <version>${compiler.plugin.version}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/helloworld/pom.xml
+++ b/helloworld/pom.xml
@@ -34,6 +34,18 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+       <!-- other plugin versions -->
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <war.plugin.version>2.1.1</war.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -49,7 +61,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -91,7 +103,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>${war.plugin.version}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -102,16 +114,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>

--- a/hibernate3/pom.xml
+++ b/hibernate3/pom.xml
@@ -36,6 +36,24 @@
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+        <hibernate.common.annotations.version>3.2.0.Final</hibernate.common.annotations.version>
+        <hibernate.core.version>3.6.8.Final</hibernate.core.version>
+        <hibernate.em.version>3.6.8.Final</hibernate.em.version>
+        <hibernate.infinispan.version>3.6.8.Final</hibernate.infinispan.version>
+        <hibernate.validator.version>3.1.0.GA</hibernate.validator.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
+
     </properties>
 
     <!-- NOTE: hibernate-annotations are not included here, since hibernate-core 
@@ -47,7 +65,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>3.6.8.Final</version>
+                <version>${hibernate.core.version}</version>
 
                 <!-- Some transitive dependencies of Hibernate 3 are available 
                     in JBoss AS 7 as modules, so we don't include them in WEB-INF/lib, but instead 
@@ -80,7 +98,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-entitymanager</artifactId>
-                <version>3.6.8.Final</version>
+                <version>${hibernate.em.version}</version>
                 <!-- Some transitive dependencies of Hibernate 3 are available 
                     in JBoss AS 7 as modules, so we don't include them in WEB-INF/lib, but instead 
                     depend on the modules -->
@@ -108,7 +126,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>3.1.0.GA</version>
+                <version>${hibernate.validator.version}</version>
                 <!-- Some transitive dependencies of Hibernate 3 are available 
                     in JBoss AS 7 as modules, so we don't include them in WEB-INF/lib, but instead 
                     depend on the modules -->
@@ -124,7 +142,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-commons-annotations</artifactId>
-                <version>3.2.0.Final</version>
+                <version>${hibernate.common.annotations.version}</version>
                 <!-- Some transitive dependencies of Hibernate 3 are available 
                     in JBoss AS 7 as modules, so we don't include them in WEB-INF/lib, but instead 
                     depend on the modules -->
@@ -140,7 +158,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-infinispan</artifactId>
-                <version>3.6.8.Final</version>
+                <version>${hibernate.infinispan.version}</version>
                 <exclusions>
                     <!-- Some transitive dependencies of Hibernate 3 are 
                         available in JBoss AS 7 as modules, so we don't include them in WEB-INF/lib, 
@@ -173,7 +191,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>3.0.0.Final</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -275,7 +293,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -286,16 +304,16 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -34,6 +34,10 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.version>7.1.1.Final</jboss.as.version>
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
         <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want 
             to import. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
@@ -42,6 +46,14 @@
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
         <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version> -->
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -157,15 +169,15 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -179,7 +191,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
         </plugins>
     </build>
@@ -199,7 +211,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>2.1.1</version>
+                        <version>${war.plugin.version}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
                             <warName>ROOT</warName>

--- a/inter-app/appA/pom.xml
+++ b/inter-app/appA/pom.xml
@@ -60,7 +60,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -79,16 +79,16 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/inter-app/appB/pom.xml
+++ b/inter-app/appB/pom.xml
@@ -60,7 +60,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -79,16 +79,16 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/inter-app/pom.xml
+++ b/inter-app/pom.xml
@@ -35,6 +35,22 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+        <!-- Other dependency versions -->
+        <gwt.version>2.4.0</gwt.version>
+        <osgi.version>4.2.0</osgi.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -52,7 +68,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>3.0.0.Final</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -84,7 +100,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
                 <inherited>false</inherited>
                 <configuration>
                     <skip>true</skip>

--- a/inter-app/shared/pom.xml
+++ b/inter-app/shared/pom.xml
@@ -43,16 +43,16 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/jax-rs-client/pom.xml
+++ b/jax-rs-client/pom.xml
@@ -90,11 +90,11 @@
                     <systemProperties>
                         <property>
                             <name>xmlUrl</name>
-                            <value>http://localhost:8080/jboss-as-helloworld-rs/xml</value>
+                            <value>http://localhost:8080/jboss-as-helloworld-rs/rest/xml</value>
                         </property>
                         <property>
                             <name>jsonUrl</name>
-                            <value>http://localhost:8080/jboss-as-helloworld-rs/json</value>
+                            <value>http://localhost:8080/jboss-as-helloworld-rs/rest/json</value>
                         </property>
                     </systemProperties>
                 </configuration>

--- a/jax-rs-client/pom.xml
+++ b/jax-rs-client/pom.xml
@@ -34,24 +34,40 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <resteasy.version>2.2.2.GA</resteasy.version>
+
+        <!-- Other dependency versions -->
+        <apache.httpcomponents.version>4.1.4</apache.httpcomponents.version>
+        <junit.version>4.10</junit.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <surefire.plugin.version>2.4.3</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>2.2.2.GA</version>
+            <version>${resteasy.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.1.4</version>
+            <version>${apache.httpcomponents.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -60,16 +76,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.4.3</version>
+                <version>${surefire.plugin.version}</version>
                 <configuration>
                     <systemProperties>
                         <property>

--- a/jta-crash-rec/pom.xml
+++ b/jta-crash-rec/pom.xml
@@ -34,15 +34,27 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.version>7.1.1.Final</jboss.as.version>
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
         <!-- Define the version of JBoss' Java EE 6 APIs we want to import. 
-            Any dependencies from org.jboss.spec will have their version defined by this 
-            BOM -->
-        <javaee6.spec.version>3.0.0.Final</javaee6.spec.version>
+       Any dependencies from org.jboss.spec will have their version defined by this 
+       BOM -->
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 3.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <javaee6.spec.version>3.0.0.Final-redhat-1</javaee6.spec.version> -->
+        <!-- <jboss.javaee6.spec.version>3.0.0.Final-redhat-1</jboss.javaee6.spec.version> -->
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -56,7 +68,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-web-6.0</artifactId>
-                <version>${javaee6.spec.version}</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -130,7 +142,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -141,16 +153,16 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/jts/application-component-1/pom.xml
+++ b/jts/application-component-1/pom.xml
@@ -32,14 +32,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <!-- Explicitly declaring the source encoding eliminates the following 
-            message: -->
-        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
-            resources, i.e. build is platform dependent! -->
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <!-- Import the client stub for the application-component-2 -->
         <dependency>
@@ -101,16 +93,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->

--- a/jts/application-component-2/pom.xml
+++ b/jts/application-component-2/pom.xml
@@ -33,14 +33,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <!-- Explicitly declaring the source encoding eliminates the following 
-            message: -->
-        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
-            resources, i.e. build is platform dependent! -->
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <!-- Import the JPA API, we use provided scope as the API is included 
             in JBoss AS 7 -->
@@ -82,10 +74,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <!-- The JBoss AS plugin deploys your war to a local JBoss AS 
@@ -95,7 +87,6 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
                 <configuration>
                     <port>10099</port>
                 </configuration>
@@ -104,7 +95,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ejb-plugin</artifactId>
-                <version>2.3</version>
+                <version>${ejb.plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/jts/pom.xml
+++ b/jts/pom.xml
@@ -27,6 +27,27 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
     </licenses>
+    
+    <properties>
+        <!-- Explicitly declaring the source encoding eliminates the following 
+            message: -->
+        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
+            resources, i.e. build is platform dependent! -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <ejb.plugin.version>2.3</ejb.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
+    </properties>
 
     <modules>
         <!-- Build module 2 first as it is the remote EJB which provides 
@@ -45,7 +66,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>3.0.0.Final</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -53,7 +74,7 @@
             <dependency>
                 <groupId>org.jboss.as.quickstarts</groupId>
                 <artifactId>jboss-as-jts-application-component-2</artifactId>
-                <version>7.1.2-SNAPSHOT</version>
+                <version>${project.version}</version>
                 <classifier>client</classifier>
             </dependency>
         </dependencies>
@@ -69,7 +90,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>7.1.1.Final</version>
+                    <version>${jboss.as.plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/kitchensink-ear/jboss-as-kitchensink-ear-ear/pom.xml
+++ b/kitchensink-ear/jboss-as-kitchensink-ear-ear/pom.xml
@@ -54,7 +54,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-ear-plugin</artifactId>
-            <version>2.6</version>
+            <version>${ear.plugin.version}</version>
             <configuration>
                <!-- Tell Maven we are using Java EE 6 -->
                <version>6</version>
@@ -101,7 +101,7 @@
             <plugins>
                <plugin>
                   <artifactId>maven-ear-plugin</artifactId>
-                  <version>2.6</version>
+                  <version>${ear.plugin.version}</version>
                   <configuration>
                      <outputDirectory>deployments</outputDirectory>
                   </configuration>

--- a/kitchensink-ear/jboss-as-kitchensink-ear-ejb/pom.xml
+++ b/kitchensink-ear/jboss-as-kitchensink-ear-ejb/pom.xml
@@ -99,7 +99,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-ejb-plugin</artifactId>
-            <version>2.3</version>
+            <version>${ejb.plugin.version}</version>
             <configuration>
                <!-- Tell Maven we are using EJB 3.1 -->
                <ejbVersion>3.1</ejbVersion>
@@ -122,7 +122,7 @@
             <plugins>
                <plugin>
                   <artifactId>maven-surefire-plugin</artifactId>
-                  <version>2.4.3</version>
+                  <version>${surefire.plugin.version}</version>
                   <configuration>
                      <skip>true</skip>
                   </configuration>

--- a/kitchensink-ear/jboss-as-kitchensink-ear-web/pom.xml
+++ b/kitchensink-ear/jboss-as-kitchensink-ear-web/pom.xml
@@ -96,7 +96,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>${war.plugin.version}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->

--- a/kitchensink-ear/pom.xml
+++ b/kitchensink-ear/pom.xml
@@ -38,6 +38,10 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.version>7.1.1.Final</jboss.as.version>
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
@@ -46,6 +50,17 @@
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
         <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>> -->
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <ear.plugin.version>2.6</ear.plugin.version>
+        <ejb.plugin.version>2.3</ejb.plugin.version>
+        <surefire.plugin.version>2.4.3</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -56,7 +71,7 @@
             <dependency>
                 <groupId>org.jboss.as.quickstarts</groupId>
                 <artifactId>jboss-as-kitchensink-ear-ejb</artifactId>
-                <version>7.1.2-SNAPSHOT</version>
+                <version>${project.version}</version>
                 <type>ejb</type>
             </dependency>
 
@@ -65,7 +80,7 @@
             <dependency>
                 <groupId>org.jboss.as.quickstarts</groupId>
                 <artifactId>jboss-as-kitchensink-ear-web</artifactId>
-                <version>7.1.2-SNAPSHOT</version>
+                <version>${project.version}</version>
                 <type>war</type>
                 <scope>compile</scope>
             </dependency>
@@ -104,10 +119,10 @@
                     activates annotation processors -->
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.3.2</version>
+                    <version>${compiler.plugin.version}</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>${maven.compiler.source}</source>
+                        <target>${maven.compiler.target}</target>
                     </configuration>
                 </plugin>
                 <!-- The JBoss AS plugin deploys your ear to a local JBoss 
@@ -118,7 +133,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>7.1.1.Final</version>
+                    <version>${jboss.as.plugin.version}</version>
                     <inherited>true</inherited>
                     <configuration>
                         <skip>true</skip>

--- a/kitchensink-html5-mobile/pom.xml
+++ b/kitchensink-html5-mobile/pom.xml
@@ -28,22 +28,34 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         
         <!-- You can reference property in pom.xml or filtered resources (must enable third-party plugin if using Maven < 2.1) -->
-
-        <!-- Define the version of JBoss' Java EE 6 APIs we want to import. Any dependencies from org.jboss.spec will have their
-             version defined by this BOM -->
-        <javaee6.web.spec.version>3.0.0.Final</javaee6.web.spec.version>
+        
+        <!-- JBoss dependency versions -->
+        <jboss.as.version>7.1.1.Final</jboss.as.version>
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
         <!-- JBoss EAP Certified Versions -->
         <!-- <javaee6.web.spec.version>3.0.0.Beta1-redhat-1</javaee6.web.spec.version> -->
         <!-- <version.org.hibernate.validator>4.2.0.Final-redhat-1</version.org.hibernate.validator> -->
-        
+
+        <arquillian.version>1.0.0.Final</arquillian.version>
+
+        <hibernate.jpamodelgen.version>1.1.1.Final</hibernate.jpamodelgen.version>
+        <hibernate.validator.version>4.2.0.Final</hibernate.validator.version>
+
+        <!-- Other dependency versions -->
+        <junit.version>4.10</junit.version>
+        <m2e.version>1.0.0</m2e.version>
         <wro4j.version>1.4.4</wro4j.version>
-        
-        <!-- Versions not covered in jboss-javaee-web-6.0 BOM  -->
-        <version.org.hibernate.validator>4.2.0.Final</version.org.hibernate.validator>
-        <version.org.hibernate-jpamodelgen>1.1.1.Final</version.org.hibernate-jpamodelgen>
-        <version.org.jboss.arquillian>1.0.0.Final</version.org.jboss.arquillian>
-        <version.org.jboss.as.arquillian.container>7.1.1.Final</version.org.jboss.as.arquillian.container>
-        <version.junit>4.10</version.junit>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <license.pluging.version>1.9.0</license.pluging.version>
+        <surefire.plugin.version>2.4.3</surefire.plugin.version>
+        <war.plugin.version>2.2</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <licenses>
@@ -65,7 +77,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-web-6.0</artifactId>
-                <version>${javaee6.web.spec.version}</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -123,7 +135,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>${version.org.hibernate.validator}</version>
+            <version>${hibernate.validator.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -139,7 +151,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
-            <version>${version.org.hibernate-jpamodelgen}</version>
+            <version>${hibernate.jpamodelgen.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -147,7 +159,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${version.junit}</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -156,14 +168,14 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <version>${version.org.jboss.arquillian}</version>
+            <version>${arquillian.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
             <artifactId>arquillian-protocol-servlet</artifactId>
-            <version>${version.org.jboss.arquillian}</version>
+            <version>${arquillian.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -177,15 +189,15 @@
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.2</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -196,13 +208,13 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
             
             <plugin>
                 <groupId>com.mycila.maven-license-plugin</groupId>
                 <artifactId>maven-license-plugin</artifactId>
-                <version>1.9.0</version>
+                <version>${license.pluging.version}</version>
                 <configuration>
                     <header>src/etc/license.txt</header>
                     <mapping>
@@ -236,7 +248,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.4.3</version>
+                        <version>${surefire.plugin.version}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -254,7 +266,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>2.2</version>
+                        <version>${war.plugin.version}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
                             <warName>ROOT</warName>
@@ -278,7 +290,7 @@
                         <plugin>
                             <groupId>org.eclipse.m2e</groupId>
                             <artifactId>lifecycle-mapping</artifactId>
-                            <version>1.0.0</version>
+                            <version>${m2e.version}</version>
                             <configuration>
                                 <lifecycleMappingMetadata>
                                     <pluginExecutions>
@@ -288,7 +300,7 @@
                                                 <artifactId>
                                                     wro4j-maven-plugin
                                                 </artifactId>
-                                                <version>1.4.4</version>
+                                                <version>${wro4j.version}</version>
                                                 <goals>
                                                     <goal>run</goal>
                                                 </goals>
@@ -325,7 +337,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.4.3</version>
+                        <version>${surefire.plugin.version}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -342,7 +354,7 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-managed</artifactId>
-                    <version>7.1.1.Final</version>
+                    <version>${jboss.as.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -356,7 +368,7 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-remote</artifactId>
-                    <version>${version.org.jboss.as.arquillian.container}</version>
+                    <version>${jboss.as.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -368,7 +380,7 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-managed</artifactId>
-                    <version>${version.org.jboss.as.arquillian.container}</version>
+                    <version>${jboss.as.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -377,11 +389,11 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.12</version>
+                        <version>${surefire.plugin.version}</version>
                         <configuration>
                             <systemProperties>
                                 <arquillian.launch>jbossci</arquillian.launch>
-                                <arquillian.jboss_home>${project.build.directory}/jboss-as-${version.org.jboss.as.arquillian.container}/
+                                <arquillian.jboss_home>${project.build.directory}/jboss-as-${jboss.as.version}/
                                 </arquillian.jboss_home>
                             </systemProperties>
                             <includes>
@@ -404,7 +416,7 @@
                                         <artifactItem>
                                             <groupId>org.jboss.as</groupId>
                                             <artifactId>jboss-as-dist</artifactId>
-                                            <version>7.1.1.Final</version>
+                                            <version>${jboss.as.version}</version>
                                             <outputDirectory>${project.build.directory}</outputDirectory>
                                             <type>zip</type>
                                             <overWrite>false</overWrite>

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -35,6 +35,9 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
@@ -43,6 +46,20 @@
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
         <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>> -->
+
+        <hibernate.jpamodelgen.version>1.1.1.Final</hibernate.jpamodelgen.version>
+
+        <!-- Other dependency versions -->
+        <jstl.version>1.2</jstl.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <surefire.plugin.version>2.4.3</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -130,7 +147,7 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
-            <version>1.2</version>
+            <version>${jstl.version}</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -156,7 +173,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
-            <version>1.1.1.Final</version>
+            <version>${hibernate.jpamodelgen.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -193,15 +210,15 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -214,7 +231,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
         </plugins>
     </build>
@@ -233,7 +250,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.4.3</version>
+                        <version>${surefire.plugin.version}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -285,7 +302,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>2.1.1</version>
+                        <version>${war.plugin.version}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
                             <warName>ROOT</warName>

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -35,6 +35,9 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
@@ -43,6 +46,15 @@
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
         <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>> -->
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <surefire.plugin.version>2.4.3</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
 
@@ -192,15 +204,15 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -213,7 +225,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
         </plugins>
     </build>
@@ -232,7 +244,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.4.3</version>
+                        <version>${surefire.plugin.version}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -284,7 +296,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>2.1.1</version>
+                        <version>${war.plugin.version}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
                             <warName>ROOT</warName>

--- a/log4j/pom.xml
+++ b/log4j/pom.xml
@@ -35,8 +35,21 @@
 		<!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
 			resources, i.e. build is platform dependent! -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<!-- Define version of log4j we want to use. -->
-		<log4j.version>1.2.16</log4j.version>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+        <!-- Other dependency versions -->
+        <log4j.version>1.2.16</log4j.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
 	</properties>
 
 	<dependencyManagement>
@@ -59,7 +72,7 @@
 			<dependency>
 				<groupId>org.jboss.spec</groupId>
 				<artifactId>jboss-javaee-6.0</artifactId>
-				<version>3.0.0.Final</version>
+				<version>${jboss.javaee6.spec.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -109,7 +122,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.1.1</version>
+				<version>${war.plugin.version}</version>
 				<configuration>
 					<!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
 					<failOnMissingWebXml>false</failOnMissingWebXml>
@@ -119,16 +132,16 @@
 			<plugin>
 				<groupId>org.jboss.as.plugins</groupId>
 				<artifactId>jboss-as-maven-plugin</artifactId>
-				<version>7.1.1.Final</version>
+				<version>${jboss.as.plugin.version}</version>
 			</plugin>
 			<!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation 
 				processors -->
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+                <version>${compiler.plugin.version}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/logging-tools/pom.xml
+++ b/logging-tools/pom.xml
@@ -33,6 +33,20 @@
       <!-- Explicitly declaring the source encoding eliminates the following message: -->
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.logging.version>3.1.1.GA</jboss.logging.version>
+        <jboss.logging.processor.version>1.0.3.Final</jboss.logging.processor.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -50,7 +64,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>3.0.0.Final</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -71,14 +85,14 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
-            <version>1.0.1.Final</version>
+            <version>${jboss.logging.processor.version}</version>
             <scope>provided</scope>
         </dependency>
       <!--  jboss-logging API -->
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <version>3.1.0.GA</version>
+            <version>${jboss.logging.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -90,23 +104,23 @@
 
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
             </plugin>
 
          <!-- JBoss AS plugin to deploy war -->
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
 
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                     <compilerArgument>
                         -AgeneratedTranslationFilesPath=${project.basedir}/target/generated-translation-files
                     </compilerArgument>

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -34,6 +34,18 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+       <!-- other plugin versions -->
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <war.plugin.version>2.1.1</war.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -51,7 +63,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -91,7 +103,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>${war.plugin.version}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -102,16 +114,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>

--- a/numberguess/pom.xml
+++ b/numberguess/pom.xml
@@ -34,6 +34,18 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+       <!-- other plugin versions -->
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <war.plugin.version>2.1.1</war.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -51,7 +63,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -93,7 +105,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>${war.plugin.version}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -104,16 +116,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>

--- a/payment-cdi-event/pom.xml
+++ b/payment-cdi-event/pom.xml
@@ -35,6 +35,9 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
@@ -43,6 +46,15 @@
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
         <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>> -->
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -57,7 +69,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>3.0.0.Final</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -119,7 +131,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -130,16 +142,16 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <name>JBoss AS Quickstarts Parent</name>
     <description>JBoss AS Quickstarts Parent</description>
     <url>http://www.jboss.org/jdf/quickstarts/get-started/</url>
- 
+
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -33,6 +33,61 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
     </licenses>
+
+    <properties>
+        <!-- A base list of dependency and plugin version used in the various quick starts. -->
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.version>7.1.1.Final</jboss.as.version>
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <jboss.ejb.client.version>7.1.1.Final</jboss.ejb.client.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <jboss.logging.version>3.1.1.GA</jboss.logging.version>
+        <jboss.logging.processor.version>1.0.3.Final</jboss.logging.processor.version>
+
+        <arquillian.version>1.0.0.Final</arquillian.version>
+
+        <hibernate.common.annotations.version>3.2.0.Final</hibernate.common.annotations.version>
+        <hibernate.core.version>3.6.8.Final</hibernate.core.version>
+        <hibernate.em.version>3.6.8.Final</hibernate.em.version>
+        <hibernate.infinispan.version>3.6.8.Final</hibernate.infinispan.version>
+        <hibernate.jpamodelgen.version>1.1.1.Final</hibernate.jpamodelgen.version>
+        <hibernate.validator.version>4.2.0.Final</hibernate.validator.version>
+        
+        <resteasy.version>2.2.2.GA</resteasy.version>
+        
+        <richfaces.version>4.2.0.Final</richfaces.version>
+        
+        <!-- Other dependency versions -->
+        <apache.httpcomponents.version>4.1.4</apache.httpcomponents.version>
+        <dom4j.version>1.6</dom4j.version>
+        <gwt.version>2.4.0</gwt.version>
+        <jstl.version>1.2</jstl.version>
+        <junit.version>4.10</junit.version>
+        <log4j.version>1.2.16</log4j.version>
+        <m2e.version>1.0.0</m2e.version>
+        <osgi.version>4.2.0</osgi.version>
+        <wicket.version>1.5.5</wicket.version>
+        <wicket.cdi.version>1.2</wicket.cdi.version>
+        <wro4j.version>1.4.4</wro4j.version>
+
+        <!-- other plugin versions -->
+        <apache.felix.plugin.version>2.3.4</apache.felix.plugin.version>
+        <clean.pluging.version>2.4.1</clean.pluging.version>
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <ear.plugin.version>2.6</ear.plugin.version>
+        <ejb.plugin.version>2.3</ejb.plugin.version>
+        <exec.plugin.version>1.2.1</exec.plugin.version>
+        <gwt.plugin.version>2.4.0</gwt.plugin.version>
+        <license.pluging.version>1.9.0</license.pluging.version>
+        <surefire.plugin.version>2.10</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
+    </properties>
 
     <profiles>
         <profile>
@@ -46,7 +101,7 @@
                 </property>
             </activation>
             <modules>
-                <!-- All the modules that require nothing but JBoss Enterprise 
+                <!-- All the modules that require nothing but JBoss Enterprise
                     Application Platform or JBoss AS -->
                 <module>bean-validation</module>
                 <module>bmt</module>
@@ -122,7 +177,7 @@
             </modules>
         </profile>
         <profile>
-            <!-- All the quickstarts that require the "standalone-full" profile 
+            <!-- All the quickstarts that require the "standalone-full" profile
                 to be in use -->
             <id>requires-full</id>
             <activation>
@@ -154,7 +209,7 @@
             </modules>
         </profile>
         <profile>
-            <!-- All the quickstarts that don't actually use Maven. Don't 
+            <!-- All the quickstarts that don't actually use Maven. Don't
                 activate this profile! We just include this for completeness. -->
             <id>non-maven</id>
             <activation>
@@ -170,14 +225,14 @@
 
     <build>
         <plugins>
-            <!-- The JBoss AS plugin deploys your apps to a local JBoss AS 
+            <!-- The JBoss AS plugin deploys your apps to a local JBoss AS
                 container -->
-            <!-- Disabling it here means that we don't try to deploy this 
+            <!-- Disabling it here means that we don't try to deploy this
                 POM! -->
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
                 <inherited>true</inherited>
                 <configuration>
                     <skip>true</skip>

--- a/richfaces-validation/pom.xml
+++ b/richfaces-validation/pom.xml
@@ -38,6 +38,24 @@
         <!-- You can reference property in pom.xml or filtered resources (must
             enable third-party plugin if using Maven < 2.1) -->
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+
+        <hibernate.jpamodelgen.version>1.1.1.Final</hibernate.jpamodelgen.version>
+        <hibernate.validator.version>4.2.0.Final</hibernate.validator.version>
+
+        <richfaces.version>4.2.0.Final</richfaces.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <surefire.plugin.version>2.4.3</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -51,7 +69,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>1.0.0.Final</version>
+                <version>${jboss.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -61,7 +79,7 @@
             <dependency>
                 <groupId>org.richfaces</groupId>
                 <artifactId>richfaces-bom</artifactId>
-                <version>4.2.0.Final</version>
+                <version>${richfaces.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -95,7 +113,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>4.2.0.Final</version>
+            <version>${hibernate.validator.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -131,7 +149,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
-            <version>1.1.1.Final</version>
+            <version>${hibernate.jpamodelgen.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -170,7 +188,7 @@
                 <!-- The Maven Surefire plugin tests your application. Here we ensure we are using a version compatible with Arquillian -->
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.4.3</version>
+                    <version>${surefire.plugin.version}</version>
                 </plugin>
                 <!-- The JBoss AS plugin deploys your war to a local JBoss AS container -->
                 <!-- To use, set the JBOSS_HOME environment variable and run:
@@ -178,7 +196,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>7.1.1.Final</version>
+                    <version>${jboss.as.plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -186,7 +204,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -195,10 +213,10 @@
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/servlet-async/pom.xml
+++ b/servlet-async/pom.xml
@@ -35,6 +35,18 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+       <!-- other plugin versions -->
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <war.plugin.version>2.1.1</war.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -50,7 +62,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -99,7 +111,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>${war.plugin.version}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -110,16 +122,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>

--- a/servlet-filterlistener/pom.xml
+++ b/servlet-filterlistener/pom.xml
@@ -35,6 +35,18 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+       <!-- other plugin versions -->
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <war.plugin.version>2.1.1</war.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -50,7 +62,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -92,7 +104,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>${war.plugin.version}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -103,16 +115,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>

--- a/servlet-security/pom.xml
+++ b/servlet-security/pom.xml
@@ -34,6 +34,18 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+       <!-- other plugin versions -->
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <war.plugin.version>2.1.1</war.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -49,7 +61,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -93,16 +105,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>

--- a/shopping-cart/client/pom.xml
+++ b/shopping-cart/client/pom.xml
@@ -54,10 +54,10 @@
             <!-- Enforce Java 1.6 -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
 
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>${exec.plugin.version}</version>
                 <configuration>
                     <mainClass>org.jboss.as.quickstarts.client.Client</mainClass>
                 </configuration>

--- a/shopping-cart/pom.xml
+++ b/shopping-cart/pom.xml
@@ -46,14 +46,8 @@
             (must enable third-party plugin if using Maven < 2.1) -->
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
-        <!-- Define the version of JBoss' Java EE 6 APIs we want to import. -->
-        <javaee6.spec.version>3.0.0.Final</javaee6.spec.version>
-        <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 3.0.0.Final-redhat-1 which is a release certified 
-            to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
-            maven repository. -->
-        <!-- <javaee6.spec.version>3.0.0.Final-redhat-1</javaee6.spec.version> -->
-
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
         <!-- Define the version of JBoss EJB Client we want to use. This 
             should match the JBoss AS version in use -->
         <jboss.ejb.client.version>7.1.1.Final</jboss.ejb.client.version>
@@ -62,6 +56,21 @@
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
         <!-- <jboss.ejb.client.version>7.1.1.Final-redhat-1</jboss.ejb.client.version> -->
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <!-- Alternatively, comment out the above line, and un-comment the 
+            line below to use version 3.0.0.Final-redhat-1 which is a release certified 
+            to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
+            maven repository. -->
+        <!-- <jboss.javaee6.spec.version>3.0.0.Final-redhat-1</jboss.javaee6.spec.version> -->
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <exec.plugin.version>1.2.1</exec.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -74,7 +83,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${javaee6.spec.version}</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -105,7 +114,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
                 <inherited>true</inherited>
                 <configuration>
                     <skip>true</skip>

--- a/shopping-cart/server/pom.xml
+++ b/shopping-cart/server/pom.xml
@@ -59,10 +59,10 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/tasks-jsf/pom.xml
+++ b/tasks-jsf/pom.xml
@@ -39,14 +39,24 @@
             enable third-party plugin if using Maven < 2.1) -->
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
-        <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want to import.  -->
-        <javaee6.with.tools.version>1.0.0.Final</javaee6.with.tools.version>
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
         <!-- Alternatively, comment out the above line, and un-comment the line below to
         use version 1.0.0.Final-redhat-1 which is a release certified
         to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 maven repository. -->
         <!--
-        <javaee6.with.tools.version>1.0.0.Final-redhat-1</javaee6.with.tools.version>
+        <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>
         -->
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <surefire.plugin.version>2.4.3</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -60,7 +70,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${javaee6.with.tools.version}</version>
+                <version>${jboss.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -130,7 +140,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch
                         up! -->
@@ -141,17 +151,17 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <!-- Surefire plugin is responsible for running tests
                 as part of project build -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.4.3</version>
+                <version>${surefire.plugin.version}</version>
             </plugin>
             <!-- The JBoss AS plugin deploys your war to a local JBoss
                 AS container -->
@@ -159,7 +169,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/tasks-rs/pom.xml
+++ b/tasks-rs/pom.xml
@@ -29,14 +29,24 @@
             enable third-party plugin if using Maven < 2.1) -->
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
-        <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want to import.  -->
-        <javaee6.with.tools.version>1.0.0.Final</javaee6.with.tools.version>
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
         <!-- Alternatively, comment out the above line, and un-comment the line below to
         use version 1.0.0.Final-redhat-1 which is a release certified
         to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 maven repository. -->
         <!--
-        <javaee6.spec.version>1.0.0.Final-redhat-1</javaee6.spec.version>
+        <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>
         -->
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <surefire.plugin.version>2.4.3</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -50,7 +60,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${javaee6.with.tools.version}</version>
+                <version>${jboss.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -129,7 +139,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch
                         up! -->
@@ -140,17 +150,17 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <!-- Surefire plugin is responsible for running tests
                 as part of project build -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.4.3</version>
+                <version>${surefire.plugin.version}</version>
             </plugin>
             <!-- The JBoss AS plugin deploys your war to a local JBoss
                 AS container -->
@@ -158,7 +168,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/tasks/pom.xml
+++ b/tasks/pom.xml
@@ -40,14 +40,24 @@
             (must enable third-party plugin if using Maven < 2.1) -->
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
-        <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want 
-            to import. -->
-        <javaee6.with.tools.version>1.0.0.Final</javaee6.with.tools.version>
+        <!-- JBoss dependency versions -->
+        <jboss.as.version>7.1.1.Final</jboss.as.version>
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <javaee6.with.tools.version>1.0.0.Final-redhat-1</javaee6.with.tools.version> -->
+        <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version> -->
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <surefire.plugin.version>2.10</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -61,7 +71,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${javaee6.with.tools.version}</version>
+                <version>${jboss.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -123,7 +133,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -134,16 +144,16 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <!-- Versions prior 2.9 contains a bug -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.10</version>
+                <version>${surefire.plugin.version}</version>
             </plugin>
             <!-- The JBoss AS plugin deploys your war to a local JBoss AS 
                 container -->
@@ -153,7 +163,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -195,7 +205,7 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-managed</artifactId>
-                    <version>7.1.1.Final</version>
+                    <version>${jboss.as.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -210,7 +220,7 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-remote</artifactId>
-                    <version>7.1.1.Final</version>
+                    <version>${jboss.as.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/temperature-converter/pom.xml
+++ b/temperature-converter/pom.xml
@@ -35,6 +35,18 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -52,7 +64,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>3.0.0.Final</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -101,7 +113,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -112,16 +124,16 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -34,6 +34,18 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
          resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+       <!-- JBoss dependency versions -->
+       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+       <!-- other plugin versions -->
+       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <war.plugin.version>2.1.1</war.plugin.version>
+
+       <!-- maven-compiler-plugin -->
+       <maven.compiler.target>1.6</maven.compiler.target>
+       <maven.compiler.source>1.6</maven.compiler.source>
    </properties>
 
    <dependencyManagement>
@@ -51,7 +63,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>3.0.0.Final</version>
+            <version>${jboss.javaee6.spec.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -117,7 +129,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>${war.plugin.version}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -128,16 +140,16 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>${jboss.as.plugin.version}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.1</version>
-            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+             <version>${compiler.plugin.version}</version>
+             <configuration>
+                 <source>${maven.compiler.source}</source>
+                 <target>${maven.compiler.target}</target>
             </configuration>
          </plugin>
       </plugins>

--- a/wicket-ear/ear/pom.xml
+++ b/wicket-ear/ear/pom.xml
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>2.6</version>
+                <version>${ear.plugin.version}</version>
                 <configuration>
                     <!-- Tell Maven we are using Java EE 6 -->
                     <version>6</version>

--- a/wicket-ear/ejb/pom.xml
+++ b/wicket-ear/ejb/pom.xml
@@ -65,7 +65,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ejb-plugin</artifactId>
-                <version>2.3</version>
+                <version>${ejb.plugin.version}</version>
                 <configuration>
                     <ejbVersion>3.1</ejbVersion>
                 </configuration>

--- a/wicket-ear/pom.xml
+++ b/wicket-ear/pom.xml
@@ -44,16 +44,29 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- Define the version of JBoss' Java EE 6 APIs we want to import. -->
-        <jboss.spec.version>3.0.0.Final</jboss.spec.version>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 3.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.spec.version>3.0.0.Final-redhat-1</jboss.spec.version> -->
-        <!-- Specify the version of Wicket and Wicket CDI integration we will use -->
+        <!-- <jboss.javaee6.spec.version>3.0.0.Final-redhat-1</jboss.javaee6.spec.version> -->
+
+        <!-- Other dependency versions -->
         <wicket.version>1.5.5</wicket.version>
         <wicket.cdi.version>1.2</wicket.cdi.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <ear.plugin.version>2.6</ear.plugin.version>
+        <ejb.plugin.version>2.3</ejb.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -69,7 +82,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.spec.version}</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -113,10 +126,10 @@
                     activates annotation processors -->
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.3.2</version>
+                    <version>${compiler.plugin.version}</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>${maven.compiler.source}</source>
+                        <target>${maven.compiler.target}</target>
                     </configuration>
                 </plugin>
                 <!-- The JBoss AS plugin deploys your ear to a local JBoss 
@@ -127,7 +140,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>7.1.1.Final</version>
+                    <version>${jboss.as.plugin.version}</version>
                     <inherited>true</inherited>
                     <configuration>
                         <skip>true</skip>

--- a/wicket-war/pom.xml
+++ b/wicket-war/pom.xml
@@ -39,17 +39,27 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- Define the version of JBoss' Java EE 6 APIs we want to import. -->
-        <jboss.spec.version>3.0.0.Final</jboss.spec.version>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 3.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.spec.version>3.0.0.Final-redhat-1</jboss.spec.version> -->
-        <!-- Specify the version of Wicket and Wicket CDI integration we 
-            will use -->
+        <!-- <jboss.javaee6.spec.version>3.0.0.Final-redhat-1</jboss.javaee6.spec.version> -->
+
+        <!-- Other dependency versions -->
         <wicket.version>1.5.5</wicket.version>
         <wicket.cdi.version>1.2</wicket.cdi.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -65,7 +75,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.spec.version}</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -195,7 +205,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
                 <configuration>
                     <fileNames>
                         <fileName>target/${build.finalName}.war</fileName>
@@ -206,10 +216,10 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -35,6 +35,19 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
   resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <surefire.plugin.version>2.4.3</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -52,7 +65,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>1.0.0.Final</version>
+                <version>${jboss.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -62,7 +75,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-transactions</artifactId>
-                <version>1.0.0.Final</version>
+                <version>${jboss.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -135,7 +148,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -150,16 +163,16 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates
           annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -179,7 +192,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>2.1.1</version>
+                        <version>${war.plugin.version}</version>
                         <configuration>
                             <!-- Ignore the jboss-web.xml. This is needed to deploy the Web service into the root context.
                                 This is only needed by Openshift -->
@@ -188,7 +201,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.4.3</version>
+                        <version>${surefire.plugin.version}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -237,7 +250,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>2.1.1</version>
+                        <version>${war.plugin.version}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
                             <warName>ROOT</warName>

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -35,6 +35,19 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <surefire.plugin.version>2.4.3</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -53,7 +66,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>1.0.0.Final</version>
+                <version>${jboss.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -64,7 +77,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-transactions</artifactId>
-                <version>1.0.0.Final</version>
+                <version>${jboss.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -136,7 +149,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -145,10 +158,10 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -168,7 +181,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.4.3</version>
+                        <version>${surefire.plugin.version}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -35,6 +35,19 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
   resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <surefire.plugin.version>2.4.3</surefire.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -52,7 +65,7 @@
          <dependency>
             <groupId>org.jboss.bom</groupId>
             <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${jboss.bom.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -62,7 +75,7 @@
          <dependency>
             <groupId>org.jboss.bom</groupId>
             <artifactId>jboss-javaee-6.0-with-transactions</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${jboss.bom.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -134,7 +147,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
                 <configuration>
                   <skip>true</skip>
                 </configuration>
@@ -143,10 +156,10 @@
           annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -166,7 +179,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.4.3</version>
+                        <version>${surefire.plugin.version}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -185,7 +198,6 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-managed</artifactId>
-                    <version>7.1.1.Final</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -201,7 +213,6 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-remote</artifactId>
-                    <version>7.1.1.Final</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/xml-dom4j/pom.xml
+++ b/xml-dom4j/pom.xml
@@ -35,7 +35,21 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.dom4j>1.6</version.dom4j>
+
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+        <!-- Other dependency versions -->
+        <dom4j.version>1.6</dom4j.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <!-- NOTE: -->
@@ -54,7 +68,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>3.0.0.Final</version>
+                <version>${jboss.javaee6.spec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -112,7 +126,7 @@
         <dependency>
             <groupId>dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>${version.dom4j}</version>
+            <version>${dom4j.version}</version>
         </dependency>
     </dependencies>
 
@@ -123,7 +137,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${war.plugin.version}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -134,16 +148,16 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${jboss.as.plugin.version}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/xml-jaxp/pom.xml
+++ b/xml-jaxp/pom.xml
@@ -36,6 +36,18 @@
 			resources, i.e. build is platform dependent! -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- JBoss dependency versions -->
+        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+
+        <!-- other plugin versions -->
+        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <war.plugin.version>2.1.1</war.plugin.version>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
+
 	</properties>
 
 	<!-- NOTE: -->
@@ -53,7 +65,7 @@
 			<dependency>
 				<groupId>org.jboss.spec</groupId>
 				<artifactId>jboss-javaee-6.0</artifactId>
-				<version>3.0.0.Final</version>
+				<version>${jboss.javaee6.spec.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -113,7 +125,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.1.1</version>
+				<version>${war.plugin.version}</version>
 				<configuration>
 					<!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
 					<failOnMissingWebXml>false</failOnMissingWebXml>
@@ -123,16 +135,16 @@
 			<plugin>
 				<groupId>org.jboss.as.plugins</groupId>
 				<artifactId>jboss-as-maven-plugin</artifactId>
-				<version>7.1.1.Final</version>
+				<version>${jboss.as.plugin.version}</version>
 			</plugin>
 			<!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation 
 				processors -->
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+                <version>${compiler.plugin.version}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Changed all POM's to use properties for the version numbers. This allows the versions to be overridden from the command if desired.

Also fixed the URL in the jax-rs-client quick start so that it would build.
