### PR TITLE
Unify module names style.

### DIFF
--- a/cdi-injection/pom.xml
+++ b/cdi-injection/pom.xml
@@ -16,8 +16,8 @@
    <artifactId>jboss-as-cdi-injection</artifactId>
    <version>7.1.2-SNAPSHOT</version>
    <packaging>war</packaging>
-   <name>JBoss AS Quickstarts: CDI-Injection</name>
-   <description>JBoss AS Quickstarts: CDI-Injection</description>
+   <name>JBoss AS Quickstarts: CDI Injection</name>
+   <description>JBoss AS Quickstarts: CDI Injection</description>
 
    <url>http://jboss.org/jbossas</url>
    <licenses>

--- a/ejb-security/pom.xml
+++ b/ejb-security/pom.xml
@@ -16,8 +16,8 @@
    <artifactId>jboss-as-ejb-security</artifactId>
    <version>7.1.2-SNAPSHOT</version>
    <packaging>war</packaging>
-   <name>JBoss AS Quickstarts: ejb-security</name>
-   <description>JBoss AS Quickstarts: ejb-security</description>
+   <name>JBoss AS Quickstarts: EJB Security</name>
+   <description>JBoss AS Quickstarts: EJB Security</description>
 
    <url>http://jboss.org/jbossas</url>
    <licenses>

--- a/helloworld-osgi/pom.xml
+++ b/helloworld-osgi/pom.xml
@@ -17,8 +17,8 @@
     <artifactId>jboss-as-helloworld-osgi</artifactId>
     <version>7.1.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
-    <name>JBoss AS Quickstarts: Helloworld OSGi</name>
-    <description>JBoss AS Quickstarts: Helloworld OSGi</description>
+    <name>JBoss AS Quickstarts: OSGi Helloworld</name>
+    <description>JBoss AS Quickstarts: OSGi Helloworld</description>
 
     <url>http://jboss.org/jbossas/osgi</url>
     <licenses>

--- a/helloworld-rs/pom.xml
+++ b/helloworld-rs/pom.xml
@@ -16,7 +16,7 @@
    <artifactId>jboss-as-helloworld-rs</artifactId>
    <version>7.1.2-SNAPSHOT</version>
    <packaging>war</packaging>
-   <name>JBoss AS Quickstarts: helloworld-rs</name>
+   <name>JBoss AS Quickstarts: JAX-RS Helloworld</name>
    <description>JBoss AS Quickstarts: Helloworld using JAX-RS</description>
 
    <url>http://jboss.org/jbossas</url>

--- a/hibernate3/pom.xml
+++ b/hibernate3/pom.xml
@@ -17,8 +17,8 @@
     <artifactId>jboss-as-hibernate3</artifactId>
     <version>7.1.2-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss AS Quickstarts: Hiberanate3</name>
-    <description>JBoss AS Quickstarts: Hiberanate3</description>
+    <name>JBoss AS Quickstarts: Hiberanate 3</name>
+    <description>JBoss AS Quickstarts: Hiberanate 3</description>
 
     <url>http://jboss.org/jbossas</url>
     <licenses>

--- a/hibernate3/pom.xml
+++ b/hibernate3/pom.xml
@@ -17,8 +17,8 @@
     <artifactId>jboss-as-hibernate3</artifactId>
     <version>7.1.2-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss AS Quickstarts: Hiberanate 3</name>
-    <description>JBoss AS Quickstarts: Hiberanate 3</description>
+    <name>JBoss AS Quickstarts: Hibernate 3</name>
+    <description>JBoss AS Quickstarts: Hibernate 3</description>
 
     <url>http://jboss.org/jbossas</url>
     <licenses>

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -17,7 +17,7 @@
     <artifactId>jboss-as-kitchensink-jsp</artifactId>
     <version>7.1.2-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss AS Quickstarts: kitchensink-jsp</name>
+    <name>JBoss AS Quickstarts: Kitchensink JSP</name>
     <description>kitchensink-jsp: Kitchensink with JSP front end</description>
 
     <url>http://jboss.org/jbossas</url>

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -17,7 +17,7 @@
     <artifactId>jboss-as-kitchensink</artifactId>
     <version>7.1.2-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss AS Quickstarts: kitchensink</name>
+    <name>JBoss AS Quickstarts: Kitchensink</name>
     <description>A starter Java EE 6 webapp project for use on JBoss AS 7 / EAP 6, generated from the jboss-javaee6-webapp archetype</description>
 
     <url>http://jboss.org/jbossas</url>

--- a/log4j/pom.xml
+++ b/log4j/pom.xml
@@ -17,8 +17,8 @@
 	<artifactId>jboss-as-log4j</artifactId>
 	<version>7.1.2-SNAPSHOT</version>
 	<packaging>war</packaging>
-	<name>JBoss AS Quickstarts: log4j</name>
-	<description>JBoss AS Quickstarts: Logging using log4j</description>
+	<name>JBoss AS Quickstarts: Log4j</name>
+	<description>JBoss AS Quickstarts: Logging using Log4j</description>
 
 	<url>http://jboss.org/jbossas</url>
 	<licenses>

--- a/payment-cdi-event/pom.xml
+++ b/payment-cdi-event/pom.xml
@@ -17,8 +17,8 @@
     <artifactId>jboss-as-payment-cdi-event</artifactId>
     <version>7.1.2-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss AS Quickstarts: CDI-Event</name>
-    <description>JBoss AS Quickstarts: CDI-Event</description>
+    <name>JBoss AS Quickstarts: CDI Event</name>
+    <description>JBoss AS Quickstarts: CDI Event</description>
 
     <url>http://jboss.org/jbossas</url>
     <licenses>

--- a/servlet-security/pom.xml
+++ b/servlet-security/pom.xml
@@ -16,8 +16,8 @@
    <artifactId>jboss-as-servlet-security</artifactId>
    <version>7.1.2-SNAPSHOT</version>
    <packaging>war</packaging>
-   <name>JBoss AS Quickstarts: servlet-security</name>
-   <description>JBoss AS Quickstarts: servlet-security</description>
+   <name>JBoss AS Quickstarts: Servlet Security</name>
+   <description>JBoss AS Quickstarts: Servlet Security</description>
 
    <url>http://jboss.org/jbossas</url>
    <licenses>


### PR DESCRIPTION
Changes few modules' <name> to be like "Kitchensink JSF" instead of "kitchensink-jsf".
