### PR TITLE
Fix JDF-95

### DIFF
--- a/dist/release-utils.sh
+++ b/dist/release-utils.sh
@@ -69,7 +69,13 @@ update()
 markdown_to_html()
 {
    cd $DIR/../
-   subdirs=`find . -type d -maxdepth 1 ! -iname ".*" | sort`
+
+   # Clear the contents from toc.html file
+   rm dist/target/toc.html
+   touch dist/target/toc.html
+
+   # Loop through the sorted quickstart directories and process them
+   subdirs=`find . -maxdepth 1 -type d ! -iname ".*" | sort`
    for subdir in $subdirs
    do
       readmes=`find $subdir -iname readme.md`


### PR DESCRIPTION
Clear contents of toc.html file before each run to prevent growing quickstart table size
Move the maxdepth argument before type in the subdirectory find command
