### PR TITLE
Change version properties and update AS maven plugin version

### DIFF
--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -40,7 +40,7 @@
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
         <hibernate.validator.version>4.2.0.Final</hibernate.validator.version>
         <hibernate.jpamodelgen.version>1.1.1.Final</hibernate.jpamodelgen.version>

--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -40,15 +40,15 @@
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
-        <hibernate.validator.version>4.2.0.Final</hibernate.validator.version>
-        <hibernate.jpamodelgen.version>1.1.1.Final</hibernate.jpamodelgen.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
+        <version.org.hibernate.validator>4.2.0.Final</version.org.hibernate.validator>
+        <version.org.hibernate-jpamodelgen>1.1.1.Final</version.org.hibernate-jpamodelgen>
 
         <!-- other plugin versions -->
-        <surefire.plugin.version>2.10</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <version.surefire.plugin>2.10</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -66,7 +66,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate.validator.version}</version>
+            <version>${version.org.hibernate.validator}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
-            <version>${hibernate.jpamodelgen.version}</version>
+            <version>${version.org.hibernate-jpamodelgen}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -156,7 +156,7 @@
                 <!-- The Maven Surefire plugin tests your application. Here we ensure we are using a version compatible with Arquillian -->
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${surefire.plugin.version}</version>
+                    <version>${version.surefire.plugin}</version>
                 </plugin>
                 <!-- The JBoss AS plugin deploys your war to a local JBoss AS container -->
                 <!-- To use, set the JBOSS_HOME environment variable and run:
@@ -164,7 +164,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>${jboss.as.plugin.version}</version>
+                    <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -172,7 +172,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -181,7 +181,7 @@
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/bmt/pom.xml
+++ b/bmt/pom.xml
@@ -36,7 +36,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <!-- JBoss dependency versions -->
-      <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+      <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
       <!-- other plugin versions -->

--- a/bmt/pom.xml
+++ b/bmt/pom.xml
@@ -36,12 +36,12 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <!-- JBoss dependency versions -->
-      <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-      <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+      <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+      <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
       <!-- other plugin versions -->
-      <war.plugin.version>2.1.1</war.plugin.version>
-      <compiler.plugin.version>2.3.1</compiler.plugin.version>
+      <version.war.plugin>2.1.1</version.war.plugin>
+      <version.compiler.plugin>2.3.1</version.compiler.plugin>
 
       <!-- maven-compiler-plugin -->
       <maven.compiler.target>1.6</maven.compiler.target>
@@ -61,7 +61,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -126,7 +126,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>${war.plugin.version}</version>
+            <version>${version.war.plugin}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch
                   up! -->
@@ -137,13 +137,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>${compiler.plugin.version}</version>
+            <version>${version.compiler.plugin}</version>
             <configuration>
                <source>${maven.compiler.source}</source>
                <target>${maven.compiler.target}</target>

--- a/cdi-injection/pom.xml
+++ b/cdi-injection/pom.xml
@@ -36,7 +36,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
        <!-- other plugin versions -->

--- a/cdi-injection/pom.xml
+++ b/cdi-injection/pom.xml
@@ -36,12 +36,12 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
        <!-- other plugin versions -->
-       <war.plugin.version>2.1.1</war.plugin.version>
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
+       <version.war.plugin>2.1.1</version.war.plugin>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -61,7 +61,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -103,7 +103,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>${war.plugin.version}</version>
+            <version>${version.war.plugin}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -114,13 +114,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>${compiler.plugin.version}</version>
+            <version>${version.compiler.plugin}</version>
             <configuration>
                <source>${maven.compiler.source}</source>
                <target>${maven.compiler.target}</target>

--- a/cdi-portable-extension/pom.xml
+++ b/cdi-portable-extension/pom.xml
@@ -36,19 +36,19 @@
         resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>> -->
+        <!-- <version.org.jboss.bom>1.0.0.Final-redhat-1</version.org.jboss.bom>> -->
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -70,7 +70,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -113,7 +113,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -123,12 +123,12 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -150,7 +150,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.plugin.version}</version>
+                        <version>${version.surefire.plugin}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -160,7 +160,7 @@
                     <plugin>
                         <groupId>org.jboss.as.plugins</groupId>
                         <artifactId>jboss-as-maven-plugin</artifactId>
-                        <version>${jboss.as.plugin.version}</version>
+                        <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                     </plugin>
                 </plugins>
             </build>

--- a/cdi-portable-extension/pom.xml
+++ b/cdi-portable-extension/pom.xml
@@ -36,7 +36,7 @@
         resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
         <!-- Alternatively, comment out the above line, and un-comment the 

--- a/cluster-ha-singleton/client/pom.xml
+++ b/cluster-ha-singleton/client/pom.xml
@@ -57,7 +57,7 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.source}</target>
@@ -68,7 +68,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>${exec.plugin.version}</version>
+                <version>${version.exec.plugin}</version>
                 <configuration>
                     <executable>java</executable>
                     <arguments>

--- a/cluster-ha-singleton/pom.xml
+++ b/cluster-ha-singleton/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- JBoss dependency versions -->
         <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
         <!-- other plugin versions -->

--- a/cluster-ha-singleton/pom.xml
+++ b/cluster-ha-singleton/pom.xml
@@ -37,14 +37,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <ejb.plugin.version>2.3</ejb.plugin.version>
-        <exec.plugin.version>1.2.1</exec.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.ejb.plugin>2.3</version.ejb.plugin>
+        <version.exec.plugin>1.2.1</version.exec.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -67,14 +67,14 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-ejb-client-bom</artifactId>
-                <version>${jboss.as.version}</version>
+                <version>${version.org.jboss.as}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -86,7 +86,7 @@
             <!-- Enforce Java 1.6 -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.source}</target>
@@ -95,7 +95,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -103,7 +103,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>${exec.plugin.version}</version>
+                <version>${version.exec.plugin}</version>
             </plugin>
         </plugins>
     </build>

--- a/cluster-ha-singleton/service/pom.xml
+++ b/cluster-ha-singleton/service/pom.xml
@@ -56,7 +56,7 @@
             <!-- Enforce Java 1.6 -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.source}</target>
@@ -67,7 +67,7 @@
                     2.1 to 3.0 -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ejb-plugin</artifactId>
-                <version>${ejb.plugin.version}</version>
+                <version>${version.ejb.plugin}</version>
                 <configuration>
                     <ejbVersion>3.1</ejbVersion>
                     <source>${maven.compiler.source}</source>

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -36,13 +36,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <surefire.plugin.version>2.10</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.10</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -60,7 +60,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -121,7 +121,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -130,7 +130,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -144,7 +144,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
         </plugins>
     </build>

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
 
         <!-- other plugin versions -->

--- a/ejb-asynchronous/client/pom.xml
+++ b/ejb-asynchronous/client/pom.xml
@@ -49,14 +49,14 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-ejb-client-bom</artifactId>
-                <version>${jboss.as.version}</version>
+                <version>${version.org.jboss.as}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -139,7 +139,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>${exec.plugin.version}</version>
+                <version>${version.exec.plugin}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/ejb-asynchronous/ejb/pom.xml
+++ b/ejb-asynchronous/ejb/pom.xml
@@ -35,7 +35,7 @@
 			<plugin>	
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-ejb-plugin</artifactId>
-				<version>${ejb.plugin.version}</version>
+				<version>${version.ejb.plugin}</version>
 				<configuration>
                     <!-- set the EJB version to 3.1 -->
 					<ejbVersion>3.1</ejbVersion>
@@ -50,7 +50,7 @@
 			<plugin>
 				<groupId>org.jboss.as.plugins</groupId>
 				<artifactId>jboss-as-maven-plugin</artifactId>
-				<version>${jboss.as.plugin.version}</version>
+				<version>${version.org.jboss.as.plugins.maven.plugin}</version>
 				<configuration>
 					<filename>${project.build.finalName}.jar</filename>
 					<skip>false</skip>

--- a/ejb-asynchronous/pom.xml
+++ b/ejb-asynchronous/pom.xml
@@ -37,14 +37,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <ejb.plugin.version>2.3</ejb.plugin.version>
-        <exec.plugin.version>1.2.1</exec.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.ejb.plugin>2.3</version.ejb.plugin>
+        <version.exec.plugin>1.2.1</version.exec.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -67,14 +67,14 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-ejb-client-bom</artifactId>
-                <version>${jboss.as.version}</version>
+                <version>${version.org.jboss.as}</version>
                 <scope>runtime</scope>
                 <type>pom</type>
             </dependency>
@@ -105,7 +105,7 @@
             <!-- Enforce Java 1.6 -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -114,7 +114,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -122,7 +122,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>${exec.plugin.version}</version>
+                <version>${version.exec.plugin}</version>
             </plugin>
         </plugins>
     </build>

--- a/ejb-asynchronous/pom.xml
+++ b/ejb-asynchronous/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- JBoss dependency versions -->
         <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
         <!-- other plugin versions -->

--- a/ejb-in-ear/ear/pom.xml
+++ b/ejb-in-ear/ear/pom.xml
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>${ear.plugin.version}</version>
+                <version>${version.ear.plugin}</version>
                 <!-- configuring the ear plugin -->
                 <configuration>
                     <!-- Specify the artifact name for the EAR -->
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <configuration>
                     <filename>jboss-as-ejb-in-ear.ear</filename>
                     <skip>false</skip>
@@ -93,7 +93,7 @@
           annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/ejb-in-ear/ejb/pom.xml
+++ b/ejb-in-ear/ejb/pom.xml
@@ -72,7 +72,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/ejb-in-ear/pom.xml
+++ b/ejb-in-ear/pom.xml
@@ -37,15 +37,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <ear.plugin.version>2.3.2</ear.plugin.version>
-        <ejb.plugin.version>2.3</ejb.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.ear.plugin>2.3.2</version.ear.plugin>
+        <version.ejb.plugin>2.3</version.ejb.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -79,7 +79,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/ejb-in-ear/pom.xml
+++ b/ejb-in-ear/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- JBoss dependency versions -->
         <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
         <!-- other plugin versions -->

--- a/ejb-in-ear/web/pom.xml
+++ b/ejb-in-ear/web/pom.xml
@@ -89,7 +89,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -99,7 +99,7 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/ejb-in-war/pom.xml
+++ b/ejb-in-war/pom.xml
@@ -36,13 +36,13 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
 
        <!-- other plugin versions -->
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
-       <surefire.plugin.version>2.10</surefire.plugin.version>
-       <war.plugin.version>2.1.1</war.plugin.version>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
+       <version.surefire.plugin>2.10</version.surefire.plugin>
+       <version.war.plugin>2.1.1</version.war.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -65,7 +65,7 @@
          <dependency>
             <groupId>org.jboss.bom</groupId>
             <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-            <version>${jboss.bom.version}</version>
+            <version>${version.org.jboss.bom}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -128,7 +128,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>${war.plugin.version}</version>
+            <version>${version.war.plugin}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -139,13 +139,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>
@@ -167,7 +167,7 @@
             <plugins>
                <plugin>
                   <artifactId>maven-surefire-plugin</artifactId>
-                  <version>${surefire.plugin.version}</version>
+                  <version>${version.surefire.plugin}</version>
                   <configuration>
                      <skip>true</skip>
                   </configuration>

--- a/ejb-in-war/pom.xml
+++ b/ejb-in-war/pom.xml
@@ -36,7 +36,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
 
        <!-- other plugin versions -->

--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -15,7 +15,7 @@
 
    <groupId>org.jboss.as.quickstarts</groupId>
    <artifactId>jboss-as-ejb-remote-client</artifactId>
-   <version>7.1.1.Final</version>
+   <version>7.1.2-SNAPSHOT</version>
    <packaging>jar</packaging>
    <name>JBoss AS Quickstarts: EJB Remote Client</name>
    <description>JBoss AS Quickstarts: Java client for remote EJB</description>

--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -37,14 +37,14 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.version>7.1.1.Final</jboss.as.version>
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+       <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
        <!-- other plugin versions -->
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
-       <exec.plugin.version>1.2.1</exec.plugin.version>
-       <war.plugin.version>2.1.1</war.plugin.version>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
+       <version.exec.plugin>1.2.1</version.exec.plugin>
+       <version.war.plugin>2.1.1</version.war.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -64,7 +64,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -72,7 +72,7 @@
          <dependency>
              <groupId>org.jboss.as</groupId>
              <artifactId>jboss-as-ejb-client-bom</artifactId>
-             <version>${jboss.as.version}</version>
+             <version>${version.org.jboss.as}</version>
              <type>pom</type>
              <scope>import</scope>
          </dependency>
@@ -154,7 +154,7 @@
          <!-- Enforce Java 1.6  -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>
@@ -165,7 +165,7 @@
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>${exec.plugin.version}</version>
+            <version>${version.exec.plugin}</version>
             <executions>
               <execution>
                   <goals>
@@ -206,7 +206,7 @@
             <plugin>
                <groupId>org.jboss.as.plugins</groupId>
                <artifactId>jboss-as-maven-plugin</artifactId>
-               <version>${jboss.as.plugin.version}</version>
+               <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                <inherited>true</inherited>
                <configuration>
                   <skip>true</skip>

--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -38,7 +38,7 @@
 
        <!-- JBoss dependency versions -->
        <jboss.as.version>7.1.1.Final</jboss.as.version>
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
        <!-- other plugin versions -->

--- a/ejb-remote/pom.xml
+++ b/ejb-remote/pom.xml
@@ -29,7 +29,7 @@
     
     <properties>
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
     </properties>
 
     <!-- This quickstart consists of a server side component and a client that accesses

--- a/ejb-remote/pom.xml
+++ b/ejb-remote/pom.xml
@@ -29,7 +29,7 @@
     
     <properties>
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
     </properties>
 
     <!-- This quickstart consists of a server side component and a client that accesses
@@ -49,7 +49,7 @@
             <plugin>
                <groupId>org.jboss.as.plugins</groupId>
                <artifactId>jboss-as-maven-plugin</artifactId>
-               <version>${jboss.as.plugin.version}</version>
+               <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                <inherited>true</inherited>
                <configuration>
                   <skip>true</skip>

--- a/ejb-remote/server-side/pom.xml
+++ b/ejb-remote/server-side/pom.xml
@@ -36,7 +36,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
        <!-- other plugin versions -->

--- a/ejb-remote/server-side/pom.xml
+++ b/ejb-remote/server-side/pom.xml
@@ -15,7 +15,7 @@
  
    <groupId>org.jboss.as.quickstarts</groupId>
    <artifactId>jboss-as-ejb-remote-server-side</artifactId>
-   <version>7.1.1.Final</version>
+   <version>7.1.2-SNAPSHOT</version>
    <packaging>ejb</packaging>
    <name>JBoss AS Quickstarts: Server side of remote EJB</name>
 

--- a/ejb-remote/server-side/pom.xml
+++ b/ejb-remote/server-side/pom.xml
@@ -36,12 +36,12 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
        <!-- other plugin versions -->
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
-       <ejb.plugin.version>2.3</ejb.plugin.version>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
+       <version.ejb.plugin>2.3</version.ejb.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -61,7 +61,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -96,7 +96,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             <configuration>
                 <filename>${project.build.finalName}.jar</filename>
             </configuration>
@@ -105,7 +105,7 @@
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>
@@ -114,7 +114,7 @@
       <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-ejb-plugin</artifactId>
-            <version>${ejb.plugin.version}</version>
+            <version>${version.ejb.plugin}</version>
             <configuration>
                <ejbVersion>3.1</ejbVersion>
                <!-- this is false by default -->

--- a/ejb-security/pom.xml
+++ b/ejb-security/pom.xml
@@ -36,7 +36,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <!-- JBoss dependency versions -->
-      <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+      <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
       <!-- other plugin versions -->

--- a/ejb-security/pom.xml
+++ b/ejb-security/pom.xml
@@ -36,11 +36,11 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <!-- JBoss dependency versions -->
-      <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-      <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+      <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+      <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
       <!-- other plugin versions -->
-      <compiler.plugin.version>2.3.1</compiler.plugin.version>
+      <version.compiler.plugin>2.3.1</version.compiler.plugin>
 
       <!-- maven-compiler-plugin -->
       <maven.compiler.target>1.6</maven.compiler.target>
@@ -60,7 +60,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -108,13 +108,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/greeter/pom.xml
+++ b/greeter/pom.xml
@@ -36,7 +36,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
        <!-- other plugin versions -->

--- a/greeter/pom.xml
+++ b/greeter/pom.xml
@@ -36,12 +36,12 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
        <!-- other plugin versions -->
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
-       <war.plugin.version>2.1.1</war.plugin.version>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
+       <version.war.plugin>2.1.1</version.war.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -63,7 +63,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -129,7 +129,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>${war.plugin.version}</version>
+            <version>${version.war.plugin}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -140,13 +140,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/helloworld-errai/pom.xml
+++ b/helloworld-errai/pom.xml
@@ -36,7 +36,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <!-- JBoss dependency versions -->
-      <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+      <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
       <jboss.bom.version>1.0.0.Final</jboss.bom.version>
 
       <!-- other plugin versions -->

--- a/helloworld-errai/pom.xml
+++ b/helloworld-errai/pom.xml
@@ -36,14 +36,14 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <!-- JBoss dependency versions -->
-      <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-      <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+      <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+      <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
 
       <!-- other plugin versions -->
-      <clean.pluging.version>2.4.1</clean.pluging.version>
-      <compiler.plugin.version>2.3.1</compiler.plugin.version>
-      <gwt.plugin.version>2.4.0</gwt.plugin.version>
-      <war.plugin.version>2.1.1</war.plugin.version>
+      <version.clean.plugin>2.4.1</version.clean.plugin>
+      <version.compiler.plugin>2.3.1</version.compiler.plugin>
+      <version.org.codehaus.mojo.gwt.maven.plugin>2.4.0</version.org.codehaus.mojo.gwt.maven.plugin>
+      <version.war.plugin>2.1.1</version.war.plugin>
 
       <!-- maven-compiler-plugin -->
       <maven.compiler.target>1.6</maven.compiler.target>
@@ -55,7 +55,7 @@
       <dependency>
         <groupId>org.jboss.bom</groupId>
         <artifactId>jboss-javaee-6.0-with-errai</artifactId>
-        <version>${jboss.bom.version}</version>
+        <version>${version.org.jboss.bom}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -128,7 +128,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
-        <version>${war.plugin.version}</version>
+        <version>${version.war.plugin}</version>
         <configuration>
           <!-- Exclude client only classes from the deployment. As these classes compile down to JavaScript, 
             they are not needed at runtime. They would only introduce runtime dependencies to GWT development libraries. -->
@@ -140,13 +140,13 @@
       <plugin>
         <groupId>org.jboss.as.plugins</groupId>
         <artifactId>jboss-as-maven-plugin</artifactId>
-        <version>${jboss.as.plugin.version}</version>
+        <version>${version.org.jboss.as.plugins.maven.plugin}</version>
       </plugin>
 
       <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler.plugin.version}</version>
+        <version>${version.compiler.plugin}</version>
         <configuration>
           <source>${maven.compiler.source}</source>
           <target>${maven.compiler.target}</target>
@@ -157,7 +157,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.plugin.version}</version>
+        <version>${version.org.codehaus.mojo.gwt.maven.plugin}</version>
         <configuration>
           <inplace>true</inplace>
           <logLevel>INFO</logLevel>
@@ -186,7 +186,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>${clean.pluging.version}</version>
+        <version>${version.clean.plugin}</version>
         <configuration>
           <filesets>
             <fileset>

--- a/helloworld-gwt/pom.xml
+++ b/helloworld-gwt/pom.xml
@@ -36,7 +36,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <!-- JBoss dependency versions -->
-      <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+      <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
       <!-- Other dependency versions -->

--- a/helloworld-gwt/pom.xml
+++ b/helloworld-gwt/pom.xml
@@ -36,16 +36,16 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <!-- JBoss dependency versions -->
-      <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-      <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+      <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+      <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
       <!-- Other dependency versions -->
-      <gwt.version>2.4.0</gwt.version>
+      <version.com.google.gwt>2.4.0</version.com.google.gwt>
 
       <!-- other plugin versions -->
-      <compiler.plugin.version>2.3.1</compiler.plugin.version>
-      <gwt.plugin.version>2.4.0</gwt.plugin.version>
-      <war.plugin.version>2.1.1</war.plugin.version>
+      <version.compiler.plugin>2.3.1</version.compiler.plugin>
+      <version.org.codehaus.mojo.gwt.maven.plugin>2.4.0</version.org.codehaus.mojo.gwt.maven.plugin>
+      <version.war.plugin>2.1.1</version.war.plugin>
 
       <!-- maven-compiler-plugin -->
       <maven.compiler.target>1.6</maven.compiler.target>
@@ -68,7 +68,7 @@
       <dependency>
         <groupId>org.jboss.spec</groupId>
         <artifactId>jboss-javaee-6.0</artifactId>
-        <version>${jboss.javaee6.spec.version}</version>
+        <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
-      <version>${gwt.version}</version>
+      <version>${version.com.google.gwt}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -117,7 +117,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
-        <version>${war.plugin.version}</version>
+        <version>${version.war.plugin}</version>
         <configuration>
           <!-- Exclude client only classes from the deployment. As these 
             classes compile down to JavaScript, they are not needed at runtime. They 
@@ -130,14 +130,14 @@
       <plugin>
         <groupId>org.jboss.as.plugins</groupId>
         <artifactId>jboss-as-maven-plugin</artifactId>
-        <version>${jboss.as.plugin.version}</version>
+        <version>${version.org.jboss.as.plugins.maven.plugin}</version>
       </plugin>
 
       <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
         annotation processors -->
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-          <version>${compiler.plugin.version}</version>
+          <version>${version.compiler.plugin}</version>
           <configuration>
             <source>${maven.compiler.source}</source>
             <target>${maven.compiler.target}</target>
@@ -149,7 +149,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.plugin.version}</version>
+        <version>${version.org.codehaus.mojo.gwt.maven.plugin}</version>
         <configuration>
           <inplace>true</inplace>
           <logLevel>INFO</logLevel>

--- a/helloworld-html5/pom.xml
+++ b/helloworld-html5/pom.xml
@@ -36,13 +36,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <license.pluging.version>1.9.0</license.pluging.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.license.plugin>1.9.0</version.license.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -62,7 +62,7 @@
             <dependency>
                <groupId>org.jboss.bom</groupId>
                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-               <version>${jboss.bom.version}</version>
+               <version>${version.org.jboss.bom}</version>
                <type>pom</type>
                <scope>import</scope>
             </dependency>
@@ -103,7 +103,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch
                    up! -->
@@ -114,13 +114,13 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates
           annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -130,7 +130,7 @@
             <plugin>
                 <groupId>com.mycila.maven-license-plugin</groupId>
                 <artifactId>maven-license-plugin</artifactId>
-                <version>${license.pluging.version}</version>
+                <version>${version.license.plugin}</version>
                 <configuration>
                     <header>src/etc/license.txt</header>
                     <includes>

--- a/helloworld-html5/pom.xml
+++ b/helloworld-html5/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
 
         <!-- other plugin versions -->

--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -37,13 +37,13 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.version>7.1.1.Final</jboss.as.version>
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
+       <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
 
        <!-- other plugin versions -->
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
-       <jar.plugin.version>2.2</jar.plugin.version>
-       <exec.plugin.version>1.1.1</exec.plugin.version>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
+       <version.jar.plugin>2.2</version.jar.plugin>
+       <version.exec.plugin>1.1.1</version.exec.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -54,7 +54,7 @@
       <dependency>
          <groupId>org.jboss.as</groupId>
          <artifactId>jboss-as-jms-client-bom</artifactId>
-         <version>${jboss.as.version}</version>
+         <version>${version.org.jboss.as}</version>
          <type>pom</type>
       </dependency>
    </dependencies>
@@ -65,7 +65,7 @@
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>${exec.plugin.version}</version>
+            <version>${version.exec.plugin}</version>
             <configuration>
                <mainClass>org.jboss.as.quickstarts.jms.HelloWorldJMSClient</mainClass>
                <systemProperties>
@@ -108,7 +108,7 @@
          </plugin>
          <plugin>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>${jar.plugin.version}</version>
+            <version>${version.jar.plugin}</version>
             <configuration>
             </configuration>
          </plugin>
@@ -116,7 +116,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             <configuration>
                <username>admin</username>
                <password>admin</password>
@@ -126,7 +126,7 @@
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -38,7 +38,7 @@
 
        <!-- JBoss dependency versions -->
        <jboss.as.version>7.1.1.Final</jboss.as.version>
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
 
        <!-- other plugin versions -->
        <compiler.plugin.version>2.3.1</compiler.plugin.version>

--- a/helloworld-jsf/pom.xml
+++ b/helloworld-jsf/pom.xml
@@ -36,7 +36,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <!-- JBoss dependency versions -->
-      <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+      <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
        
       <richfaces.version>4.2.0.Final</richfaces.version>

--- a/helloworld-jsf/pom.xml
+++ b/helloworld-jsf/pom.xml
@@ -36,13 +36,13 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <!-- JBoss dependency versions -->
-      <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+      <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
        
-      <richfaces.version>4.2.0.Final</richfaces.version>
+      <version.org.richfaces>4.2.0.Final</version.org.richfaces>
 
       <!-- other plugin versions -->
-      <compiler.plugin.version>2.3.1</compiler.plugin.version>
+      <version.compiler.plugin>2.3.1</version.compiler.plugin>
 
       <!-- maven-compiler-plugin -->
       <maven.compiler.target>1.6</maven.compiler.target>
@@ -64,7 +64,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -73,7 +73,7 @@
          <dependency>
               <groupId>org.richfaces</groupId>
               <artifactId>richfaces-bom</artifactId>
-              <version>${richfaces.version}</version>
+              <version>${version.org.richfaces}</version>
               <type>pom</type>
               <scope>import</scope>
          </dependency>
@@ -128,13 +128,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/helloworld-mdb/pom.xml
+++ b/helloworld-mdb/pom.xml
@@ -36,12 +36,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -95,7 +95,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -106,13 +106,13 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -134,7 +134,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>${war.plugin.version}</version>
+                        <version>${version.war.plugin}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
                             <warName>ROOT</warName>

--- a/helloworld-mdb/pom.xml
+++ b/helloworld-mdb/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
         <!-- other plugin versions -->

--- a/helloworld-osgi/pom.xml
+++ b/helloworld-osgi/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
 
         <!-- Other dependency versions -->
         <osgi.version>4.2.0</osgi.version>

--- a/helloworld-osgi/pom.xml
+++ b/helloworld-osgi/pom.xml
@@ -37,14 +37,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
 
         <!-- Other dependency versions -->
-        <osgi.version>4.2.0</osgi.version>
+        <version.org.osgi>4.2.0</version.org.osgi>
 
         <!-- other plugin versions -->
-        <apache.felix.plugin.version>2.3.4</apache.felix.plugin.version>
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
+        <version.bundle.plugin>2.3.4</version.bundle.plugin>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
-            <version>${osgi.version}</version>
+            <version>${version.org.osgi}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -67,7 +67,7 @@
                     an OSGi Bundle -->
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>${apache.felix.plugin.version}</version>
+                <version>${version.bundle.plugin}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -98,7 +98,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <configuration>
                     <filename>${project.build.finalName}.jar</filename>
                 </configuration>
@@ -108,7 +108,7 @@
                 unnecessary warnings about execution environment in IDE -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/helloworld-rs/pom.xml
+++ b/helloworld-rs/pom.xml
@@ -36,7 +36,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
        <!-- other plugin versions -->

--- a/helloworld-rs/pom.xml
+++ b/helloworld-rs/pom.xml
@@ -36,12 +36,12 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
        <!-- other plugin versions -->
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
-       <war.plugin.version>2.1.1</war.plugin.version>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
+       <version.war.plugin>2.1.1</version.war.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -63,7 +63,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -104,7 +104,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>${war.plugin.version}</version>
+            <version>${version.war.plugin}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -115,13 +115,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>
@@ -141,7 +141,7 @@
           <plugins>
              <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                    <outputDirectory>deployments</outputDirectory>
                    <warName>ROOT</warName>

--- a/helloworld-singleton/pom.xml
+++ b/helloworld-singleton/pom.xml
@@ -36,7 +36,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
 
         <!-- other plugin versions -->

--- a/helloworld-singleton/pom.xml
+++ b/helloworld-singleton/pom.xml
@@ -36,12 +36,12 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -60,7 +60,7 @@
 			<dependency>
 				<groupId>org.jboss.spec</groupId>
 				<artifactId>jboss-javaee-6.0</artifactId>
-				<version>${jboss.bom.version}</version>
+				<version>${version.org.jboss.bom}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -91,7 +91,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>${war.plugin.version}</version>
+				<version>${version.war.plugin}</version>
 				<configuration>
 					<!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
 					<failOnMissingWebXml>false</failOnMissingWebXml>
@@ -101,13 +101,13 @@
 			<plugin>
 				<groupId>org.jboss.as.plugins</groupId>
 				<artifactId>jboss-as-maven-plugin</artifactId>
-				<version>${jboss.as.plugin.version}</version>
+				<version>${version.org.jboss.as.plugins.maven.plugin}</version>
 			</plugin>
 			<!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation 
 				processors -->
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/helloworld/pom.xml
+++ b/helloworld/pom.xml
@@ -36,7 +36,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
        <!-- other plugin versions -->

--- a/helloworld/pom.xml
+++ b/helloworld/pom.xml
@@ -36,12 +36,12 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
        <!-- other plugin versions -->
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
-       <war.plugin.version>2.1.1</war.plugin.version>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
+       <version.war.plugin>2.1.1</version.war.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -61,7 +61,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -103,7 +103,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>${war.plugin.version}</version>
+            <version>${version.war.plugin}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -114,13 +114,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/hibernate3/pom.xml
+++ b/hibernate3/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
         <hibernate.common.annotations.version>3.2.0.Final</hibernate.common.annotations.version>

--- a/hibernate3/pom.xml
+++ b/hibernate3/pom.xml
@@ -37,18 +37,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
-        <hibernate.common.annotations.version>3.2.0.Final</hibernate.common.annotations.version>
-        <hibernate.core.version>3.6.8.Final</hibernate.core.version>
-        <hibernate.em.version>3.6.8.Final</hibernate.em.version>
-        <hibernate.infinispan.version>3.6.8.Final</hibernate.infinispan.version>
-        <hibernate.validator.version>3.1.0.GA</hibernate.validator.version>
+        <version.org.hibernate3.commons.annotations>3.2.0.Final</version.org.hibernate3.commons.annotations>
+        <version.org.hibernate>3.6.8.Final</version.org.hibernate>
+        <version.org.hibernate.em>3.6.8.Final</version.org.hibernate.em>
+        <version.org.hibernate.infinispan>3.6.8.Final</version.org.hibernate.infinispan>
+        <version.org.hibernate.validator>3.1.0.GA</version.org.hibernate.validator>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -65,7 +65,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>${hibernate.core.version}</version>
+                <version>${version.org.hibernate}</version>
 
                 <!-- Some transitive dependencies of Hibernate 3 are available 
                     in JBoss AS 7 as modules, so we don't include them in WEB-INF/lib, but instead 
@@ -98,7 +98,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-entitymanager</artifactId>
-                <version>${hibernate.em.version}</version>
+                <version>${version.org.hibernate.em}</version>
                 <!-- Some transitive dependencies of Hibernate 3 are available 
                     in JBoss AS 7 as modules, so we don't include them in WEB-INF/lib, but instead 
                     depend on the modules -->
@@ -126,7 +126,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>${hibernate.validator.version}</version>
+                <version>${version.org.hibernate.validator}</version>
                 <!-- Some transitive dependencies of Hibernate 3 are available 
                     in JBoss AS 7 as modules, so we don't include them in WEB-INF/lib, but instead 
                     depend on the modules -->
@@ -142,7 +142,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-commons-annotations</artifactId>
-                <version>${hibernate.common.annotations.version}</version>
+                <version>${version.org.hibernate3.commons.annotations}</version>
                 <!-- Some transitive dependencies of Hibernate 3 are available 
                     in JBoss AS 7 as modules, so we don't include them in WEB-INF/lib, but instead 
                     depend on the modules -->
@@ -158,7 +158,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-infinispan</artifactId>
-                <version>${hibernate.infinispan.version}</version>
+                <version>${version.org.hibernate.infinispan}</version>
                 <exclusions>
                     <!-- Some transitive dependencies of Hibernate 3 are 
                         available in JBoss AS 7 as modules, so we don't include them in WEB-INF/lib, 
@@ -191,7 +191,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -293,7 +293,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -304,13 +304,13 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -37,7 +37,7 @@
 
         <!-- JBoss dependency versions -->
         <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want 
             to import. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -36,20 +36,20 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
+        <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want 
             to import. -->
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version> -->
+        <!-- <version.org.jboss.bom>1.0.0.Final-redhat-1</version.org.jboss.bom> -->
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-hibernate</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -169,7 +169,7 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -177,7 +177,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -191,7 +191,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
         </plugins>
     </build>
@@ -211,7 +211,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>${war.plugin.version}</version>
+                        <version>${version.war.plugin}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
                             <warName>ROOT</warName>

--- a/inter-app/appA/pom.xml
+++ b/inter-app/appA/pom.xml
@@ -60,7 +60,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -79,13 +79,13 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/inter-app/appB/pom.xml
+++ b/inter-app/appB/pom.xml
@@ -60,7 +60,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -79,13 +79,13 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/inter-app/pom.xml
+++ b/inter-app/pom.xml
@@ -37,16 +37,16 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- Other dependency versions -->
-        <gwt.version>2.4.0</gwt.version>
-        <osgi.version>4.2.0</osgi.version>
+        <version.com.google.gwt>2.4.0</version.com.google.gwt>
+        <version.org.osgi>4.2.0</version.org.osgi>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -68,7 +68,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <inherited>false</inherited>
                 <configuration>
                     <skip>true</skip>

--- a/inter-app/pom.xml
+++ b/inter-app/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
         <!-- Other dependency versions -->

--- a/inter-app/shared/pom.xml
+++ b/inter-app/shared/pom.xml
@@ -43,13 +43,13 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/jax-rs-client/pom.xml
+++ b/jax-rs-client/pom.xml
@@ -36,16 +36,16 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <resteasy.version>2.2.2.GA</resteasy.version>
+        <version.org.jboss.resteasy>2.2.2.GA</version.org.jboss.resteasy>
 
         <!-- Other dependency versions -->
-        <apache.httpcomponents.version>4.1.4</apache.httpcomponents.version>
-        <junit.version>4.10</junit.version>
+        <version.org.apache.httpcomponents>4.1.4</version.org.apache.httpcomponents>
+        <version.junit>4.10</version.junit>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -56,18 +56,18 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>${resteasy.version}</version>
+            <version>${version.org.jboss.resteasy}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>${apache.httpcomponents.version}</version>
+            <version>${version.org.apache.httpcomponents}</version>
         </dependency>
     </dependencies>
     <build>
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -85,7 +85,7 @@
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.plugin.version}</version>
+                <version>${version.surefire.plugin}</version>
                 <configuration>
                     <systemProperties>
                         <property>

--- a/jta-crash-rec/pom.xml
+++ b/jta-crash-rec/pom.xml
@@ -37,7 +37,7 @@
 
         <!-- JBoss dependency versions -->
         <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <!-- Define the version of JBoss' Java EE 6 APIs we want to import. 
        Any dependencies from org.jboss.spec will have their version defined by this 
        BOM -->

--- a/jta-crash-rec/pom.xml
+++ b/jta-crash-rec/pom.xml
@@ -36,21 +36,21 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
+        <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of JBoss' Java EE 6 APIs we want to import. 
        Any dependencies from org.jboss.spec will have their version defined by this 
        BOM -->
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 3.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.javaee6.spec.version>3.0.0.Final-redhat-1</jboss.javaee6.spec.version> -->
+        <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final-redhat-1</version.org.jboss.spec.jboss.javaee.6.0> -->
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -68,7 +68,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-web-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -142,7 +142,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -153,13 +153,13 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/jts/application-component-1/pom.xml
+++ b/jts/application-component-1/pom.xml
@@ -93,7 +93,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -102,7 +102,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->

--- a/jts/application-component-2/pom.xml
+++ b/jts/application-component-2/pom.xml
@@ -74,7 +74,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -95,7 +95,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ejb-plugin</artifactId>
-                <version>${ejb.plugin.version}</version>
+                <version>${version.ejb.plugin}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/jts/pom.xml
+++ b/jts/pom.xml
@@ -36,13 +36,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <ejb.plugin.version>2.3</ejb.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.ejb.plugin>2.3</version.ejb.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -66,7 +66,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -90,7 +90,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>${jboss.as.plugin.version}</version>
+                    <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/jts/pom.xml
+++ b/jts/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
         <!-- other plugin versions -->

--- a/kitchensink-ear/jboss-as-kitchensink-ear-ear/pom.xml
+++ b/kitchensink-ear/jboss-as-kitchensink-ear-ear/pom.xml
@@ -54,7 +54,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-ear-plugin</artifactId>
-            <version>${ear.plugin.version}</version>
+            <version>${version.ear.plugin}</version>
             <configuration>
                <!-- Tell Maven we are using Java EE 6 -->
                <version>6</version>
@@ -101,7 +101,7 @@
             <plugins>
                <plugin>
                   <artifactId>maven-ear-plugin</artifactId>
-                  <version>${ear.plugin.version}</version>
+                  <version>${version.ear.plugin}</version>
                   <configuration>
                      <outputDirectory>deployments</outputDirectory>
                   </configuration>

--- a/kitchensink-ear/jboss-as-kitchensink-ear-ejb/pom.xml
+++ b/kitchensink-ear/jboss-as-kitchensink-ear-ejb/pom.xml
@@ -99,7 +99,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-ejb-plugin</artifactId>
-            <version>${ejb.plugin.version}</version>
+            <version>${version.ejb.plugin}</version>
             <configuration>
                <!-- Tell Maven we are using EJB 3.1 -->
                <ejbVersion>3.1</ejbVersion>
@@ -122,7 +122,7 @@
             <plugins>
                <plugin>
                   <artifactId>maven-surefire-plugin</artifactId>
-                  <version>${surefire.plugin.version}</version>
+                  <version>${version.surefire.plugin}</version>
                   <configuration>
                      <skip>true</skip>
                   </configuration>

--- a/kitchensink-ear/jboss-as-kitchensink-ear-web/pom.xml
+++ b/kitchensink-ear/jboss-as-kitchensink-ear-web/pom.xml
@@ -96,7 +96,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>${war.plugin.version}</version>
+            <version>${version.war.plugin}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->

--- a/kitchensink-ear/pom.xml
+++ b/kitchensink-ear/pom.xml
@@ -41,7 +41,7 @@
 
         <!-- JBoss dependency versions -->
         <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>

--- a/kitchensink-ear/pom.xml
+++ b/kitchensink-ear/pom.xml
@@ -40,23 +40,23 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
+        <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>> -->
+        <!-- <version.org.jboss.bom>1.0.0.Final-redhat-1</version.org.jboss.bom>> -->
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <ear.plugin.version>2.6</ear.plugin.version>
-        <ejb.plugin.version>2.3</ejb.plugin.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.ear.plugin>2.6</version.ear.plugin>
+        <version.ejb.plugin>2.3</version.ejb.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -96,7 +96,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-hibernate</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -119,7 +119,7 @@
                     activates annotation processors -->
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${compiler.plugin.version}</version>
+                    <version>${version.compiler.plugin}</version>
                     <configuration>
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>
@@ -133,7 +133,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>${jboss.as.plugin.version}</version>
+                    <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                     <inherited>true</inherited>
                     <configuration>
                         <skip>true</skip>

--- a/kitchensink-html5-mobile/pom.xml
+++ b/kitchensink-html5-mobile/pom.xml
@@ -30,28 +30,28 @@
         <!-- You can reference property in pom.xml or filtered resources (must enable third-party plugin if using Maven < 2.1) -->
         
         <!-- JBoss dependency versions -->
-        <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
         <!-- JBoss EAP Certified Versions -->
-        <!-- <javaee6.web.spec.version>3.0.0.Beta1-redhat-1</javaee6.web.spec.version> -->
+        <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Beta1-redhat-1</version.org.jboss.spec.jboss.javaee.6.0> -->
         <!-- <version.org.hibernate.validator>4.2.0.Final-redhat-1</version.org.hibernate.validator> -->
 
-        <arquillian.version>1.0.0.Final</arquillian.version>
+        <version.org.jboss.arquillian>1.0.0.Final</version.org.jboss.arquillian>
 
-        <hibernate.jpamodelgen.version>1.1.1.Final</hibernate.jpamodelgen.version>
-        <hibernate.validator.version>4.2.0.Final</hibernate.validator.version>
+        <version.org.hibernate-jpamodelgen>1.1.1.Final</version.org.hibernate-jpamodelgen>
+        <version.org.hibernate.validator>4.2.0.Final</version.org.hibernate.validator>
 
         <!-- Other dependency versions -->
-        <junit.version>4.10</junit.version>
-        <m2e.version>1.0.0</m2e.version>
-        <wro4j.version>1.4.4</wro4j.version>
+        <version.junit>4.10</version.junit>
+        <version.org.eclipse.m2e>1.0.0</version.org.eclipse.m2e>
+        <version.ro.isdc.wro4j>1.4.4</version.ro.isdc.wro4j>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <license.pluging.version>1.9.0</license.pluging.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.2</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.license.plugin>1.9.0</version.license.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.2</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -77,7 +77,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-web-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate.validator.version}</version>
+            <version>${version.org.hibernate.validator}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
-            <version>${hibernate.jpamodelgen.version}</version>
+            <version>${version.org.hibernate-jpamodelgen}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
 
@@ -168,14 +168,14 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>${version.org.jboss.arquillian}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
             <artifactId>arquillian-protocol-servlet</artifactId>
-            <version>${arquillian.version}</version>
+            <version>${version.org.jboss.arquillian}</version>
             <scope>test</scope>
         </dependency>
 
@@ -189,7 +189,7 @@
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -197,7 +197,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -208,13 +208,13 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
             
             <plugin>
                 <groupId>com.mycila.maven-license-plugin</groupId>
                 <artifactId>maven-license-plugin</artifactId>
-                <version>${license.pluging.version}</version>
+                <version>${version.license.plugin}</version>
                 <configuration>
                     <header>src/etc/license.txt</header>
                     <mapping>
@@ -248,7 +248,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.plugin.version}</version>
+                        <version>${version.surefire.plugin}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -266,7 +266,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>${war.plugin.version}</version>
+                        <version>${version.war.plugin}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
                             <warName>ROOT</warName>
@@ -290,7 +290,7 @@
                         <plugin>
                             <groupId>org.eclipse.m2e</groupId>
                             <artifactId>lifecycle-mapping</artifactId>
-                            <version>${m2e.version}</version>
+                            <version>${version.org.eclipse.m2e}</version>
                             <configuration>
                                 <lifecycleMappingMetadata>
                                     <pluginExecutions>
@@ -300,7 +300,7 @@
                                                 <artifactId>
                                                     wro4j-maven-plugin
                                                 </artifactId>
-                                                <version>${wro4j.version}</version>
+                                                <version>${version.ro.isdc.wro4j}</version>
                                                 <goals>
                                                     <goal>run</goal>
                                                 </goals>
@@ -319,7 +319,7 @@
                     <plugin>
                         <groupId>ro.isdc.wro4j</groupId>
                         <artifactId>wro4j-maven-plugin</artifactId>
-                        <version>${wro4j.version}</version>
+                        <version>${version.ro.isdc.wro4j}</version>
                         <executions>
                             <execution>
                                 <phase>compile</phase>
@@ -337,7 +337,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.plugin.version}</version>
+                        <version>${version.surefire.plugin}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -354,7 +354,7 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-managed</artifactId>
-                    <version>${jboss.as.version}</version>
+                    <version>${version.org.jboss.as}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -368,7 +368,7 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-remote</artifactId>
-                    <version>${jboss.as.version}</version>
+                    <version>${version.org.jboss.as}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -380,7 +380,7 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-managed</artifactId>
-                    <version>${jboss.as.version}</version>
+                    <version>${version.org.jboss.as}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -389,11 +389,11 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.plugin.version}</version>
+                        <version>${version.surefire.plugin}</version>
                         <configuration>
                             <systemProperties>
                                 <arquillian.launch>jbossci</arquillian.launch>
-                                <arquillian.jboss_home>${project.build.directory}/jboss-as-${jboss.as.version}/
+                                <arquillian.jboss_home>${project.build.directory}/jboss-as-${version.org.jboss.as}/
                                 </arquillian.jboss_home>
                             </systemProperties>
                             <includes>
@@ -416,7 +416,7 @@
                                         <artifactItem>
                                             <groupId>org.jboss.as</groupId>
                                             <artifactId>jboss-as-dist</artifactId>
-                                            <version>${jboss.as.version}</version>
+                                            <version>${version.org.jboss.as}</version>
                                             <outputDirectory>${project.build.directory}</outputDirectory>
                                             <type>zip</type>
                                             <overWrite>false</overWrite>

--- a/kitchensink-html5-mobile/pom.xml
+++ b/kitchensink-html5-mobile/pom.xml
@@ -31,7 +31,7 @@
         
         <!-- JBoss dependency versions -->
         <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
         <!-- JBoss EAP Certified Versions -->
         <!-- <javaee6.web.spec.version>3.0.0.Beta1-redhat-1</javaee6.web.spec.version> -->

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -37,25 +37,25 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>> -->
+        <!-- <version.org.jboss.bom>1.0.0.Final-redhat-1</version.org.jboss.bom>> -->
 
-        <hibernate.jpamodelgen.version>1.1.1.Final</hibernate.jpamodelgen.version>
+        <version.org.hibernate-jpamodelgen>1.1.1.Final</version.org.hibernate-jpamodelgen>
 
         <!-- Other dependency versions -->
-        <jstl.version>1.2</jstl.version>
+        <version.javax.servlet.jstl>1.2</version.javax.servlet.jstl>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -74,7 +74,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -82,7 +82,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-hibernate</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
-            <version>${jstl.version}</version>
+            <version>${version.javax.servlet.jstl}</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -173,7 +173,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
-            <version>${hibernate.jpamodelgen.version}</version>
+            <version>${version.org.hibernate-jpamodelgen}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -210,7 +210,7 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -218,7 +218,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -231,7 +231,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
         </plugins>
     </build>
@@ -250,7 +250,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.plugin.version}</version>
+                        <version>${version.surefire.plugin}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -302,7 +302,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>${war.plugin.version}</version>
+                        <version>${version.war.plugin}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
                             <warName>ROOT</warName>

--- a/kitchensink-ml-ear/jboss-as-kitchensink-ml-ear-ear/pom.xml
+++ b/kitchensink-ml-ear/jboss-as-kitchensink-ml-ear-ear/pom.xml
@@ -54,7 +54,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-ear-plugin</artifactId>
-            <version>${ear.plugin.version}</version>
+            <version>${version.ear.plugin}</version>
             <configuration>
                <!-- Tell Maven we are using Java EE 6 -->
                <version>6</version>
@@ -101,7 +101,7 @@
             <plugins>
                <plugin>
                   <artifactId>maven-ear-plugin</artifactId>
-                  <version>${ear.plugin.version}</version>
+                  <version>${version.ear.plugin}</version>
                   <configuration>
                      <outputDirectory>deployments</outputDirectory>
                   </configuration>

--- a/kitchensink-ml-ear/jboss-as-kitchensink-ml-ear-ejb/pom.xml
+++ b/kitchensink-ml-ear/jboss-as-kitchensink-ml-ear-ejb/pom.xml
@@ -99,7 +99,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-ejb-plugin</artifactId>
-            <version>${ejb.plugin.version}</version>
+            <version>${version.ejb.plugin}</version>
             <configuration>
                <!-- Tell Maven we are using EJB 3.1 -->
                <ejbVersion>3.1</ejbVersion>
@@ -122,7 +122,7 @@
             <plugins>
                <plugin>
                   <artifactId>maven-surefire-plugin</artifactId>
-                  <version>${surefire.plugin.version}</version>
+                  <version>${version.surefire.plugin}</version>
                   <configuration>
                      <skip>true</skip>
                   </configuration>

--- a/kitchensink-ml-ear/jboss-as-kitchensink-ml-ear-web/pom.xml
+++ b/kitchensink-ml-ear/jboss-as-kitchensink-ml-ear-web/pom.xml
@@ -96,7 +96,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>${war.plugin.version}</version>
+            <version>${version.war.plugin}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->

--- a/kitchensink-ml-ear/pom.xml
+++ b/kitchensink-ml-ear/pom.xml
@@ -41,7 +41,7 @@
 
         <!-- JBoss dependency versions -->
         <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>

--- a/kitchensink-ml-ear/pom.xml
+++ b/kitchensink-ml-ear/pom.xml
@@ -40,23 +40,23 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
+        <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>> -->
+        <!-- <version.org.jboss.bom>1.0.0.Final-redhat-1</version.org.jboss.bom>> -->
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <ear.plugin.version>2.6</ear.plugin.version>
-        <ejb.plugin.version>2.3</ejb.plugin.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.ear.plugin>2.6</version.ear.plugin>
+        <version.ejb.plugin>2.3</version.ejb.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -96,7 +96,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-hibernate</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -119,7 +119,7 @@
                     activates annotation processors -->
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${compiler.plugin.version}</version>
+                    <version>${version.compiler.plugin}</version>
                     <configuration>
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>
@@ -133,7 +133,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>${jboss.as.plugin.version}</version>
+                    <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                     <inherited>true</inherited>
                     <configuration>
                         <skip>true</skip>

--- a/kitchensink-ml/pom.xml
+++ b/kitchensink-ml/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>

--- a/kitchensink-ml/pom.xml
+++ b/kitchensink-ml/pom.xml
@@ -37,20 +37,20 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>> -->
+        <!-- <version.org.jboss.bom>1.0.0.Final-redhat-1</version.org.jboss.bom>> -->
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -71,14 +71,14 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-hibernate</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -204,7 +204,7 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -212,7 +212,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                 <version>${war.plugin.version}</version>
+                 <version>${version.war.plugin}</version>
                <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -225,7 +225,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                 <version>${jboss.as.plugin.version}</version>
+                 <version>${version.org.jboss.as.plugins.maven.plugin}</version>
            </plugin>
         </plugins>
     </build>
@@ -244,7 +244,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.plugin.version}</version>
+                        <version>${version.surefire.plugin}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -296,7 +296,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                         <version>${war.plugin.version}</version>
+                         <version>${version.war.plugin}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
                             <warName>ROOT</warName>

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -37,20 +37,20 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>> -->
+        <!-- <version.org.jboss.bom>1.0.0.Final-redhat-1</version.org.jboss.bom>> -->
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -71,14 +71,14 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-hibernate</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -204,7 +204,7 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -212,7 +212,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -225,7 +225,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
         </plugins>
     </build>
@@ -244,7 +244,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.plugin.version}</version>
+                        <version>${version.surefire.plugin}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -296,7 +296,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>${war.plugin.version}</version>
+                        <version>${version.war.plugin}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
                             <warName>ROOT</warName>

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>

--- a/log4j/pom.xml
+++ b/log4j/pom.xml
@@ -37,7 +37,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
         <!-- Other dependency versions -->

--- a/log4j/pom.xml
+++ b/log4j/pom.xml
@@ -37,15 +37,15 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- Other dependency versions -->
-        <log4j.version>1.2.16</log4j.version>
+        <version.log4j>1.2.16</version.log4j>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -58,7 +58,7 @@
 			<dependency>
 				<groupId>log4j</groupId>
 				<artifactId>log4j</artifactId>
-				<version>${log4j.version}</version>
+				<version>${version.log4j}</version>
 			</dependency>
 			<!-- Define the version of JBoss' Java EE 6 APIs we want to import. Any 
 				dependencies from org.jboss.spec will have their version defined by this 
@@ -72,7 +72,7 @@
 			<dependency>
 				<groupId>org.jboss.spec</groupId>
 				<artifactId>jboss-javaee-6.0</artifactId>
-				<version>${jboss.javaee6.spec.version}</version>
+				<version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -122,7 +122,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>${war.plugin.version}</version>
+				<version>${version.war.plugin}</version>
 				<configuration>
 					<!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
 					<failOnMissingWebXml>false</failOnMissingWebXml>
@@ -132,13 +132,13 @@
 			<plugin>
 				<groupId>org.jboss.as.plugins</groupId>
 				<artifactId>jboss-as-maven-plugin</artifactId>
-				<version>${jboss.as.plugin.version}</version>
+				<version>${version.org.jboss.as.plugins.maven.plugin}</version>
 			</plugin>
 			<!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation 
 				processors -->
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/logging-tools/pom.xml
+++ b/logging-tools/pom.xml
@@ -35,14 +35,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.logging.version>3.1.1.GA</jboss.logging.version>
-        <jboss.logging.processor.version>1.0.3.Final</jboss.logging.processor.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.logging>3.1.1.GA</version.org.jboss.logging>
+        <version.org.jboss.logging.processor>1.0.3.Final</version.org.jboss.logging.processor>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -64,7 +64,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -85,14 +85,14 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
-            <version>${jboss.logging.processor.version}</version>
+            <version>${version.org.jboss.logging.processor}</version>
             <scope>provided</scope>
         </dependency>
       <!--  jboss-logging API -->
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <version>${jboss.logging.version}</version>
+            <version>${version.org.jboss.logging}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -104,20 +104,20 @@
 
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
             </plugin>
 
          <!-- JBoss AS plugin to deploy war -->
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
 
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/logging-tools/pom.xml
+++ b/logging-tools/pom.xml
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.logging.version>3.1.1.GA</jboss.logging.version>
         <jboss.logging.processor.version>1.0.3.Final</jboss.logging.processor.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -36,7 +36,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
        <!-- other plugin versions -->

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -36,12 +36,12 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
        <!-- other plugin versions -->
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
-       <war.plugin.version>2.1.1</war.plugin.version>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
+       <version.war.plugin>2.1.1</version.war.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -63,7 +63,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -103,7 +103,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>${war.plugin.version}</version>
+            <version>${version.war.plugin}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -114,13 +114,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/numberguess/pom.xml
+++ b/numberguess/pom.xml
@@ -36,7 +36,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
        <!-- other plugin versions -->

--- a/numberguess/pom.xml
+++ b/numberguess/pom.xml
@@ -36,12 +36,12 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
        <!-- other plugin versions -->
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
-       <war.plugin.version>2.1.1</war.plugin.version>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
+       <version.war.plugin>2.1.1</version.war.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -63,7 +63,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -105,7 +105,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>${war.plugin.version}</version>
+            <version>${version.war.plugin}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -116,13 +116,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/payment-cdi-event/pom.xml
+++ b/payment-cdi-event/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>

--- a/payment-cdi-event/pom.xml
+++ b/payment-cdi-event/pom.xml
@@ -37,20 +37,20 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>> -->
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <!-- <version.org.jboss.bom>1.0.0.Final-redhat-1</version.org.jboss.bom>> -->
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -69,7 +69,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -77,7 +77,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-hibernate</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -131,7 +131,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -142,13 +142,13 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
         <!-- JBoss dependency versions -->
         <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
         <jboss.ejb.client.version>7.1.1.Final</jboss.ejb.client.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,51 +38,52 @@
         <!-- A base list of dependency and plugin version used in the various quick starts. -->
 
         <!-- JBoss dependency versions -->
-        <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
-        <jboss.ejb.client.version>7.1.1.Final</jboss.ejb.client.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
-        <jboss.logging.version>3.1.1.GA</jboss.logging.version>
-        <jboss.logging.processor.version>1.0.3.Final</jboss.logging.processor.version>
+        <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
+        <version.org.jboss.ejb.client>7.1.1.Final</version.org.jboss.ejb.client>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
+        <version.org.jboss.logging>3.1.1.GA</version.org.jboss.logging>
+        <version.org.jboss.logging.processor>1.0.3.Final</version.org.jboss.logging.processor>
 
-        <arquillian.version>1.0.0.Final</arquillian.version>
+        <version.org.jboss.arquillian>1.0.0.Final</version.org.jboss.arquillian>
 
-        <hibernate.common.annotations.version>3.2.0.Final</hibernate.common.annotations.version>
-        <hibernate.core.version>3.6.8.Final</hibernate.core.version>
-        <hibernate.em.version>3.6.8.Final</hibernate.em.version>
-        <hibernate.infinispan.version>3.6.8.Final</hibernate.infinispan.version>
-        <hibernate.jpamodelgen.version>1.1.1.Final</hibernate.jpamodelgen.version>
-        <hibernate.validator.version>4.2.0.Final</hibernate.validator.version>
+        <version.org.hibernate3.commons.annotations>3.2.0.Final</version.org.hibernate3.commons.annotations>
+        <version.org.hibernate>3.6.8.Final</version.org.hibernate>
+        <version.org.hibernate.em>3.6.8.Final</version.org.hibernate.em>
+        <version.org.hibernate.infinispan>3.6.8.Final</version.org.hibernate.infinispan>
+        <version.org.hibernate-jpamodelgen>1.1.1.Final</version.org.hibernate-jpamodelgen>
+        <version.org.hibernate.validator>4.2.0.Final</version.org.hibernate.validator>
         
-        <resteasy.version>2.2.2.GA</resteasy.version>
+        <version.org.jboss.resteasy>2.2.2.GA</version.org.jboss.resteasy>
         
-        <richfaces.version>4.2.0.Final</richfaces.version>
+        <version.org.richfaces>4.2.0.Final</version.org.richfaces>
         
         <!-- Other dependency versions -->
-        <apache.httpcomponents.version>4.1.4</apache.httpcomponents.version>
-        <dom4j.version>1.6</dom4j.version>
-        <gwt.version>2.4.0</gwt.version>
-        <jstl.version>1.2</jstl.version>
-        <junit.version>4.10</junit.version>
-        <log4j.version>1.2.16</log4j.version>
-        <m2e.version>1.0.0</m2e.version>
-        <osgi.version>4.2.0</osgi.version>
-        <wicket.version>1.5.5</wicket.version>
-        <wicket.cdi.version>1.2</wicket.cdi.version>
-        <wro4j.version>1.4.4</wro4j.version>
+        <version.org.apache.httpcomponents>4.1.4</version.org.apache.httpcomponents>
+        <version.dom4j>1.6</version.dom4j>
+        <version.com.google.gwt>2.4.0</version.com.google.gwt>
+        <version.javax.servlet.jstl>1.2</version.javax.servlet.jstl>
+        <version.junit>4.10</version.junit>
+        <version.log4j>1.2.16</version.log4j>
+        <version.org.eclipse.m2e>1.0.0</version.org.eclipse.m2e>
+        <version.org.osgi>4.2.0</version.org.osgi>
+        <version.org.apache.wicket>1.5.5</version.org.apache.wicket>
+        <version.net.ftlines.wicket-cdi>1.2</version.net.ftlines.wicket-cdi>
+        <version.ro.isdc.wro4j>1.4.4</version.ro.isdc.wro4j>
 
         <!-- other plugin versions -->
-        <apache.felix.plugin.version>2.3.4</apache.felix.plugin.version>
-        <clean.pluging.version>2.4.1</clean.pluging.version>
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <ear.plugin.version>2.6</ear.plugin.version>
-        <ejb.plugin.version>2.3</ejb.plugin.version>
-        <exec.plugin.version>1.2.1</exec.plugin.version>
-        <gwt.plugin.version>2.4.0</gwt.plugin.version>
-        <license.pluging.version>1.9.0</license.pluging.version>
-        <surefire.plugin.version>2.10</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.bundle.plugin>2.3.4</version.bundle.plugin>
+        <version.clean.plugin>2.4.1</version.clean.plugin>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.ear.plugin>2.6</version.ear.plugin>
+        <version.ejb.plugin>2.3</version.ejb.plugin>
+        <version.exec.plugin>1.2.1</version.exec.plugin>
+        <version.jar.plugin>2.2</version.jar.plugin>
+        <version.license.plugin>1.9.0</version.license.plugin>
+        <version.org.codehaus.mojo.gwt.maven.plugin>2.4.0</version.org.codehaus.mojo.gwt.maven.plugin>
+        <version.surefire.plugin>2.10</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -235,7 +236,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <inherited>true</inherited>
                 <configuration>
                     <skip>true</skip>

--- a/richfaces-validation/pom.xml
+++ b/richfaces-validation/pom.xml
@@ -40,7 +40,7 @@
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
 
         <hibernate.jpamodelgen.version>1.1.1.Final</hibernate.jpamodelgen.version>

--- a/richfaces-validation/pom.xml
+++ b/richfaces-validation/pom.xml
@@ -40,18 +40,18 @@
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
 
-        <hibernate.jpamodelgen.version>1.1.1.Final</hibernate.jpamodelgen.version>
-        <hibernate.validator.version>4.2.0.Final</hibernate.validator.version>
+        <version.org.hibernate-jpamodelgen>1.1.1.Final</version.org.hibernate-jpamodelgen>
+        <version.org.hibernate.validator>4.2.0.Final</version.org.hibernate.validator>
 
-        <richfaces.version>4.2.0.Final</richfaces.version>
+        <version.org.richfaces>4.2.0.Final</version.org.richfaces>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -69,7 +69,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -79,7 +79,7 @@
             <dependency>
                 <groupId>org.richfaces</groupId>
                 <artifactId>richfaces-bom</artifactId>
-                <version>${richfaces.version}</version>
+                <version>${version.org.richfaces}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate.validator.version}</version>
+            <version>${version.org.hibernate.validator}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
-            <version>${hibernate.jpamodelgen.version}</version>
+            <version>${version.org.hibernate-jpamodelgen}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -188,7 +188,7 @@
                 <!-- The Maven Surefire plugin tests your application. Here we ensure we are using a version compatible with Arquillian -->
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${surefire.plugin.version}</version>
+                    <version>${version.surefire.plugin}</version>
                 </plugin>
                 <!-- The JBoss AS plugin deploys your war to a local JBoss AS container -->
                 <!-- To use, set the JBOSS_HOME environment variable and run:
@@ -196,7 +196,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>${jboss.as.plugin.version}</version>
+                    <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -204,7 +204,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -213,7 +213,7 @@
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/servlet-async/pom.xml
+++ b/servlet-async/pom.xml
@@ -37,12 +37,12 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
        <!-- other plugin versions -->
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
-       <war.plugin.version>2.1.1</war.plugin.version>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
+       <version.war.plugin>2.1.1</version.war.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -62,7 +62,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -111,7 +111,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>${war.plugin.version}</version>
+            <version>${version.war.plugin}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -122,13 +122,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/servlet-async/pom.xml
+++ b/servlet-async/pom.xml
@@ -37,7 +37,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
        <!-- other plugin versions -->

--- a/servlet-filterlistener/pom.xml
+++ b/servlet-filterlistener/pom.xml
@@ -37,7 +37,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
        <!-- other plugin versions -->

--- a/servlet-filterlistener/pom.xml
+++ b/servlet-filterlistener/pom.xml
@@ -37,12 +37,12 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
        <!-- other plugin versions -->
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
-       <war.plugin.version>2.1.1</war.plugin.version>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
+       <version.war.plugin>2.1.1</version.war.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -62,7 +62,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -104,7 +104,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>${war.plugin.version}</version>
+            <version>${version.war.plugin}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -115,13 +115,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/servlet-security/pom.xml
+++ b/servlet-security/pom.xml
@@ -36,7 +36,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
        <!-- other plugin versions -->

--- a/servlet-security/pom.xml
+++ b/servlet-security/pom.xml
@@ -36,12 +36,12 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
        <!-- other plugin versions -->
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
-       <war.plugin.version>2.1.1</war.plugin.version>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
+       <version.war.plugin>2.1.1</version.war.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -61,7 +61,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -105,13 +105,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/shopping-cart/client/pom.xml
+++ b/shopping-cart/client/pom.xml
@@ -54,7 +54,7 @@
             <!-- Enforce Java 1.6 -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>${exec.plugin.version}</version>
+                <version>${version.exec.plugin}</version>
                 <configuration>
                     <mainClass>org.jboss.as.quickstarts.client.Client</mainClass>
                 </configuration>

--- a/shopping-cart/pom.xml
+++ b/shopping-cart/pom.xml
@@ -47,7 +47,7 @@
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <!-- Define the version of JBoss EJB Client we want to use. This 
             should match the JBoss AS version in use -->
         <jboss.ejb.client.version>7.1.1.Final</jboss.ejb.client.version>

--- a/shopping-cart/pom.xml
+++ b/shopping-cart/pom.xml
@@ -47,26 +47,26 @@
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of JBoss EJB Client we want to use. This 
             should match the JBoss AS version in use -->
-        <jboss.ejb.client.version>7.1.1.Final</jboss.ejb.client.version>
+        <version.org.jboss.ejb.client>7.1.1.Final</version.org.jboss.ejb.client>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 7.1.1.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.ejb.client.version>7.1.1.Final-redhat-1</jboss.ejb.client.version> -->
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <!-- <version.org.jboss.ejb.client>7.1.1.Final-redhat-1</version.org.jboss.ejb.client> -->
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 3.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.javaee6.spec.version>3.0.0.Final-redhat-1</jboss.javaee6.spec.version> -->
+        <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final-redhat-1</version.org.jboss.spec.jboss.javaee.6.0> -->
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <exec.plugin.version>1.2.1</exec.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.exec.plugin>1.2.1</version.exec.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -83,7 +83,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -99,7 +99,7 @@
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-ejb-client-bom</artifactId>
-                <version>${jboss.ejb.client.version}</version>
+                <version>${version.org.jboss.ejb.client}</version>
                 <type>pom</type>
             </dependency>
         </dependencies>
@@ -114,7 +114,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <inherited>true</inherited>
                 <configuration>
                     <skip>true</skip>

--- a/shopping-cart/server/pom.xml
+++ b/shopping-cart/server/pom.xml
@@ -59,7 +59,7 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/tasks-jsf/pom.xml
+++ b/tasks-jsf/pom.xml
@@ -40,7 +40,7 @@
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
         <!-- Alternatively, comment out the above line, and un-comment the line below to
         use version 1.0.0.Final-redhat-1 which is a release certified

--- a/tasks-jsf/pom.xml
+++ b/tasks-jsf/pom.xml
@@ -40,19 +40,19 @@
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the line below to
         use version 1.0.0.Final-redhat-1 which is a release certified
         to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 maven repository. -->
         <!--
-        <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>
+        <version.org.jboss.bom>1.0.0.Final-redhat-1</version.org.jboss.bom>
         -->
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -70,7 +70,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -140,7 +140,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch
                         up! -->
@@ -151,7 +151,7 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -161,7 +161,7 @@
                 as part of project build -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.plugin.version}</version>
+                <version>${version.surefire.plugin}</version>
             </plugin>
             <!-- The JBoss AS plugin deploys your war to a local JBoss
                 AS container -->
@@ -169,7 +169,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
         </plugins>
     </build>

--- a/tasks-rs/pom.xml
+++ b/tasks-rs/pom.xml
@@ -30,19 +30,19 @@
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the line below to
         use version 1.0.0.Final-redhat-1 which is a release certified
         to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 maven repository. -->
         <!--
-        <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version>
+        <version.org.jboss.bom>1.0.0.Final-redhat-1</version.org.jboss.bom>
         -->
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -60,7 +60,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -139,7 +139,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch
                         up! -->
@@ -150,7 +150,7 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -160,7 +160,7 @@
                 as part of project build -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.plugin.version}</version>
+                <version>${version.surefire.plugin}</version>
             </plugin>
             <!-- The JBoss AS plugin deploys your war to a local JBoss
                 AS container -->
@@ -168,7 +168,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
         </plugins>
     </build>

--- a/tasks-rs/pom.xml
+++ b/tasks-rs/pom.xml
@@ -30,7 +30,7 @@
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
         <!-- Alternatively, comment out the above line, and un-comment the line below to
         use version 1.0.0.Final-redhat-1 which is a release certified

--- a/tasks/pom.xml
+++ b/tasks/pom.xml
@@ -41,19 +41,19 @@
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.bom.version>1.0.0.Final-redhat-1</jboss.bom.version> -->
+        <!-- <version.org.jboss.bom>1.0.0.Final-redhat-1</version.org.jboss.bom> -->
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <surefire.plugin.version>2.10</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.10</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -133,7 +133,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -144,7 +144,7 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -153,7 +153,7 @@
             <!-- Versions prior 2.9 contains a bug -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.plugin.version}</version>
+                <version>${version.surefire.plugin}</version>
             </plugin>
             <!-- The JBoss AS plugin deploys your war to a local JBoss AS 
                 container -->
@@ -163,7 +163,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -205,7 +205,7 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-managed</artifactId>
-                    <version>${jboss.as.version}</version>
+                    <version>${version.org.jboss.as}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -220,7 +220,7 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-remote</artifactId>
-                    <version>${jboss.as.version}</version>
+                    <version>${version.org.jboss.as}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/tasks/pom.xml
+++ b/tasks/pom.xml
@@ -42,7 +42,7 @@
 
         <!-- JBoss dependency versions -->
         <jboss.as.version>7.1.1.Final</jboss.as.version>
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.0.Final-redhat-1 which is a release certified 

--- a/temperature-converter/pom.xml
+++ b/temperature-converter/pom.xml
@@ -37,12 +37,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -64,7 +64,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -113,7 +113,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -124,13 +124,13 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/temperature-converter/pom.xml
+++ b/temperature-converter/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
         <!-- other plugin versions -->

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -36,7 +36,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
        <!-- other plugin versions -->

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -36,12 +36,12 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
        <!-- JBoss dependency versions -->
-       <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-       <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+       <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+       <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
        <!-- other plugin versions -->
-       <compiler.plugin.version>2.3.1</compiler.plugin.version>
-       <war.plugin.version>2.1.1</war.plugin.version>
+       <version.compiler.plugin>2.3.1</version.compiler.plugin>
+       <version.war.plugin>2.1.1</version.war.plugin>
 
        <!-- maven-compiler-plugin -->
        <maven.compiler.target>1.6</maven.compiler.target>
@@ -63,7 +63,7 @@
          <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
-            <version>${jboss.javaee6.spec.version}</version>
+            <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -129,7 +129,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>${war.plugin.version}</version>
+            <version>${version.war.plugin}</version>
             <configuration>
                <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
                   up! -->
@@ -140,13 +140,13 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${jboss.as.plugin.version}</version>
+            <version>${version.org.jboss.as.plugins.maven.plugin}</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-             <version>${compiler.plugin.version}</version>
+             <version>${version.compiler.plugin}</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/wicket-ear/ear/pom.xml
+++ b/wicket-ear/ear/pom.xml
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>${ear.plugin.version}</version>
+                <version>${version.ear.plugin}</version>
                 <configuration>
                     <!-- Tell Maven we are using Java EE 6 -->
                     <version>6</version>

--- a/wicket-ear/ejb/pom.xml
+++ b/wicket-ear/ejb/pom.xml
@@ -65,7 +65,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ejb-plugin</artifactId>
-                <version>${ejb.plugin.version}</version>
+                <version>${version.ejb.plugin}</version>
                 <configuration>
                     <ejbVersion>3.1</ejbVersion>
                 </configuration>

--- a/wicket-ear/pom.xml
+++ b/wicket-ear/pom.xml
@@ -46,23 +46,23 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 3.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.javaee6.spec.version>3.0.0.Final-redhat-1</jboss.javaee6.spec.version> -->
+        <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final-redhat-1</version.org.jboss.spec.jboss.javaee.6.0> -->
 
         <!-- Other dependency versions -->
-        <wicket.version>1.5.5</wicket.version>
-        <wicket.cdi.version>1.2</wicket.cdi.version>
+        <version.org.apache.wicket>1.5.5</version.org.apache.wicket>
+        <version.net.ftlines.wicket-cdi>1.2</version.net.ftlines.wicket-cdi>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <ear.plugin.version>2.6</ear.plugin.version>
-        <ejb.plugin.version>2.3</ejb.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.ear.plugin>2.6</version.ear.plugin>
+        <version.ejb.plugin>2.3</version.ejb.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -82,7 +82,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -91,14 +91,14 @@
             <dependency>
                 <groupId>org.apache.wicket</groupId>
                 <artifactId>wicket-core</artifactId>
-                <version>${wicket.version}</version>
+                <version>${version.org.apache.wicket}</version>
             </dependency>
 
             <!-- Wicket Java EE integration. -->
             <dependency>
                 <groupId>net.ftlines.wicket-cdi</groupId>
                 <artifactId>wicket-cdi</artifactId>
-                <version>${wicket.cdi.version}</version>
+                <version>${version.net.ftlines.wicket-cdi}</version>
             </dependency>
 
             <!-- EJB JAR module. -->
@@ -126,7 +126,7 @@
                     activates annotation processors -->
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${compiler.plugin.version}</version>
+                    <version>${version.compiler.plugin}</version>
                     <configuration>
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>
@@ -140,7 +140,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>${jboss.as.plugin.version}</version>
+                    <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                     <inherited>true</inherited>
                     <configuration>
                         <skip>true</skip>

--- a/wicket-ear/pom.xml
+++ b/wicket-ear/pom.xml
@@ -46,7 +46,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 3.0.0.Final-redhat-1 which is a release certified 

--- a/wicket-war/pom.xml
+++ b/wicket-war/pom.xml
@@ -41,21 +41,21 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 3.0.0.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <jboss.javaee6.spec.version>3.0.0.Final-redhat-1</jboss.javaee6.spec.version> -->
+        <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final-redhat-1</version.org.jboss.spec.jboss.javaee.6.0> -->
 
         <!-- Other dependency versions -->
-        <wicket.version>1.5.5</wicket.version>
-        <wicket.cdi.version>1.2</wicket.cdi.version>
+        <version.org.apache.wicket>1.5.5</version.org.apache.wicket>
+        <version.net.ftlines.wicket-cdi>1.2</version.net.ftlines.wicket-cdi>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -75,7 +75,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -84,14 +84,14 @@
             <dependency>
                 <groupId>org.apache.wicket</groupId>
                 <artifactId>wicket-core</artifactId>
-                <version>${wicket.version}</version>
+                <version>${version.org.apache.wicket}</version>
             </dependency>
 
             <!-- Wicket Java EE integration. -->
             <dependency>
                 <groupId>net.ftlines.wicket-cdi</groupId>
                 <artifactId>wicket-cdi</artifactId>
-                <version>${wicket.cdi.version}</version>
+                <version>${version.net.ftlines.wicket-cdi}</version>
             </dependency>
 
             <!-- EJB JAR module. -->
@@ -205,7 +205,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <configuration>
                     <fileNames>
                         <fileName>target/${build.finalName}.war</fileName>
@@ -216,7 +216,7 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/wicket-war/pom.xml
+++ b/wicket-war/pom.xml
@@ -41,7 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 3.0.0.Final-redhat-1 which is a release certified 

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -37,13 +37,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -65,7 +65,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -75,7 +75,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-transactions</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -148,7 +148,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -163,13 +163,13 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates
           annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -192,7 +192,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>${war.plugin.version}</version>
+                        <version>${version.war.plugin}</version>
                         <configuration>
                             <!-- Ignore the jboss-web.xml. This is needed to deploy the Web service into the root context.
                                 This is only needed by Openshift -->
@@ -201,7 +201,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.plugin.version}</version>
+                        <version>${version.surefire.plugin}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -250,7 +250,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>${war.plugin.version}</version>
+                        <version>${version.war.plugin}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
                             <warName>ROOT</warName>

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
 
         <!-- other plugin versions -->

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
 
         <!-- other plugin versions -->

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -37,13 +37,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -66,7 +66,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -77,7 +77,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-transactions</artifactId>
-                <version>${jboss.bom.version}</version>
+                <version>${version.org.jboss.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -149,7 +149,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -158,7 +158,7 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -181,7 +181,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.plugin.version}</version>
+                        <version>${version.surefire.plugin}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
 
         <!-- other plugin versions -->

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -37,13 +37,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.bom.version>1.0.0.Final</jboss.bom.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.bom>1.0.0.Final</version.org.jboss.bom>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <surefire.plugin.version>2.4.3</surefire.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.4.3</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -65,7 +65,7 @@
          <dependency>
             <groupId>org.jboss.bom</groupId>
             <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-            <version>${jboss.bom.version}</version>
+            <version>${version.org.jboss.bom}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -75,7 +75,7 @@
          <dependency>
             <groupId>org.jboss.bom</groupId>
             <artifactId>jboss-javaee-6.0-with-transactions</artifactId>
-            <version>${jboss.bom.version}</version>
+            <version>${version.org.jboss.bom}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <configuration>
                   <skip>true</skip>
                 </configuration>
@@ -156,7 +156,7 @@
           annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -179,7 +179,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.plugin.version}</version>
+                        <version>${version.surefire.plugin}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>

--- a/xml-dom4j/pom.xml
+++ b/xml-dom4j/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
         <!-- Other dependency versions -->

--- a/xml-dom4j/pom.xml
+++ b/xml-dom4j/pom.xml
@@ -37,15 +37,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- Other dependency versions -->
-        <dom4j.version>1.6</dom4j.version>
+        <version.dom4j>1.6</version.dom4j>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -68,7 +68,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>${jboss.javaee6.spec.version}</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>${dom4j.version}</version>
+            <version>${version.dom4j}</version>
         </dependency>
     </dependencies>
 
@@ -137,7 +137,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war.plugin.version}</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to 
                         catch up! -->
@@ -148,13 +148,13 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${jboss.as.plugin.version}</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/xml-jaxp/pom.xml
+++ b/xml-jaxp/pom.xml
@@ -37,12 +37,12 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
-        <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- other plugin versions -->
-        <compiler.plugin.version>2.3.1</compiler.plugin.version>
-        <war.plugin.version>2.1.1</war.plugin.version>
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -65,7 +65,7 @@
 			<dependency>
 				<groupId>org.jboss.spec</groupId>
 				<artifactId>jboss-javaee-6.0</artifactId>
-				<version>${jboss.javaee6.spec.version}</version>
+				<version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -125,7 +125,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>${war.plugin.version}</version>
+				<version>${version.war.plugin}</version>
 				<configuration>
 					<!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
 					<failOnMissingWebXml>false</failOnMissingWebXml>
@@ -135,13 +135,13 @@
 			<plugin>
 				<groupId>org.jboss.as.plugins</groupId>
 				<artifactId>jboss-as-maven-plugin</artifactId>
-				<version>${jboss.as.plugin.version}</version>
+				<version>${version.org.jboss.as.plugins.maven.plugin}</version>
 			</plugin>
 			<!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation 
 				processors -->
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler.plugin.version}</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/xml-jaxp/pom.xml
+++ b/xml-jaxp/pom.xml
@@ -37,7 +37,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <jboss.as.plugin.version>7.1.1.Final</jboss.as.plugin.version>
+        <jboss.as.plugin.version>7.2.Final</jboss.as.plugin.version>
         <jboss.javaee6.spec.version>3.0.0.Final</jboss.javaee6.spec.version>
 
         <!-- other plugin versions -->


### PR DESCRIPTION
Changed the version properties to match the BOM and jboss-as-parent POM files.

Updated the AS plugin version. This adds the new `jboss-as:run` goal as well as the ability to execute commands. Further information at https://docs.jboss.org/jbossas/7/plugins/maven/latest/.

Included minor fix for 2 pom versions.
