### PR TITLE
[JDF-152] helloworld-mdb demonstrates JMS topic

### DIFF
--- a/helloworld-mdb/README.md
+++ b/helloworld-mdb/README.md
@@ -1,17 +1,20 @@
 helloworld-mdb: Helloword Using an MDB (Message-Driven Bean)
 ============================================================
-Author: Serge Pagop, Andy Taylor
-Level: Intermediate
-Technologies: JMS, EJB, MDB
-Summary: Demonstrates the use of JMS 1.1 and EJB 3.1 Message-Driven Bean
+Author: Serge Pagop, Andy Taylor, Jeff Mesnil  
+Level: Intermediate  
+Technologies: JMS, EJB, MDB  
+Summary: Demonstrates the use of JMS 1.1 and EJB 3.1 Message-Driven Bean  
 Target Product: EAP
 
 What is it?
 -----------
 
-This example demonstrates the use of *JMS 1.1* and *EJB 3.1 Message-Driven Bean* in JBoss AS 7.1.0.
+This example demonstrates the use of *JMS 1.1* and *EJB 3.1 Message-Driven Bean* in JBoss Enterprise Application Platform 6 or JBoss AS 7.1.0.
 
-This project creates a queue named `HELLOWORLDMDBQueue` which is bound in JNDI as `java:/queue/HELLOWORLDMDBQueue`.
+This project creates two JMS resources:
+
+* A queue named `HELLOWORLDMDBQueue` bound in JNDI as `java:/queue/HELLOWORLDMDBQueue`
+* A topic named `HELLOWORLDMDBTopic` bound in JNDI as `java:/topic/HELLOWORLDMDBTopic`
 
 
 System requirements
@@ -49,25 +52,32 @@ _NOTE: The following build command assumes you have configured your Maven user s
 
         mvn clean package jboss-as:deploy
 
-4. This will deploy `target/jboss-as-helloworld-mdb.war` to the running instance of the server.
+4. This will deploy `target/jboss-as-helloworld-mdb.war` to the running instance of the server. Look at the JBoss Application Server console or Server log and you should see log messages corresponding to the deployment of the message-driven beans and the JMS destinations:
 
+        14:11:01,020 INFO org.hornetq.core.server.impl.HornetQServerImpl trying to deploy queue jms.queue.HELLOWORLDMDBQueue
+        14:11:01,029 INFO org.jboss.as.messaging JBAS011601: Bound messaging object to jndi name java:/queue/HELLOWORLDMDBQueue
+        14:11:01,030 INFO org.hornetq.core.server.impl.HornetQServerImpl trying to deploy queue jms.topic.HELLOWORLDMDBTopic
+        14:11:01,060 INFO org.jboss.as.ejb3 JBAS014142: Started message driven bean 'HelloWorldQueueMDB' with 'hornetq-ra' resource adapter
+        14:11:01,060 INFO org.jboss.as.ejb3 JBAS014142: Started message driven bean 'HelloWorldQTopicMDB' with 'hornetq-ra' resource adapter
+        14:11:01,070 INFO org.jboss.as.messaging JBAS011601: Bound messaging object to jndi name java:/topic/HELLOWORLDMDBTopic
 
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-as-helloworld-mdb/>.
+The application will be running at the following URL: <http://localhost:8080/jboss-as-helloworld-mdb/> and will send some messages to the queue.
 
+To send messages to the topic, use the following URL: <http://localhost:8080/jboss-as-helloworld-mdb/HelloWorldMDBServletClient?topic>
 
 Investigate the Server Console Output
 -------------------------
 
 Look at the JBoss Application Server console or Server log and you should see log messages like the following:
 
-    15:42:35,453 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-47 (group:HornetQ-client-global-threads-1267410030)) Received Message: This is message 1
-    15:42:35,455 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-46 (group:HornetQ-client-global-threads-1267410030)) Received Message: This is message 2
-    15:42:35,457 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-50 (group:HornetQ-client-global-threads-1267410030)) Received Message: This is message 3
-    15:42:35,478 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-53 (group:HornetQ-client-global-threads-1267410030)) Received Message: This is message 5
-    15:42:35,481 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-52 (group:HornetQ-client-global-threads-1267410030)) Received Message: This is message 4
+    17:51:52,122 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldQueueMDB] (Thread-1 (HornetQ-client-global-threads-26912020)) Received Message from queue: This is message 1
+    17:51:52,123 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldQueueMDB] (Thread-11 (HornetQ-client-global-threads-26912020)) Received Message from queue: This is message 2
+    17:51:52,124 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldQueueMDB] (Thread-12 (HornetQ-client-global-threads-26912020)) Received Message from queue: This is message 5
+    17:51:52,135 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldQueueMDB] (Thread-13 (HornetQ-client-global-threads-26912020)) Received Message from queue: This is message 4
+    17:51:52,136 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldQueueMDB] (Thread-14 (HornetQ-client-global-threads-26912020)) Received Message from queue: This is message 3
 
 
 Undeploy the Archive
@@ -137,71 +147,7 @@ Copy the source for the `helloworld-mdb` quickstart into this new git repository
     
 ### Configure the OpenShift Server
 
-Next, you must enable HornetQ messaging provider. Open the `.openshift/config/standalone.xml` file (this file may be hidden) in an editor and make the following changes:
-
-1. If the following extension does not exist, add it under the `<extensions>` element:
-
-        <extension module="org.jboss.as.messaging"/>
-2. If the following `<mdb>` elements are commented out or missing from the the `ejb3` subsytem, un-comment or add them:
-
-        <mdb>
-            <resource-adapter-ref resource-adapter-name="hornetq-ra" />
-            <bean-instance-pool-ref pool-name="mdb-strict-max-pool" />
-        </mdb>
-3. If the messaging subsystem is not already configured under the `<profile>` element, copy the following under the `<profile>` element to enable and configure HornetQ:
-
-        <subsystem xmlns='urn:jboss:domain:messaging:1.1'>
-            <hornetq-server>
-                <persistence-enabled>true</persistence-enabled>
-                <journal-file-size>102400</journal-file-size>
-                <journal-min-files>2</journal-min-files>
-                <connectors>
-                    <in-vm-connector name='in-vm' server-id='0' />
-                </connectors>
-                <acceptors>
-                    <in-vm-acceptor name='in-vm' server-id='0' />
-                </acceptors>
-                <address-settings>
-                    <address-setting match='#'>
-                        <dead-letter-address>jms.queue.DLQ</dead-letter-address>
-                        <expiry-address>jms.queue.ExpiryQueue</expiry-address>
-                        <redelivery-delay>0</redelivery-delay>
-                        <max-size-bytes>20971520</max-size-bytes>
-                        <address-full-policy>PAGE</address-full-policy>
-                        <message-counter-history-day-limit>10</message-counter-history-day-limit>
-                    </address-setting>
-                </address-settings>
-                <jms-connection-factories>
-                    <connection-factory name='InVmConnectionFactory'>
-                        <connectors>
-                            <connector-ref connector-name='in-vm' />
-                        </connectors>
-                        <entries>
-                            <entry name='java:/ConnectionFactory' />
-                        </entries>
-                    </connection-factory>
-                    <connection-factory name='RemoteConnectionFactory'>
-                        <connectors>
-                            <connector-ref connector-name='in-vm' />
-                        </connectors>
-                        <entries>
-                            <entry name='RemoteConnectionFactory' />
-                        </entries>
-                    </connection-factory>
-                    <pooled-connection-factory name='hornetq-ra'>
-                        <transaction mode='xa' />
-                        <connectors>
-                            <connector-ref connector-name='in-vm' />
-                        </connectors>
-                        <entries>
-                            <entry name='java:/JmsXA' />
-                        </entries>
-                    </pooled-connection-factory>
-                </jms-connection-factories>
-                <jms-destinations />
-                <security-enabled>false</security-enabled>
-            </hornetq-server>
-        </subsystem>
+HornetQ is enabled by default in `.openshift/config/standalone.xml`. There is nothing to do to be able to send and receive messages from OpenShift.
 
 ### Deploy the OpenShift Application
 
@@ -219,21 +165,22 @@ Note that the `openshift` profile in the `pom.xml` file is activated by OpenShif
 
 When the push command returns you can test the application by getting the following URL either via a browser or using tools such as curl or wget. Be sure to replace the `quickstart` in the URL with your domain name.
 
-* <http://helloworldmdb-quickstart.rhcloud.com/> 
+* <http://helloworldmdb-quickstart.rhcloud.com/> to send messages to the queue
+* <http://helloworldmdb-quickstart.rhcloud.com/HelloWorldMDBServletClient?topic> to send messages to the topic
 
 If the application has run succesfully you should see some output in the browser.
 
-now you can look at the output of the server by running the following command:
+Now you can look at the output of the server by running the following command:
 
     rhc app status -a helloworldmdb
 
 This will show the tail of the servers log which should show something like the following.
 
-    2012/03/02 05:52:33,065 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-0 (HornetQ-client-global-threads-1772719)) Received Message: This is message 4
-    2012/03/02 05:52:33,065 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-1 (HornetQ-client-global-threads-1772719)) Received Message: This is message 1
-    2012/03/02 05:52:33,067 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-6 (HornetQ-client-global-threads-1772719)) Received Message: This is message 5
-    2012/03/02 05:52:33,065 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-3 (HornetQ-client-global-threads-1772719)) Received Message: This is message 3
-    2012/03/02 05:52:33,065 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-2 (HornetQ-client-global-threads-1772719)) Received Message: This is message 2
+    2012/03/02 05:52:33,065 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-0 (HornetQ-client-global-threads-1772719)) Received Message from queue: This is message 4
+    2012/03/02 05:52:33,065 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-1 (HornetQ-client-global-threads-1772719)) Received Message from queue: This is message 1
+    2012/03/02 05:52:33,067 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-6 (HornetQ-client-global-threads-1772719)) Received Message from queue: This is message 5
+    2012/03/02 05:52:33,065 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-3 (HornetQ-client-global-threads-1772719)) Received Message from queue: This is message 3
+    2012/03/02 05:52:33,065 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldMDB] (Thread-2 (HornetQ-client-global-threads-1772719)) Received Message from queue: This is message 2
 
 
 You can use the OpenShift command line tools or the OpenShift web console to discover and control the application.

--- a/helloworld-mdb/cheatsheets/helloworld-mdb.xml
+++ b/helloworld-mdb/cheatsheets/helloworld-mdb.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?> 
-<!-- JBoss, Home of Professional Open Source Copyright 2012, Red Hat, Inc. 
-    and/or its affiliates, and individual contributors by the @authors tag. See 
-    the copyright.txt in the distribution for a full listing of individual contributors. 
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not 
-    use this file except in compliance with the License. You may obtain a copy 
+<!-- JBoss, Home of Professional Open Source Copyright 2012, Red Hat, Inc.
+    and/or its affiliates, and individual contributors by the @authors tag. See
+    the copyright.txt in the distribution for a full listing of individual contributors.
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License. You may obtain a copy
     of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
-    by applicable law or agreed to in writing, software distributed under the 
-    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+    by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
     OF ANY KIND, either express or implied. See the License for the specific 
     language governing permissions and limitations under the License. -->
 <cheatsheet title="EJB 3.1 Message-Driven Bean + Servlet 3.0 - HelloWorldMDB">
@@ -25,13 +25,13 @@ Message-Driven Bean (MDB) is an enterprise bean that can be used in an Java EE 6
         title="The helloworld mdb example in depth">
      <description>
     	 The helloworld mdb is very simple - all it does is send several messages by a sevlet 3.0 component.
-The helloworld mdb example is comprised a servlet 3.0 as client <b>HelloWorldMDBServletClient</b> with a context <b>@WebServlet("/HelloWorldMDBServletClient")</b> that send several messages to the queue "queue/HELLOWORLDMDBQueue" and a message-driven bean, that processes asynchronously messages from the specific queue.
-The servlet client injects a connection factory <b>@@Resource(mappedName = "java:/ConnectionFactory") private static ConnectionFactory connectionFactory;</b> to create a connection and a queue <b>@Resource(mappedName = "java:/queue/HELLOWORLDMDBQueue") private static Queue queue;</b> where messages need to be send. 
+The helloworld mdb example is comprised a servlet 3.0 as client <b>HelloWorldMDBServletClient</b> with a context <b>@WebServlet("/HelloWorldMDBServletClient")</b> that send several messages to a queue "queue/HELLOWORLDMDBQueue" or a topic "topic/HELLOWORLDMDBTopic" and a message-driven bean, that processes asynchronously messages from the specific queue.
+The servlet client injects a connection factory <b>@@Resource(mappedName = "java:/ConnectionFactory") private ConnectionFactory connectionFactory;</b> to create a connection and a queue <b>@Resource(mappedName = "java:/queue/HELLOWORLDMDBQueue") private Queue queue;</b> and a topic <b>@Resource(mappedName = "java:/topic/HELLOWORLDMDBTopic") private Topic topic;</b>where messages need to be send. 
 The message-driven bean class <b>HelloWorldMDB</b> achieves the requirements of a typical JMS listener through it annotation with <b>@MessageDriven(name = "HelloWorldMDB", activationConfig = {
 		@ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
 		@ActivationConfigProperty(propertyName = "destination", propertyValue = "queue/HELLOWORLDMDBQueue"),
 		@ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge") })</b>
-The message-driven bean processes the messages and print and print <b>(Thread-3 (group:HornetQ-client-global-threads-343422187)) Received Message: This is message 3</b><br/><b>(Thread-4 (group:HornetQ-client-global-threads-343422187)) Received Message: This is message 4</b><br/><b>(Thread-2 (group:HornetQ-client-global-threads-343422187)) Received Message: This is message 2</b><br/><b>(Thread-0 (group:HornetQ-client-global-threads-343422187)) Received Message: This is message 0</b><br/> on the log console. 
+The message-driven bean processes the messages and print and print <b>(Thread-3 (group:HornetQ-client-global-threads-343422187)) Received Message from queue: This is message 3</b><br/><b>(Thread-4 (group:HornetQ-client-global-threads-343422187)) Received Message from queue: This is message 4</b><br/><b>(Thread-2 (group:HornetQ-client-global-threads-343422187)) Received Message from queue: This is message 2</b><br/><b>(Thread-0 (group:HornetQ-client-global-threads-343422187)) Received Message from queue: This is message 0</b><br/> on the log console. 
 For sending message uses this url <b>http://localhost:8080//jboss-as-helloworld-mdb/HelloWorldMDBServletClient</b>.
     </description>         
   </item>
@@ -54,8 +54,16 @@ For sending message uses this url <b>http://localhost:8080//jboss-as-helloworld-
 		<action
 			pluginId="org.jboss.tools.project.examples.cheatsheet"
 			class="org.jboss.tools.project.examples.cheatsheet.actions.OpenFileInEditor"
-			param1="/jboss-as-helloworld-mdb/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldMDB.java"/>
+			param1="/jboss-as-helloworld-mdb/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldQueueMDB.java"/>
 	  </subitem>
+        <subitem
+            label="We Create message-driven bean to process messages from the topic."
+            skip="true">
+            <action
+                 pluginId="org.jboss.tools.project.examples.cheatsheet"
+                 class="org.jboss.tools.project.examples.cheatsheet.actions.OpenFileInEditor"
+                 param1="/jboss-as-helloworld-mdb/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldTopicMDB.java"/>
+    </subitem>
   </item>  
   <item
         skip="true"

--- a/helloworld-mdb/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldQueueMDB.java
+++ b/helloworld-mdb/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldQueueMDB.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.mdb;
+
+import java.util.logging.Logger;
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+
+
+/**
+ * <p>
+ * A simple Message Driven Bean that asynchronously receives and processes the
+ * messages that are sent to the queue.
+ * </p>
+ * 
+ * @author Serge Pagop (spagop@redhat.com)
+ * 
+ */
+@MessageDriven(name = "HelloWorldQueueMDB", activationConfig = {
+		@ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
+		@ActivationConfigProperty(propertyName = "destination", propertyValue = "queue/HELLOWORLDMDBQueue"),
+		@ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge") })
+public class HelloWorldQueueMDB implements MessageListener {
+
+	private final static Logger LOGGER = Logger.getLogger(HelloWorldQueueMDB.class
+			.toString());
+
+	/**
+	 * @see MessageListener#onMessage(Message)
+	 */
+	public void onMessage(Message rcvMessage) {
+		TextMessage msg = null;
+		try {
+			if (rcvMessage instanceof TextMessage) {
+				msg = (TextMessage) rcvMessage;
+				LOGGER.info("Received Message from queue: " + msg.getText());
+			} else {
+				LOGGER.warning("Message of wrong type: "
+						+ rcvMessage.getClass().getName());
+			}
+		} catch (JMSException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/helloworld-mdb/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldTopicMDB.java
+++ b/helloworld-mdb/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldTopicMDB.java
@@ -28,19 +28,19 @@ import javax.jms.TextMessage;
 /**
  * <p>
  * A simple Message Driven Bean that asynchronously receives and processes the
- * messages that are sent to the queue.
+ * messages that are sent to the topic.
  * </p>
  * 
  * @author Serge Pagop (spagop@redhat.com)
  * 
  */
-@MessageDriven(name = "HelloWorldMDB", activationConfig = {
-		@ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
-		@ActivationConfigProperty(propertyName = "destination", propertyValue = "queue/HELLOWORLDMDBQueue"),
+@MessageDriven(name = "HelloWorldQTopicMDB", activationConfig = {
+		@ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
+		@ActivationConfigProperty(propertyName = "destination", propertyValue = "topic/HELLOWORLDMDBTopic"),
 		@ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge") })
-public class HelloWorldMDB implements MessageListener {
+public class HelloWorldTopicMDB implements MessageListener {
 
-	private final static Logger LOGGER = Logger.getLogger(HelloWorldMDB.class
+	private final static Logger LOGGER = Logger.getLogger(HelloWorldTopicMDB.class
 			.toString());
 
 	/**
@@ -51,7 +51,7 @@ public class HelloWorldMDB implements MessageListener {
 		try {
 			if (rcvMessage instanceof TextMessage) {
 				msg = (TextMessage) rcvMessage;
-				LOGGER.info("Received Message: " + msg.getText());
+				LOGGER.info("Received Message from topic: " + msg.getText());
 			} else {
 				LOGGER.warning("Message of wrong type: "
 						+ rcvMessage.getClass().getName());

--- a/helloworld-mdb/src/main/java/org/jboss/as/quickstarts/servlet/HelloWorldMDBServletClient.java
+++ b/helloworld-mdb/src/main/java/org/jboss/as/quickstarts/servlet/HelloWorldMDBServletClient.java
@@ -22,11 +22,13 @@ import java.io.PrintWriter;
 import javax.annotation.Resource;
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
+import javax.jms.Topic;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -35,7 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * <p>
- * A simple servlet 3 as client that sends several messages to a queue.
+ * A simple servlet 3 as client that sends several messages to a queue or a topic.
  * </p>
  * 
  * <p>
@@ -59,20 +61,30 @@ public class HelloWorldMDBServletClient extends HttpServlet {
 	@Resource(mappedName = "java:/queue/HELLOWORLDMDBQueue")
 	private Queue queue;
 
+	@Resource(mappedName = "java:/topic/HELLOWORLDMDBTopic")
+	private Topic topic;
+
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp)
 			throws ServletException, IOException {
 		resp.setContentType("text/html");
 		PrintWriter out = resp.getWriter();
 		Connection connection = null;
-		out.write("<h1>Quickstart: Example demonstrates the use of *JMS 1.1* and *EJB 3.1 Message-Driven Bean* in JBoss AS 7.1.0.</h1>");
+		out.write("<h1>Quickstart: Example demonstrates the use of <strong>JMS 1.1</strong> and <strong>EJB 3.1 Message-Driven Bean</strong> in JBoss Enterprise Application 6 or JBoss AS 7.1.0.</h1>");
 		try {
+		    Destination destination;
+		    if (req.getParameterMap().keySet().contains("topic")) {
+		        destination = topic;
+		    } else {
+		        destination = queue;
+		    }
+		    out.write("<p>Sending messages to <em>" + destination + "</em></p>");
 			connection = connectionFactory.createConnection();
 			Session session = connection.createSession(false,
 					Session.AUTO_ACKNOWLEDGE);
-			MessageProducer messageProducer = session.createProducer(queue);
+			MessageProducer messageProducer = session.createProducer(destination);
 			connection.start();
-			out.write("<h2>Following messages will be send to the queue:</h2>");
+			out.write("<h2>Following messages will be send to the destination:</h2>");
 			TextMessage message = session.createTextMessage();
 			for (int i = 0; i < MSG_COUNT; i++) {
 				message.setText("This is message " + (i + 1));

--- a/helloworld-mdb/src/main/webapp/WEB-INF/hornetq-jms.xml
+++ b/helloworld-mdb/src/main/webapp/WEB-INF/hornetq-jms.xml
@@ -15,6 +15,9 @@
             <jms-queue name="HELLOWORLDMDBQueue">
                 <entry name="/queue/HELLOWORLDMDBQueue"/>
             </jms-queue>
+            <jms-topic name="HELLOWORLDMDBTopic">
+                <entry name="/topic/HELLOWORLDMDBTopic"/>
+            </jms-topic>
         </jms-destinations>
     </hornetq-server>
 </messaging-deployment>


### PR DESCRIPTION
- add a 2nd MDB which receives messages from a topic
- let the servlet sends messageis either to the queue or to the topic
  (by adding the topic HTTP request parameter)
- update the README and remove the section about configuring the
  messaging subsystem for OpenShift, .openshift/config/standalone.xml is
  already properly configured for both AS7 and EAP6

The files EOL were using Windows format. I assumed it was an error and saved them using UNIX format
