### PR TITLE
Identity switching and propagation quickstart.

### DIFF
--- a/ejb-security-interceptors/README.md
+++ b/ejb-security-interceptors/README.md
@@ -1,0 +1,220 @@
+ejb-security-interceptors:  Using client and server side interceptors to switch the identity for an EJB call.
+====================
+Author: Darran Lofthouse
+Level: Advanced
+Technologies: EJB, Security
+Summary: Demonstrates how interceptors can be used to switch the identity for EJB calls on a call by call basis.
+Target Product: EAP
+
+What is it?
+-----------
+
+By default for Remote calls to EJBs deployed to the application server the connection to the server is authenticated
+and then any request received over this connection is executed as the identity which authenticated the connection.  This
+is true for both client to server and server to server calls, where different identities are required from the same client
+this requires multiple connections to be opened to the server - each authenticated as a different identity.
+
+This quickstart offers an alternative solution where the identity used to authenticate the connection is given the permission
+to execute a request as a different user, this is achieved with the addition of the following three components: -
+ * A client side interceptor to pass the requested identity to the remote server.
+ * A server side interceptor to receive the identity and request that the call switches to that identity.
+ * A JAAS LoginModule to decide if the user of the connection is allowed to execute requests as the user specified.
+ 
+The quickstart then makes use of two EJBs to verify that the propagation and identity switching is happening as required,
+the first of these is the SecuredEJB which has three methods: -
+
+    String getSecurityInformation();
+    boolean roleOneMethod();
+    boolean roleTwoMethod();
+
+The first of these methods can be called by all users that are created in the steps below, the purpose of the method is to 
+return a String containing the name of the Principal that called the EJB and also the results of checking if the user has the
+roles 'RoleOne' and 'RoleTwo' e.g.
+
+   [Principal={ConnectionUser}, In role {User}=true, In role {RoleOne}=false, In role {RoleTwo}=false]
+   
+The next two methods are annotated to require that the calling user has roles 'RoleOne' and 'RoleTwo' respectively.
+
+The next EJB is the 'IntermediateEJB', this EJB contains a single method and it's purpose is to make use of a remote connection 
+and invoke each of the methods on the 'SecuredEJB' - a summary is then returned with the outcome of the calls.
+
+Finally the class 'RemoteClient' is a stand alone client to make the calls, the client makes calls using the identity of 
+the connection established and also makes calls switching the identity to the users that are subsequently defined.
+
+One point to keep in mind is that for the server to server propagation scenarios in normal circumstances this would be to 
+servers that are truely remote to each other - however for the purpose of the quickstart we make use of a loopback connection
+to the same server so we don't need two servers just to run the test.               
+
+System requirements
+-------------------
+
+This quick start is based around JBoss AS 7.2.0 or JBoss EAP 6.1.0 using the default standalone configuration plus the
+modifications described here.
+
+If you are reviewing this quickstart with a view to making use of this approach within your own environment it is still
+recommended to try this using a clean installation first and then porting to your own environment. 
+
+
+Configure Maven
+---------------
+
+If you have not yet done so, you must [Configure Maven](../README.md#mavenconfiguration) before testing the quickstarts.
+
+
+Add the Application Users
+---------------
+
+This quick start is built around the default 'ApplicationRealm' as configured in the AS7 / EAP 6 distribution, the following four 
+users should be added using the add-user utility.
+
+'ConnectionUser' with role 'User' and password 'ConnectionPassword1!'.
+'AppUserOne' with roles 'User' and 'RoleOne', any password can be specified for this user.
+'AppUserTwo' with roles 'User' and 'RoleTwo', again any password can be specified for this user.
+'AppUserThree' with roles 'User', 'RoleOne', and 'RoleTwo' and again any password.  
+
+The first user is used for establishing the actual connection to the server, the subsequent two users are the users that this
+quickstart demonstrates can be switched to on demand.  The final user is a user that can access everything but can not be switched to.
+
+Add the LoginModule
+---------------
+
+The EJB side of this quick start makes use of the 'other' security domain which by default delegates to the 'ApplicationRealm',
+in order to support identity switching an additional login module needs to be added to the domain definition.
+
+  <login-module code="org.jboss.as.quickstarts.ejb_security_interceptors.DelegationLoginModule" flag="optional">
+    <module-option name="password-stacking" value="useFirstPass"/>
+  </login-module>
+  
+This login module can either be added before or after the existing 'Remoting' login module in the domain but it MUST be somewhere before
+the existing RealmDirect login module.  
+
+If this approach is used and the majority of requests will involve an identity switch then it would recommended to have this module as
+the first module in the list, however if the majority of requests will run as the connection user with occasional switches it would
+be recommended ot place the 'Remoting' login module first and this one second.
+
+This login module will load the properties file 'delegation-mapping.properties' from the deployment, the location of this properties
+file can be overridden with the module-option 'delegationProperties'.
+
+At runtime this login module is used to decide if the user of the connection to the server is allowed to ask that the request is executed
+as the specified user.
+
+There are four variations of how the key can be specified in the properties file: -
+
+ - user@realm        - Exact match of user and realm.
+ - user@*            - Allow a match of user for any realm.
+ - *@realm           - Match for any user in the realm specified.
+ - *                 - Match for all users in all realms.
+ 
+When a request is received that involves switching the user the identity of the user that opened the connection is used to 
+check the properties file for an entry, the check is performed in the order listed above until the first match is found - once
+a match is found further entries that could match are not read.
+
+The value in the properties file can either be a wildcard '*' or it can be a comma separated list of users, do be aware
+that in the value/mapping side there is no notion of the realm.
+
+For this quick start we use the following entry: -
+
+  ConnectionUser@ApplicationRealm=AppUserOne,AppUserTwo
+  
+This means that the ConnectionUser added above can only ask that a request is executed as either AppUserOne or AppUserTwo, it is not
+allowed to ask for it to be executed as AppUserThree.
+
+All users are permitted to execute requests as themselves as in that case the login module is not called, that is the default behaviour
+that exists without the addition of the interceptors in this quick start.    
+
+* Further Use *
+
+Taking this further the DelegationLoginModule can be extended to provide custom delegation checks, one thing not currently 
+checked is if the user being switched to actually exists, if the module is extended the following method can be overridden to
+provide a custom check.
+
+  protected boolean delegationAcceptable(String requestedUser, OuterUserCredential connectionUser);   
+
+Server to Server Connection
+-------------------------
+
+For the purpose of the quickstart we just need an outbound connection that loops back to the same server, this will be
+sufficient to demonstrate the server to server capabilities.
+
+Add the following security realm, note the Base64 password is for the ConnectionUser account created above.
+
+   <security-realm name="ejb-outbound-realm">
+      <server-identities>
+         <secret value="Q29ubmVjdGlvblBhc3N3b3JkMSE="/>
+      </server-identities>
+   </security-realm>
+            
+Within the socket-binding-group 'standard-sockets' add the following outbound connection: -
+
+   <outbound-socket-binding name="ejb-outbound">
+      <remote-destination host="localhost" port="4447"/>
+   </outbound-socket-binding>          
+
+Within the Remoting susbsytem add the following outbound connection: -
+
+   <outbound-connections>
+      <remote-outbound-connection name="ejb-outbound-connection" outbound-socket-binding-ref="ejb-outbound" security-realm="ejb-outbound-realm" username="ConnectionUser">
+         <properties>
+            <property name="SSL_ENABLED" value="false"/>
+         </properties>
+      </remote-outbound-connection>
+   </outbound-connections>
+
+Start JBoss Enterprise Application Platform 6 or JBoss AS 7
+-------------------------
+
+1. Open a command line and navigate to the root of the JBoss server directory.
+2. The following shows the command line to start the server with the web profile:
+
+        For Linux:   JBOSS_HOME/bin/standalone.sh
+        For Windows: JBOSS_HOME\bin\standalone.bat
+
+
+Build and Deploy the Quickstart
+-------------------------
+
+_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See [Build and Deploy the Quickstarts](../README.md#buildanddeploy) for complete instructions and additional options._
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. Type this command to build and deploy the archive:
+
+        mvn clean package jboss-as:deploy
+
+4. This will deploy `target/jboss-as-ejb-security-interceptors.jar` to the running instance of the server.
+
+
+Run the client 
+---------------------
+
+The step here assumes you have already successfully deployed the EJBs to the server in the previous step
+and that your command prompt is still in the same folder.
+
+1.  Type this command to execute the client:
+
+        mvn exec:exec
+        
+        
+
+Undeploy the Archive
+--------------------
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. When you are finished testing, type this command to undeploy the archive:
+
+        mvn jboss-as:undeploy
+
+
+Run the Quickstart in JBoss Developer Studio or Eclipse
+-------------------------------------
+You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see [Use JBoss Developer Studio or Eclipse to Run the Quickstarts](../README.md#useeclipse) 
+
+
+Debug the Application
+------------------------------------
+
+If you want to debug the source code or look at the Javadocs of any library in the project, run either of the following commands to pull them into your local repository. The IDE should then detect them.
+
+    mvn dependency:sources
+    mvn dependency:resolve -Dclassifier=javadoc

--- a/ejb-security-interceptors/README.md
+++ b/ejb-security-interceptors/README.md
@@ -9,46 +9,38 @@ Target Product: EAP
 What is it?
 -----------
 
-By default for Remote calls to EJBs deployed to the application server the connection to the server is authenticated
-and then any request received over this connection is executed as the identity which authenticated the connection.  This
-is true for both client to server and server to server calls, where different identities are required from the same client
-this requires multiple connections to be opened to the server - each authenticated as a different identity.
+By default, when you make a remote call to an EJB deployed to the application server, the connection to the server is authenticated and any request received over this connection is executed as the identity that authenticated the connection. This is true for both client-to-server and server-to-server calls. If you need to use different identities from the same client, you normally need to open multiple connections to the server so that each one is authenticated as a different identity.
 
-This quickstart offers an alternative solution where the identity used to authenticate the connection is given the permission
-to execute a request as a different user, this is achieved with the addition of the following three components: -
- * A client side interceptor to pass the requested identity to the remote server.
- * A server side interceptor to receive the identity and request that the call switches to that identity.
- * A JAAS LoginModule to decide if the user of the connection is allowed to execute requests as the user specified.
+Rather than open multiple client connections, this quickstart offers an alternative solution. The identity used to authenticate the connection is given permission to execute a request as a different user. This is achieved with the addition of the following three components: 
+
+1. A client side interceptor to pass the requested identity to the remote server.
+2. A server side interceptor to receive the identity and request that the call switches to that identity.
+3. A JAAS LoginModule to decide if the user of the connection is allowed to execute requests as the specified identity.
  
-The quickstart then makes use of two EJBs to verify that the propagation and identity switching is happening as required,
-the first of these is the SecuredEJB which has three methods: -
+The quickstart then makes use of two EJBs, `SecuredEJB` and `IntermediateEJB`, to verify that the propagation and identity switching is correct. 
+
+1. The `SecuredEJB` which has three methods: 
 
     String getSecurityInformation();
     boolean roleOneMethod();
     boolean roleTwoMethod();
 
-The first of these methods can be called by all users that are created in the steps below, the purpose of the method is to 
-return a String containing the name of the Principal that called the EJB and also the results of checking if the user has the
-roles 'RoleOne' and 'RoleTwo' e.g.
+The first method can be called by all users that are created in this quickstart. The purpose of this method is to return a String containing the name of the Principal that called the EJB along with the user's authorized role information, for example:
 
    [Principal={ConnectionUser}, In role {User}=true, In role {RoleOne}=false, In role {RoleTwo}=false]
    
-The next two methods are annotated to require that the calling user has roles 'RoleOne' and 'RoleTwo' respectively.
+The next two methods are annotated to require that the calling user is authorized for roles 'RoleOne' and 'RoleTwo' respectively.
 
-The next EJB is the 'IntermediateEJB', this EJB contains a single method and it's purpose is to make use of a remote connection 
-and invoke each of the methods on the 'SecuredEJB' - a summary is then returned with the outcome of the calls.
+2. The `IntermediateEJB` contains a single method. Its purpose is to make use of a remote connection and invoke each of the methods on the `SecuredEJB`. A summary is then returned with the outcome of the calls.
 
-Finally the class 'RemoteClient' is a stand alone client to make the calls, the client makes calls using the identity of 
-the connection established and also makes calls switching the identity to the users that are subsequently defined.
+Finally there is the `RemoteClient` stand-alone client. The client makes calls using the identity of the established connection and also makes calls switching the identity to the different users.
 
-One point to keep in mind is that for the server to server propagation scenarios in normal circumstances this would be to 
-servers that are truely remote to each other - however for the purpose of the quickstart we make use of a loopback connection
-to the same server so we don't need two servers just to run the test.               
+In the real world, remote calls between servers in the servers-to-server scenario would truly be remote and separate. For the purpose of this quickstart, we make use of a loopback connection to the same server so we don't need two servers just to run the test. 
 
 System requirements
 -------------------
 
-This quick start is based around JBoss AS 7.2.0 or JBoss EAP 6.1.0 using the default standalone configuration plus the
+This quick start is based around JBoss Enterprise Application Platform 6.1.0 or JBoss AS 7.2.0 using the default standalone configuration plus the
 modifications described here.
 
 If you are reviewing this quickstart with a view to making use of this approach within your own environment it is still
@@ -64,79 +56,63 @@ If you have not yet done so, you must [Configure Maven](../README.md#mavenconfig
 Add the Application Users
 ---------------
 
-This quick start is built around the default 'ApplicationRealm' as configured in the AS7 / EAP 6 distribution, the following four 
-users should be added using the add-user utility.
+This quick start is built around the default `ApplicationRealm` as configured in the JBoss Enterprise Application Platform 6 or JBoss AS 7 server distribution. The following four users should be added using the add-user utility. For an example of how to use this utility, see [Add User](../README.md#addapplicationuser).
 
-'ConnectionUser' with role 'User' and password 'ConnectionPassword1!'.
-'AppUserOne' with roles 'User' and 'RoleOne', any password can be specified for this user.
-'AppUserTwo' with roles 'User' and 'RoleTwo', again any password can be specified for this user.
-'AppUserThree' with roles 'User', 'RoleOne', and 'RoleTwo' and again any password.  
+1. 'ConnectionUser' with role 'User' and password 'ConnectionPassword1!'.
+2. 'AppUserOne' with roles 'User' and 'RoleOne', any password can be specified for this user.
+3. 'AppUserTwo' with roles 'User' and 'RoleTwo', again any password can be specified for this user.
+4. 'AppUserThree' with roles 'User', 'RoleOne', and 'RoleTwo' and again any password.  
 
-The first user is used for establishing the actual connection to the server, the subsequent two users are the users that this
-quickstart demonstrates can be switched to on demand.  The final user is a user that can access everything but can not be switched to.
+The first user is used for establishing the actual connection to the server. The subsequent two users are used to demonstrate how to switch identities on demand.  The final user is a user that can access everything but can not participate in identity switching.
 
 Add the LoginModule
 ---------------
 
-The EJB side of this quick start makes use of the 'other' security domain which by default delegates to the 'ApplicationRealm',
-in order to support identity switching an additional login module needs to be added to the domain definition.
+The EJB side of this quick start makes use of the `other` security domain which by default delegates to the `ApplicationRealm`, in order to support identity switching, an additional login module must be added to the domain definition.
 
-  <login-module code="org.jboss.as.quickstarts.ejb_security_interceptors.DelegationLoginModule" flag="optional">
-    <module-option name="password-stacking" value="useFirstPass"/>
-  </login-module>
+    <login-module code="org.jboss.as.quickstarts.ejb_security_interceptors.DelegationLoginModule" flag="optional">
+        <module-option name="password-stacking" value="useFirstPass"/>
+    </login-module>
   
-This login module can either be added before or after the existing 'Remoting' login module in the domain but it MUST be somewhere before
-the existing RealmDirect login module.  
+This login module can either be added before or after the existing `Remoting` login module in the domain, but it MUST be somewhere before the existing RealmDirect login module.
 
-If this approach is used and the majority of requests will involve an identity switch then it would recommended to have this module as
-the first module in the list, however if the majority of requests will run as the connection user with occasional switches it would
-be recommended ot place the 'Remoting' login module first and this one second.
+If this approach is used and the majority of requests will involve an identity switch, then it is recommended to have this module as the first module in the list. However, if the majority of requests will run as the connection user with occasional switches, it is recommended to place the `Remoting` login module first and this one second.
 
-This login module will load the properties file 'delegation-mapping.properties' from the deployment, the location of this properties
-file can be overridden with the module-option 'delegationProperties'.
+This login module will load the properties file 'delegation-mapping.properties' from the deployment. The location of this properties file can be overridden with the module-option `delegationProperties`.
 
-At runtime this login module is used to decide if the user of the connection to the server is allowed to ask that the request is executed
-as the specified user.
+At runtime, this login module is used to decide if the user of the connection to the server is allowed to ask that the request is executed as the specified user.
 
-There are four variations of how the key can be specified in the properties file: -
+There are four variations of how the key can be specified in the properties file: 
 
  - user@realm        - Exact match of user and realm.
  - user@*            - Allow a match of user for any realm.
  - *@realm           - Match for any user in the realm specified.
  - *                 - Match for all users in all realms.
  
-When a request is received that involves switching the user the identity of the user that opened the connection is used to 
-check the properties file for an entry, the check is performed in the order listed above until the first match is found - once
-a match is found further entries that could match are not read.
+When a request is received that involves switching the user, the identity of the user that opened the connection is used to check the properties file for an entry. The check is performed in the order listed above until the first match is found. Once a match is found, further entries that could match are not read.
 
-The value in the properties file can either be a wildcard '*' or it can be a comma separated list of users, do be aware
-that in the value/mapping side there is no notion of the realm.
+The value in the properties file can either be a wildcard '*' or it can be a comma separated list of users. Be aware that in the value/mapping side there is no notion of the realm.
 
-For this quick start we use the following entry: -
+For this quickstart we use the following entry: -
 
-  ConnectionUser@ApplicationRealm=AppUserOne,AppUserTwo
+    ConnectionUser@ApplicationRealm=AppUserOne,AppUserTwo
   
-This means that the ConnectionUser added above can only ask that a request is executed as either AppUserOne or AppUserTwo, it is not
-allowed to ask for it to be executed as AppUserThree.
+This means that the ConnectionUser added above can only ask that a request is executed as either AppUserOne or AppUserTwo. It is not allowed to ask to be executed as AppUserThree.
 
-All users are permitted to execute requests as themselves as in that case the login module is not called, that is the default behaviour
-that exists without the addition of the interceptors in this quick start.    
+All users are permitted to execute requests as themselves, as in that case, the login module is not called. That is the default behavior that exists without the addition of the interceptors in this quickstart. 
 
 * Further Use *
 
-Taking this further the DelegationLoginModule can be extended to provide custom delegation checks, one thing not currently 
-checked is if the user being switched to actually exists, if the module is extended the following method can be overridden to
-provide a custom check.
+Taking this further, the `DelegationLoginModule` can be extended to provide custom delegation checks. One thing not currently checked is if the user being switched to actually exists. If the module is extended, the following method can be overridden to provide a custom check.
 
   protected boolean delegationAcceptable(String requestedUser, OuterUserCredential connectionUser);   
 
 Server to Server Connection
 -------------------------
 
-For the purpose of the quickstart we just need an outbound connection that loops back to the same server, this will be
-sufficient to demonstrate the server to server capabilities.
+For the purpose of the quickstart we just need an outbound connection that loops back to the same server. This will be sufficient to demonstrate the server to server capabilities.
 
-Add the following security realm, note the Base64 password is for the ConnectionUser account created above.
+Add the following security realm. Note the Base64 password is for the ConnectionUser account created above.
 
    <security-realm name="ejb-outbound-realm">
       <server-identities>
@@ -144,13 +120,13 @@ Add the following security realm, note the Base64 password is for the Connection
       </server-identities>
    </security-realm>
             
-Within the socket-binding-group 'standard-sockets' add the following outbound connection: -
+Within the socket-binding-group 'standard-sockets' add the following outbound connection: 
 
    <outbound-socket-binding name="ejb-outbound">
       <remote-destination host="localhost" port="4447"/>
    </outbound-socket-binding>          
 
-Within the Remoting susbsytem add the following outbound connection: -
+Within the Remoting susbsytem add the following outbound connection: 
 
    <outbound-connections>
       <remote-outbound-connection name="ejb-outbound-connection" outbound-socket-binding-ref="ejb-outbound" security-realm="ejb-outbound-realm" username="ConnectionUser">

--- a/ejb-security-interceptors/pom.xml
+++ b/ejb-security-interceptors/pom.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0"?>
+<!-- JBoss, Home of Professional Open Source Copyright 2013, Red Hat, Inc. 
+	and/or its affiliates, and individual contributors by the @authors tag. See 
+	the copyright.txt in the distribution for a full listing of individual contributors. 
+	Licensed under the Apache License, Version 2.0 (the "License"); you may not 
+	use this file except in compliance with the License. You may obtain a copy 
+	of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.jboss.as.quickstarts</groupId>
+	<artifactId>jboss-as-ejb-security-interceptors</artifactId>
+	<version>7.1.2-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>JBoss AS Quickstarts: EJB Security Interceptors</name>
+	<description>JBoss AS Quickstarts: EJB Security Interceptors</description>
+
+	<url>http://jboss.org/jbossas</url>
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<distribution>repo</distribution>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+		</license>
+	</licenses>
+
+	<properties>
+		<!-- Explicitly declaring the source encoding eliminates the following 
+			message: -->
+		<!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
+			resources, i.e. build is platform dependent! -->
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+		<!-- JBoss dependency versions -->
+		<version.org.jboss.as>7.2.0.Alpha1-SNAPSHOT</version.org.jboss.as>
+		<version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
+		<version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
+
+		<!-- other plugin versions -->
+		<version.compiler.plugin>2.3.1</version.compiler.plugin>
+		<version.exec.plugin>1.2.1</version.exec.plugin>
+
+		<!-- maven-compiler-plugin -->
+		<maven.compiler.target>1.6</maven.compiler.target>
+		<maven.compiler.source>1.6</maven.compiler.source>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<!-- Define the version of JBoss' Java EE 6 APIs we want to use -->
+			<!-- JBoss distributes a complete set of Java EE 6 APIs including a Bill 
+				of Materials (BOM). A BOM specifies the versions of a "stack" (or a collection) 
+				of artifacts. We use this here so that we always get the correct versions 
+				of artifacts. Here we use the jboss-javaee-6.0 stack (you can read this as 
+				the JBoss stack of the Java EE 6 APIs). You can actually use this stack with 
+				any version of JBoss AS that implements Java EE 6, not just JBoss AS 7! -->
+			<dependency>
+				<groupId>org.jboss.spec</groupId>
+				<artifactId>jboss-javaee-6.0</artifactId>
+				<version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.as</groupId>
+				<artifactId>jboss-as-ejb-client-bom</artifactId>
+				<version>${version.org.jboss.as}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.jboss.as</groupId>
+			<artifactId>jboss-as-security</artifactId>
+		</dependency>
+
+		<!-- Import the CDI API, we use provided scope as the API is included in 
+			JBoss AS 7 -->
+		<dependency>
+			<groupId>javax.enterprise</groupId>
+			<artifactId>cdi-api</artifactId>
+		</dependency>
+
+		<!-- Import the Common Annotations API (JSR-250), we use provided scope 
+			as the API is included in JBoss AS 7 -->
+		<dependency>
+			<groupId>org.jboss.spec.javax.annotation</groupId>
+			<artifactId>jboss-annotations-api_1.1_spec</artifactId>
+		</dependency>
+
+		<!-- Import the Servlet API, we use provided scope as the API is included 
+			in JBoss AS 7 -->
+		<dependency>
+			<groupId>org.jboss.spec.javax.servlet</groupId>
+			<artifactId>jboss-servlet-api_3.0_spec</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jboss.spec.javax.ejb</groupId>
+			<artifactId>jboss-ejb-api_3.1_spec</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jboss.ejb3</groupId>
+			<artifactId>jboss-ejb3-ext-api</artifactId>
+		</dependency>
+
+		<!-- JBoss EJB client API jar. We use runtime scope because the EJB client 
+			API isn't directly used in this example. We just need it in our runtime classpath -->
+		<dependency>
+			<groupId>org.jboss</groupId>
+			<artifactId>jboss-ejb-client</artifactId>
+		</dependency>
+
+		<!-- client communications with the server use XNIO -->
+		<dependency>
+			<groupId>org.jboss.xnio</groupId>
+			<artifactId>xnio-api</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jboss.xnio</groupId>
+			<artifactId>xnio-nio</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<!-- data serialization for invoking remote EJBs -->
+		<dependency>
+			<groupId>org.jboss.marshalling</groupId>
+			<artifactId>jboss-marshalling-river</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<!-- Import the transaction spec API, we use runtime scope because we aren't 
+			using any direct reference to the spec API in our client code -->
+		<dependency>
+			<groupId>org.jboss.spec.javax.transaction</groupId>
+			<artifactId>jboss-transaction-api_1.1_spec</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<!-- Set the name of the war, used as the context root when the app is 
+			deployed -->
+		<finalName>jboss-as-ejb-security-interceptors</finalName>
+		<plugins>
+			<!-- Add the maven exec plugin to allow us to run a java program via maven -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>${version.exec.plugin}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<executable>java</executable>
+					<workingDirectory>${project.build.directory}/exec-working-directory</workingDirectory>
+					<arguments>
+						<!-- automatically creates the classpath using all project dependencies, 
+							also adding the project build directory -->
+						<argument>-classpath</argument>
+						<classpath>
+						</classpath>
+						<argument>org.jboss.as.quickstarts.ejb_security_interceptors.RemoteClient</argument>
+					</arguments>
+				</configuration>
+			</plugin>
+
+			<!-- JBoss AS plugin to deploy war -->
+			<plugin>
+				<groupId>org.jboss.as.plugins</groupId>
+				<artifactId>jboss-as-maven-plugin</artifactId>
+				<version>${version.org.jboss.as.plugins.maven.plugin}</version>
+			</plugin>
+			<!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation 
+				processors -->
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${version.compiler.plugin}</version>
+				<configuration>
+					<source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/ClientSecurityInterceptor.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/ClientSecurityInterceptor.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_interceptors;
+
+import java.security.Principal;
+import java.util.Map;
+
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+
+/**
+ * Client side interceptor responsible for propagating the local identity.
+ * 
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ClientSecurityInterceptor implements EJBClientInterceptor {
+
+    public void handleInvocation(EJBClientInvocationContext context) throws Exception {
+        Principal currentPrincipal = SecurityActions.securityContextGetPrincipal();
+
+        if (currentPrincipal != null) {
+            Map<String, Object> contextData = context.getContextData();
+            contextData.put(ServerSecurityInterceptor.DELEGATED_USER_KEY, currentPrincipal.getName());
+        }
+
+        context.sendRequest();
+    }
+
+    public Object handleInvocationResult(EJBClientInvocationContext context) throws Exception {
+        return context.getResult();
+    }
+
+}

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/DelegationLoginModule.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/DelegationLoginModule.java
@@ -1,0 +1,208 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_interceptors;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.Principal;
+import java.security.acl.Group;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.login.LoginException;
+
+import org.jboss.security.SimpleGroup;
+import org.jboss.security.SimplePrincipal;
+import org.jboss.security.auth.callback.ObjectCallback;
+import org.jboss.security.auth.spi.AbstractServerLoginModule;
+
+/**
+ * Login module to make the decision if one user can ask for the current request to be switched to an alternative specified
+ * user.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class DelegationLoginModule extends AbstractServerLoginModule {
+
+    private static final String DELEGATION_PROPERTIES = "delegationProperties";
+
+    private static final String DEFAULT_DELEGATION_PROPERTIES = "delegation-mapping.properties";
+
+    private Properties delegationMappings;
+
+    private CallbackHandler callbackHandler;
+
+    private Principal identity;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        addValidOptions(new String[] { DELEGATION_PROPERTIES });
+        super.initialize(subject, callbackHandler, sharedState, options);
+        this.callbackHandler = callbackHandler;
+
+        String propertiesName;
+        if (options.containsKey(DELEGATION_PROPERTIES)) {
+            propertiesName = (String) options.get(DELEGATION_PROPERTIES);
+        } else {
+            propertiesName = DEFAULT_DELEGATION_PROPERTIES;
+        }
+        try {
+            delegationMappings = loadProperties(propertiesName);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(String.format("Unable to load properties '%s'", propertiesName), e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean login() throws LoginException {
+        if (super.login() == true) {
+            log.debug("super.login()==true");
+            return true;
+        }
+
+        // Time to see if this is a delegation request.
+        NameCallback ncb = new NameCallback("Username:");
+        ObjectCallback ocb = new ObjectCallback("Password:");
+
+        try {
+            callbackHandler.handle(new Callback[] { ncb, ocb });
+        } catch (Exception e) {
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            }
+            return false; // If the CallbackHandler can not handle the required callbacks then no chance.
+        }
+
+        String name = ncb.getName();
+        Object credential = ocb.getCredential();
+
+        if (credential instanceof OuterUserCredential) {
+            // This credential type will only be seen for a delegation request, if not seen then the request is not for us.
+
+            if (delegationAcceptable(name, (OuterUserCredential) credential)) {
+
+                identity = new SimplePrincipal(name);
+                if (getUseFirstPass()) {
+                    String userName = identity.getName();
+                    if (log.isDebugEnabled())
+                        log.debug("Storing username '" + userName + "' and empty password");
+                    // Add the username and an empty password to the shared state map
+                    sharedState.put("javax.security.auth.login.name", identity);
+                    sharedState.put("javax.security.auth.login.password", "");
+                }
+                loginOk = true;
+                return true;
+            }
+        }
+
+        return false; // Attempted login but not successful.
+    }
+
+    /**
+     * Make a trust user to decide if the user switch is acceptable.
+     *
+     * The default implementation checks the Properties for the user that opened the connection looking for a match, the
+     * property read is then used to check if the connection user can delegate to the user specified.
+     *
+     * The following entries will be checked in the Properties in this order: - user@realm - This is an exact match for the user
+     * / realm combination of the connection user. user@* - This entry allows a match by username for any realm. *@realm - This
+     * entry allows for any user in the realm specified. * - This matches all users.
+     *
+     * Once an entry has been found the Properties will not be read again, even if the entry loaded does not allow delegation.
+     *
+     * The value for the property is either '*' which means delegation to any user is allowed or a comma separate list of users
+     * that can be delegated to.
+     *
+     * @param requestedUser - The user this request wants to be authorized as.
+     * @param connectionUser - The use of the connection to the server.
+     * @return true if a switch is acceptable, false otherwise.
+     */
+    protected boolean delegationAcceptable(String requestedUser, OuterUserCredential connectionUser) {
+        if (delegationMappings == null) {
+            return false;
+        }
+
+        String[] allowedMappings = loadPropertyValue(connectionUser.getName(), connectionUser.getRealm());
+        if (allowedMappings.length == 1 && "*".equals(allowedMappings[1])) {
+            // A wild card mapping was found.
+            return true;
+        }
+        for (String current : allowedMappings) {
+            if (requestedUser.equals(current)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private String[] loadPropertyValue(final String userName, final String realm) {
+        String value = null;
+
+        value = delegationMappings.getProperty(userName + "@" + realm);
+        if (value == null) {
+            value = delegationMappings.getProperty(userName + "@*");
+        }
+        if (value == null) {
+            value = delegationMappings.getProperty("*@" + realm);
+        }
+        if (value == null) {
+            value = delegationMappings.getProperty("*");
+        }
+
+        if (value == null) {
+            return new String[0];
+        } else {
+            return value.split(",");
+        }
+    }
+
+    @Override
+    protected Principal getIdentity() {
+        return identity;
+    }
+
+    @Override
+    protected Group[] getRoleSets() throws LoginException {
+        Group roles = new SimpleGroup("Roles");
+        Group callerPrincipal = new SimpleGroup("CallerPrincipal");
+        Group[] groups = { roles, callerPrincipal };
+        callerPrincipal.addMember(getIdentity());
+        return groups;
+    }
+
+    private Properties loadProperties(final String name) throws IOException {
+        ClassLoader classLoader = SecurityActions.getContextClassLoader();
+        URL url = classLoader.getResource(name);
+        InputStream is = url.openStream();
+        try {
+            Properties props = new Properties();
+            props.load(is);
+            return props;
+
+        } finally {
+            is.close();
+        }
+    }
+
+}

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/EJBUtil.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/EJBUtil.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_interceptors;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+import org.jboss.ejb.client.EJBClientContext;
+
+/**
+ * Utility class for looking up EJBs
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class EJBUtil {
+
+    private static final int CLIENT_INTERCEPTOR_ORDER = 0x99999;
+
+    static void registerClientSecurityInterceptor() {
+        final EJBClientContext ejbClientContext = EJBClientContext.requireCurrent();
+
+        final ClientSecurityInterceptor clientInterceptor = new ClientSecurityInterceptor();
+
+        ejbClientContext.registerInterceptor(CLIENT_INTERCEPTOR_ORDER, clientInterceptor);
+    }
+
+    static IntermediateEJBRemote lookupIntermediateEJB() throws Exception {
+        final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        final Context context = new InitialContext(jndiProperties);
+
+        return (IntermediateEJBRemote) context.lookup("ejb:/jboss-as-ejb-security-interceptors/IntermediateEJB!"
+                + IntermediateEJBRemote.class.getName());
+    }
+
+    static SecuredEJBRemote lookupSecuredEJB() throws Exception {
+        final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        final Context context = new InitialContext(jndiProperties);
+
+        return (SecuredEJBRemote) context.lookup("ejb:/jboss-as-ejb-security-interceptors/SecuredEJB!"
+                + SecuredEJBRemote.class.getName());
+    }
+
+}

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/EJBUtil.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/EJBUtil.java
@@ -21,24 +21,12 @@ import java.util.Hashtable;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 
-import org.jboss.ejb.client.EJBClientContext;
-
 /**
  * Utility class for looking up EJBs
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 class EJBUtil {
-
-    private static final int CLIENT_INTERCEPTOR_ORDER = 0x99999;
-
-    static void registerClientSecurityInterceptor() {
-        final EJBClientContext ejbClientContext = EJBClientContext.requireCurrent();
-
-        final ClientSecurityInterceptor clientInterceptor = new ClientSecurityInterceptor();
-
-        ejbClientContext.registerInterceptor(CLIENT_INTERCEPTOR_ORDER, clientInterceptor);
-    }
 
     static IntermediateEJBRemote lookupIntermediateEJB() throws Exception {
         final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/IntermediateEJB.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/IntermediateEJB.java
@@ -16,7 +16,7 @@
  */
 package org.jboss.as.quickstarts.ejb_security_interceptors;
 
-import static org.jboss.as.quickstarts.ejb_security_interceptors.EJBUtil.registerClientSecurityInterceptor;
+
 import static org.jboss.as.quickstarts.ejb_security_interceptors.EJBUtil.lookupSecuredEJB;
 
 import javax.annotation.security.PermitAll;
@@ -39,7 +39,6 @@ public class IntermediateEJB implements IntermediateEJBRemote {
     public String makeTestCalls() {
         try {
             StringBuilder sb = new StringBuilder("* * IntermediateEJB - Begin Testing * * \n");
-            registerClientSecurityInterceptor();
             SecuredEJBRemote remote = lookupSecuredEJB();
 
             sb.append("SecuredEJBRemote.getSecurityInformation()=").append(remote.getSecurityInformation()).append("\n");

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/IntermediateEJB.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/IntermediateEJB.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_interceptors;
+
+import static org.jboss.as.quickstarts.ejb_security_interceptors.EJBUtil.registerClientSecurityInterceptor;
+import static org.jboss.as.quickstarts.ejb_security_interceptors.EJBUtil.lookupSecuredEJB;
+
+import javax.annotation.security.PermitAll;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * An EJB for testing EJB to remote EJB calls.
+ * 
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Stateless
+@Remote(IntermediateEJBRemote.class)
+@SecurityDomain("other")
+@PermitAll
+public class IntermediateEJB implements IntermediateEJBRemote {
+
+    public String makeTestCalls() {
+        try {
+            StringBuilder sb = new StringBuilder("* * IntermediateEJB - Begin Testing * * \n");
+            registerClientSecurityInterceptor();
+            SecuredEJBRemote remote = lookupSecuredEJB();
+
+            sb.append("SecuredEJBRemote.getSecurityInformation()=").append(remote.getSecurityInformation()).append("\n");
+
+            try {
+                sb.append("Can call roleOneMethod=");
+                remote.roleOneMethod();
+                sb.append("true\n");
+            } catch (Exception e) {
+                sb.append("false\n");
+            }
+
+            try {
+                sb.append("Can call roleTwoMethod=");
+                remote.roleTwoMethod();
+                sb.append("true\n");
+            } catch (Exception e) {
+                sb.append("false\n");
+            }
+
+            sb.append("* * IntermediateEJB - End Testing * * ");
+            return sb.toString();
+        } catch (Exception e) {
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            }
+            throw new RuntimeException("Teasting failed.", e);
+        }
+    }
+
+}

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/IntermediateEJB.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/IntermediateEJB.java
@@ -32,7 +32,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
  */
 @Stateless
 @Remote(IntermediateEJBRemote.class)
-@SecurityDomain("other")
+@SecurityDomain("quickstart-domain")
 @PermitAll
 public class IntermediateEJB implements IntermediateEJBRemote {
 

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/IntermediateEJBRemote.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/IntermediateEJBRemote.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_interceptors;
+
+import javax.ejb.Remote;
+
+/**
+ * The interface to the intermediate EJB used to test EJB to remote EJB calls.
+ * 
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Remote
+public interface IntermediateEJBRemote {
+    
+    String makeTestCalls();
+
+}

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/OuterUserCredential.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/OuterUserCredential.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_interceptors;
+
+import org.jboss.as.domain.management.security.RealmUser;
+
+/**
+ * A wrapper around the user for the Connection to act as a Credential.
+ * 
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public final class OuterUserCredential {
+
+    private final RealmUser user;
+
+    OuterUserCredential(final RealmUser user) {
+        if (user == null) {
+            throw new IllegalArgumentException("UserPrincipal can not be null.");
+        }
+        this.user = user;
+    }
+
+    String getName() {
+        return user.getName();
+    }
+
+    String getRealm() {
+        return user.getRealm();
+    }
+
+    @Override
+    public int hashCode() {
+        return user.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof OuterUserCredential && equals((OuterUserCredential) other);
+    }
+
+    public boolean equals(OuterUserCredential other) {
+        return this == other || other != null && user.equals(other.user);
+    }
+
+}

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/RemoteClient.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/RemoteClient.java
@@ -1,0 +1,193 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_interceptors;
+
+import static org.jboss.as.quickstarts.ejb_security_interceptors.EJBUtil.lookupIntermediateEJB;
+import static org.jboss.as.quickstarts.ejb_security_interceptors.EJBUtil.lookupSecuredEJB;
+import static org.jboss.as.quickstarts.ejb_security_interceptors.EJBUtil.registerClientSecurityInterceptor;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+
+import org.jboss.security.ClientLoginModule;
+import org.jboss.security.SimplePrincipal;
+
+/**
+ * The remote client responsible for making a number of calls to the server to demonstrate the capabilities of the interceptors.
+ * 
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class RemoteClient {
+
+    /**
+     * Perform the tests of this quick start using the SecurityContextAssociation API to set the desired Principal.
+     */
+    private static void performTestingSecurityContext(final String user, final SecuredEJBRemote secured,
+            final IntermediateEJBRemote intermediate) {
+        try {
+            if (user != null) {
+                SecurityActions.securityContextSetPrincpal(new SimplePrincipal(user));
+            }
+
+            System.out
+                    .println(String.format("* * About to perform test as %s * *\n\n", user == null ? "ConnectionUser" : user));
+
+            makeCalls(secured, intermediate);
+        } finally {
+            SecurityActions.securityContextClear();
+            System.out.println("* * Test Complete * * \n\n\n");
+        }
+    }
+
+    /**
+     * Perform the tests of this quick start using the ClientLoginModule and LoginContext API to set the desired Principal.
+     */
+    private static void performTestingClientLoginModule(final String user, final SecuredEJBRemote secured,
+            final IntermediateEJBRemote intermediate) throws Exception {
+        LoginContext loginContext = null;
+        try {
+            if (user != null) {
+                loginContext = getCLMLoginContext(user, "");
+                loginContext.login();
+            }
+
+            System.out
+                    .println(String.format("* * About to perform test as %s * *\n\n", user == null ? "ConnectionUser" : user));
+
+            makeCalls(secured, intermediate);
+        } finally {
+            if (loginContext != null) {
+                loginContext.logout();
+            }
+            System.out.println("* * Test Complete * * \n\n");
+        }
+    }
+
+    public static LoginContext getCLMLoginContext(final String username, final String password) throws LoginException {
+        final String configurationName = "Testing";
+
+        CallbackHandler cbh = new CallbackHandler() {
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (Callback current : callbacks) {
+                    if (current instanceof NameCallback) {
+                        ((NameCallback) current).setName(username);
+                    } else if (current instanceof PasswordCallback) {
+                        ((PasswordCallback) current).setPassword(password.toCharArray());
+                    } else {
+                        throw new UnsupportedCallbackException(current);
+                    }
+                }
+            }
+        };
+        Configuration config = new Configuration() {
+
+            @Override
+            public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+                if (configurationName.equals(name) == false) {
+                    throw new IllegalArgumentException("Unexpected configuration name '" + name + "'");
+                }
+                Map<String, String> options = new HashMap<String, String>();
+                options.put("multi-threaded", "true");
+                options.put("restore-login-identity", "true");
+
+                AppConfigurationEntry clmEntry = new AppConfigurationEntry(ClientLoginModule.class.getName(),
+                        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, options);
+
+                return new AppConfigurationEntry[] { clmEntry };
+            }
+        };
+
+        return new LoginContext(configurationName, new Subject(), cbh, config);
+    }
+
+    private static void makeCalls(final SecuredEJBRemote secured, final IntermediateEJBRemote intermediate) {
+        System.out.println("* Making Direct Calls to the SecuredEJB\n");
+        System.out.println(String.format("* getSecurityInformation()=%s", secured.getSecurityInformation()));
+
+        boolean roleMethodSuccess;
+        try {
+            secured.roleOneMethod();
+            roleMethodSuccess = true;
+        } catch (Exception e) {
+            roleMethodSuccess = false;
+        }
+        System.out.println(String.format("* Can call roleOneMethod()=%b", roleMethodSuccess));
+
+        try {
+            secured.roleTwoMethod();
+            roleMethodSuccess = true;
+        } catch (Exception e) {
+            roleMethodSuccess = false;
+        }
+        System.out.println(String.format("* Can call roleTwoMethod()=%b", roleMethodSuccess));
+
+        System.out.println("\n* Calling the IntermediateEJB to repeat the test server to server \n");
+        System.out.println(intermediate.makeTestCalls());
+    }
+
+    /**
+     * @param args
+     */
+    public static void main(String[] args) throws Exception {
+        System.out.println("\n\n\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n\n");
+        registerClientSecurityInterceptor();
+
+        SecuredEJBRemote secured = lookupSecuredEJB();
+        IntermediateEJBRemote intermediate = lookupIntermediateEJB();
+
+        System.out
+                .println("This first round of tests is using the SecurityContextAssociation API to set the desired Principal.\n\n");
+
+        performTestingSecurityContext(null, secured, intermediate);
+        performTestingSecurityContext("AppUserOne", secured, intermediate);
+        performTestingSecurityContext("AppUserTwo", secured, intermediate);
+        try {
+            performTestingSecurityContext("AppUserThree", secured, intermediate);
+            System.err.println("ERROR - We did not expect the switch to 'AppUserThree' to work.");
+        } catch (Exception e) {
+            System.out.println("Call as 'AppUserThree' correctly rejected.\n");
+        }
+
+        System.out
+                .println("This second round of tests is using the ClientLoginModule with LoginContext API to set the desired Principal.\n\n");
+
+        performTestingClientLoginModule(null, secured, intermediate);
+        performTestingClientLoginModule("AppUserOne", secured, intermediate);
+        performTestingClientLoginModule("AppUserTwo", secured, intermediate);
+        try {
+            performTestingClientLoginModule("AppUserThree", secured, intermediate);
+            System.err.println("ERROR - We did not expect the switch to 'AppUserThree' to work.");
+        } catch (Exception e) {
+            System.out.println("Call as 'AppUserThree' correctly rejected.\n");
+        }
+
+        System.out.println("\n\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n\n\n");
+    }
+
+}

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/RemoteClient.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/RemoteClient.java
@@ -18,12 +18,13 @@ package org.jboss.as.quickstarts.ejb_security_interceptors;
 
 import static org.jboss.as.quickstarts.ejb_security_interceptors.EJBUtil.lookupIntermediateEJB;
 import static org.jboss.as.quickstarts.ejb_security_interceptors.EJBUtil.lookupSecuredEJB;
-import static org.jboss.as.quickstarts.ejb_security_interceptors.EJBUtil.registerClientSecurityInterceptor;
+
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.ejb.EJBAccessException;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
@@ -55,6 +56,7 @@ public class RemoteClient {
                 SecurityActions.securityContextSetPrincpal(new SimplePrincipal(user));
             }
 
+            System.out.println("-------------------------------------------------");
             System.out
                     .println(String.format("* * About to perform test as %s * *\n\n", user == null ? "ConnectionUser" : user));
 
@@ -62,6 +64,7 @@ public class RemoteClient {
         } finally {
             SecurityActions.securityContextClear();
             System.out.println("* * Test Complete * * \n\n\n");
+            System.out.println("-------------------------------------------------");
         }
     }
 
@@ -77,6 +80,7 @@ public class RemoteClient {
                 loginContext.login();
             }
 
+            System.out.println("-------------------------------------------------");
             System.out
                     .println(String.format("* * About to perform test as %s * *\n\n", user == null ? "ConnectionUser" : user));
 
@@ -86,6 +90,7 @@ public class RemoteClient {
                 loginContext.logout();
             }
             System.out.println("* * Test Complete * * \n\n");
+            System.out.println("-------------------------------------------------");
         }
     }
 
@@ -134,7 +139,7 @@ public class RemoteClient {
         try {
             secured.roleOneMethod();
             roleMethodSuccess = true;
-        } catch (Exception e) {
+        } catch (EJBAccessException e) {
             roleMethodSuccess = false;
         }
         System.out.println(String.format("* Can call roleOneMethod()=%b", roleMethodSuccess));
@@ -142,7 +147,7 @@ public class RemoteClient {
         try {
             secured.roleTwoMethod();
             roleMethodSuccess = true;
-        } catch (Exception e) {
+        } catch (EJBAccessException e) {
             roleMethodSuccess = false;
         }
         System.out.println(String.format("* Can call roleTwoMethod()=%b", roleMethodSuccess));
@@ -156,13 +161,12 @@ public class RemoteClient {
      */
     public static void main(String[] args) throws Exception {
         System.out.println("\n\n\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n\n");
-        registerClientSecurityInterceptor();
 
         SecuredEJBRemote secured = lookupSecuredEJB();
         IntermediateEJBRemote intermediate = lookupIntermediateEJB();
 
         System.out
-                .println("This first round of tests is using the SecurityContextAssociation API to set the desired Principal.\n\n");
+                .println("This first round of tests is using the (PicketBox) SecurityContextAssociation API to set the desired Principal.\n\n");
 
         performTestingSecurityContext(null, secured, intermediate);
         performTestingSecurityContext("AppUserOne", secured, intermediate);
@@ -175,7 +179,7 @@ public class RemoteClient {
         }
 
         System.out
-                .println("This second round of tests is using the ClientLoginModule with LoginContext API to set the desired Principal.\n\n");
+                .println("This second round of tests is using the (PicketBox) ClientLoginModule with LoginContext API to set the desired Principal.\n\n");
 
         performTestingClientLoginModule(null, secured, intermediate);
         performTestingClientLoginModule("AppUserOne", secured, intermediate);

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/SecuredEJB.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/SecuredEJB.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_interceptors;
+
+import javax.annotation.Resource;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Remote;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * A secured EJB which is used to test the identity and roles of the current user during a request.
+ * 
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Stateless
+@Remote(SecuredEJBRemote.class)
+@SecurityDomain("other")
+public class SecuredEJB implements SecuredEJBRemote {
+
+    @Resource
+    private SessionContext context;
+
+    @RolesAllowed("User")
+    public String getSecurityInformation() {        
+        StringBuilder sb = new StringBuilder("[");
+        sb.append("Principal={").append(context.getCallerPrincipal().getName()).append("}, ");
+        userInRole("User", sb).append(", ");
+        userInRole("RoleOne", sb).append(", ");
+        userInRole("RoleTwo", sb).append("]");
+
+        return sb.toString();
+    }
+
+    @RolesAllowed("RoleOne")
+    public boolean roleOneMethod() {
+        return true;
+    }
+
+    @RolesAllowed("RoleTwo")
+    public boolean roleTwoMethod() {
+        return true;
+    }
+
+    private StringBuilder userInRole(final String role, final StringBuilder sb) {
+        sb.append("In role {").append(role).append("}=").append(context.isCallerInRole(role));
+
+        return sb;
+    }
+
+}

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/SecuredEJB.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/SecuredEJB.java
@@ -31,7 +31,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
  */
 @Stateless
 @Remote(SecuredEJBRemote.class)
-@SecurityDomain("other")
+@SecurityDomain("quickstart-domain")
 public class SecuredEJB implements SecuredEJBRemote {
 
     @Resource

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/SecuredEJBRemote.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/SecuredEJBRemote.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_interceptors;
+
+/**
+ * The interface used to access the SecuredEJB
+ * 
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface SecuredEJBRemote {
+
+    /**
+     * @return A String containing the name of the current principal and also confirmation of role membership.
+     */
+    String getSecurityInformation();
+
+    /**
+     * A method that is only invokable if the user has the role 'RoleOne'.
+     */
+    boolean roleOneMethod();
+
+    /**
+     * A method that is only invokable if the user has the role 'RoleTwo'.
+     */
+    boolean roleTwoMethod();
+
+}

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/SecurityActions.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/SecurityActions.java
@@ -1,0 +1,296 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_interceptors;
+
+import java.security.AccessController;
+import java.security.Principal;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+import javax.security.auth.Subject;
+
+import org.jboss.as.security.remoting.RemotingContext;
+import org.jboss.remoting3.Connection;
+import org.jboss.security.SecurityContext;
+import org.jboss.security.SecurityContextAssociation;
+import org.jboss.security.SecurityContextFactory;
+
+/**
+ * Security actions for this package only.
+ * 
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+final class SecurityActions {
+
+    private SecurityActions() {
+    }
+
+    /*
+     * RemotingContext Actions
+     */
+
+    static void remotingContextClear() {
+        remotingContextActions().clear();
+    }
+
+    static Connection remotingContextGetConnection() {
+        return remotingContextActions().getConnection();
+    }
+
+    static boolean remotingContextIsSet() {
+        return remotingContextActions().isSet();
+    }
+
+    private static RemotingContextActions remotingContextActions() {
+        return System.getSecurityManager() == null ? RemotingContextActions.NON_PRIVILEGED : RemotingContextActions.PRIVILEGED;
+    }
+
+    private interface RemotingContextActions {
+
+        void clear();
+
+        Connection getConnection();
+
+        boolean isSet();
+
+        RemotingContextActions NON_PRIVILEGED = new RemotingContextActions() {
+
+            public void clear() {
+                RemotingContext.clear();
+            }
+
+            public boolean isSet() {
+                return RemotingContext.isSet();
+            }
+
+            public Connection getConnection() {
+                return RemotingContext.getConnection();
+            }
+        };
+
+        RemotingContextActions PRIVILEGED = new RemotingContextActions() {
+
+            PrivilegedAction<Void> CLEAR_ACTION = new PrivilegedAction<Void>() {
+
+                public Void run() {
+                    NON_PRIVILEGED.clear();
+                    return null;
+                }
+            };
+
+            PrivilegedAction<Boolean> IS_SET_ACTION = new PrivilegedAction<Boolean>() {
+
+                public Boolean run() {
+                    return NON_PRIVILEGED.isSet();
+                }
+            };
+
+            PrivilegedAction<Connection> GET_CONNECTION_ACTION = new PrivilegedAction<Connection>() {
+
+                public Connection run() {
+                    return NON_PRIVILEGED.getConnection();
+                }
+            };
+
+            public void clear() {
+                AccessController.doPrivileged(CLEAR_ACTION);
+            }
+
+            public boolean isSet() {
+                return AccessController.doPrivileged(IS_SET_ACTION);
+            }
+
+            public Connection getConnection() {
+                return AccessController.doPrivileged(GET_CONNECTION_ACTION);
+            }
+        };
+
+    }
+
+    /*
+     * SecurityContext Actions
+     */
+
+    static void securityContextSet(final SecurityContext context) {
+        securityContextActions().setSecurityContext(context);
+    }
+
+    static void securityContextClear() {
+        securityContextActions().clear();
+    }
+
+    static Principal securityContextGetPrincipal() {
+        return securityContextActions().getPrincipal();
+    }
+
+    static void securityContextSetPrincpal(final Principal principal) {
+        securityContextActions().setPrincipal(principal);
+    }
+
+    /**
+     * @return The SecurityContext previously set if any.
+     */
+    static SecurityContext securityContextSetPrincipalInfo(final Principal principal, final OuterUserCredential credential)
+            throws Exception {
+        return securityContextActions().setPrincipalInfo(principal, credential);
+    }
+
+    private static SecurityContextActions securityContextActions() {
+        return System.getSecurityManager() == null ? SecurityContextActions.NON_PRIVILEGED : SecurityContextActions.PRIVILEGED;
+    }
+
+    private interface SecurityContextActions {
+
+        void setSecurityContext(final SecurityContext context);
+
+        void clear();
+
+        Principal getPrincipal();
+
+        void setPrincipal(final Principal principal);
+
+        SecurityContext setPrincipalInfo(final Principal principal, final OuterUserCredential credential) throws Exception;
+
+        SecurityContextActions NON_PRIVILEGED = new SecurityContextActions() {
+
+            public void setSecurityContext(SecurityContext context) {
+                SecurityContextAssociation.setSecurityContext(context);
+            }
+
+            public void clear() {
+                SecurityContextAssociation.clearSecurityContext();
+            }
+
+            public Principal getPrincipal() {
+                return SecurityContextAssociation.getPrincipal();
+            }
+
+            public void setPrincipal(final Principal principal) {
+                SecurityContextAssociation.setPrincipal(principal);
+            }
+
+            public SecurityContext setPrincipalInfo(Principal principal, OuterUserCredential credential) throws Exception {
+                SecurityContext currentContext = SecurityContextAssociation.getSecurityContext();
+
+                SecurityContext nextContext = SecurityContextFactory.createSecurityContext(principal, credential,
+                        new Subject(), "USER_DELEGATION");
+                SecurityContextAssociation.setSecurityContext(nextContext);
+
+                return currentContext;
+            }
+
+        };
+
+        SecurityContextActions PRIVILEGED = new SecurityContextActions() {
+
+            PrivilegedAction<Principal> GET_PRINCIPAL_ACTION = new PrivilegedAction<Principal>() {
+
+                public Principal run() {
+                    return NON_PRIVILEGED.getPrincipal();
+                }
+            };
+
+            PrivilegedAction<Void> CLEAR_ACTION = new PrivilegedAction<Void>() {
+
+                public Void run() {
+                    NON_PRIVILEGED.clear();
+                    return null;
+                }
+            };
+
+            public void setSecurityContext(final SecurityContext context) {
+                AccessController.doPrivileged(new PrivilegedAction<Void>() {
+
+                    public Void run() {
+                        NON_PRIVILEGED.setSecurityContext(context);
+                        return null;
+                    }
+                });
+            }
+
+            public void clear() {
+                AccessController.doPrivileged(CLEAR_ACTION);
+            }
+
+            public Principal getPrincipal() {
+                return AccessController.doPrivileged(GET_PRINCIPAL_ACTION);
+            }
+
+            public void setPrincipal(final Principal principal) {
+                AccessController.doPrivileged(new PrivilegedAction<Void>() {
+
+                    public Void run() {
+                        NON_PRIVILEGED.setPrincipal(principal);
+                        return null;
+                    }
+                });
+            }
+
+            public SecurityContext setPrincipalInfo(final Principal principal, final OuterUserCredential credential)
+                    throws Exception {
+                try {
+                    return AccessController.doPrivileged(new PrivilegedExceptionAction<SecurityContext>() {
+
+                        public SecurityContext run() throws Exception {
+                            return NON_PRIVILEGED.setPrincipalInfo(principal, credential);
+                        }
+                    });
+                } catch (PrivilegedActionException e) {
+                    throw e.getException();
+                }
+            }
+
+        };
+
+    }
+
+    /*
+     * ClassLoader Actions
+     */
+
+    static ClassLoader getContextClassLoader() {
+        return (System.getSecurityManager() == null ? ContextClassLoaderAction.NON_PRIVILEGED
+                : ContextClassLoaderAction.PRIVILEGED).getContextClassLoader();
+    }
+
+    private interface ContextClassLoaderAction {
+
+        ClassLoader getContextClassLoader();
+
+        ContextClassLoaderAction NON_PRIVILEGED = new ContextClassLoaderAction() {
+
+            public ClassLoader getContextClassLoader() {
+                return Thread.currentThread().getContextClassLoader();
+            }
+        };
+
+        ContextClassLoaderAction PRIVILEGED = new ContextClassLoaderAction() {
+
+            private PrivilegedAction<ClassLoader> GET_CONTEXT_CLASS_LOADER = new PrivilegedAction<ClassLoader>() {
+
+                public ClassLoader run() {
+                    return NON_PRIVILEGED.getContextClassLoader();
+                }
+            };
+
+            public ClassLoader getContextClassLoader() {
+                return AccessController.doPrivileged(GET_CONTEXT_CLASS_LOADER);
+            }
+        };
+    }
+}

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/ServerSecurityInterceptor.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/ServerSecurityInterceptor.java
@@ -1,0 +1,127 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_interceptors;
+
+import java.security.Principal;
+import java.util.Map;
+
+import javax.ejb.EJBAccessException;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.InvocationContext;
+import javax.resource.spi.IllegalStateException;
+
+import org.jboss.as.controller.security.SubjectUserInfo;
+import org.jboss.as.domain.management.security.RealmUser;
+import org.jboss.remoting3.Connection;
+import org.jboss.remoting3.security.UserInfo;
+import org.jboss.security.SecurityContext;
+
+/**
+ * The server side security interceptor responsible for handling any security identity propagated from the client.
+ * 
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ServerSecurityInterceptor {
+
+    static final String DELEGATED_USER_KEY = ServerSecurityInterceptor.class.getName() + ".DelegationUser";
+
+    @AroundInvoke
+    public Object aroundInvoke(final InvocationContext invocationContext) throws Exception {
+        Principal desiredUser = null;
+        RealmUser connectionUser = null;
+
+        Map<String, Object> contextData = invocationContext.getContextData();
+        if (contextData.containsKey(DELEGATED_USER_KEY)) {
+            desiredUser = new SimplePrincipal((String) contextData.get(DELEGATED_USER_KEY));
+
+            Connection con = SecurityActions.remotingContextGetConnection();
+
+            if (con != null) {
+                UserInfo userInfo = con.getUserInfo();
+                if (userInfo instanceof SubjectUserInfo) {
+                    SubjectUserInfo sinfo = (SubjectUserInfo) userInfo;
+                    for (Principal current : sinfo.getPrincipals()) {
+                        if (current instanceof RealmUser) {
+                            connectionUser = (RealmUser) current;
+                            break;
+                        }
+                    }
+                }
+
+            } else {
+                throw new IllegalStateException("Delegation user requested but no user on connection found.");
+            }
+        }
+
+        SecurityContext cachedSecurityContext = null;
+        boolean contextSet = false;
+        try {
+            if (desiredUser != null && connectionUser != null
+                    && (desiredUser.getName().equals(connectionUser.getName()) == false)) {
+                // The final part of this check is to verify that the change does actually indicate a change in user.
+
+                // We have been requested to switch user and have successfully identified the user from the connection
+                // so now we attempt the switch.
+                cachedSecurityContext = SecurityActions.securityContextSetPrincipalInfo(desiredUser, new OuterUserCredential(
+                        connectionUser));
+                // keep track that we switched the security context
+                contextSet = true;
+                SecurityActions.remotingContextClear();
+            }
+
+            return invocationContext.proceed();
+        } catch (Exception e) {
+            throw new EJBAccessException("Unable to attempt switching of user.");
+        } finally {
+            // switch back to original security context
+            if (contextSet) {
+                SecurityActions.securityContextSet(cachedSecurityContext);
+            }
+        }
+    }
+
+    private static class SimplePrincipal implements Principal {
+
+        private final String name;
+
+        private SimplePrincipal(final String name) {
+            if (name == null) {
+                throw new IllegalArgumentException("name can not be null.");
+            }
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof SimplePrincipal && equals((SimplePrincipal) other);
+        }
+
+        public boolean equals(SimplePrincipal other) {
+            return this == other || other != null && name.equals(other.name);
+        }
+
+    }
+}

--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/ServerSecurityInterceptor.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/ServerSecurityInterceptor.java
@@ -26,6 +26,7 @@ import javax.resource.spi.IllegalStateException;
 
 import org.jboss.as.controller.security.SubjectUserInfo;
 import org.jboss.as.domain.management.security.RealmUser;
+import org.jboss.logging.Logger;
 import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.security.UserInfo;
 import org.jboss.security.SecurityContext;
@@ -36,6 +37,8 @@ import org.jboss.security.SecurityContext;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 public class ServerSecurityInterceptor {
+
+    private static final Logger logger = Logger.getLogger(ServerSecurityInterceptor.class);
 
     static final String DELEGATED_USER_KEY = ServerSecurityInterceptor.class.getName() + ".DelegationUser";
 
@@ -85,6 +88,8 @@ public class ServerSecurityInterceptor {
 
             return invocationContext.proceed();
         } catch (Exception e) {
+            logger.error("Failed to switch security context for user", e);
+            // Don't propagate the exception stacktrace back to the client for security reasons
             throw new EJBAccessException("Unable to attempt switching of user.");
         } finally {
             // switch back to original security context

--- a/ejb-security-interceptors/src/main/resources/META-INF/jboss-deployment-structure.xml
+++ b/ejb-security-interceptors/src/main/resources/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+  ~ contributors by the @authors tag. See the copyright.txt in the 
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,  
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+  <deployment>
+    <dependencies>
+      <module name="org.jboss.remoting3" />
+      <module name="org.jboss.as.domain-management" />
+      <module name="org.jboss.as.controller" />
+    </dependencies>
+  </deployment>
+  
+</jboss-deployment-structure>

--- a/ejb-security-interceptors/src/main/resources/META-INF/jboss-ejb-client.xml
+++ b/ejb-security-interceptors/src/main/resources/META-INF/jboss-ejb-client.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+  ~ contributors by the @authors tag. See the copyright.txt in the 
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,  
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.0">
+    <client-context>
+        <ejb-receivers exclude-local-receiver="true">
+            <remoting-ejb-receiver outbound-connection-ref="ejb-outbound-connection"/>
+        </ejb-receivers>
+    </client-context>
+</jboss-ejb-client>

--- a/ejb-security-interceptors/src/main/resources/META-INF/jboss-ejb3.xml
+++ b/ejb-security-interceptors/src/main/resources/META-INF/jboss-ejb3.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+  ~ contributors by the @authors tag. See the copyright.txt in the 
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,  
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<jboss xmlns="http://www.jboss.com/xml/ns/javaee"
+       xmlns:jee="http://java.sun.com/xml/ns/javaee"
+       xmlns:ci ="urn:container-interceptors:1.0">
+
+    <jee:assembly-descriptor>
+        <ci:container-interceptors>
+            <!-- Class level container-interceptor -->
+            <jee:interceptor-binding>
+                <ejb-name>IntermediateEJB</ejb-name>
+                <interceptor-class>org.jboss.as.quickstarts.ejb_security_interceptors.ServerSecurityInterceptor</interceptor-class>
+            </jee:interceptor-binding>            
+            <jee:interceptor-binding>
+                <ejb-name>SecuredEJB</ejb-name>
+                <interceptor-class>org.jboss.as.quickstarts.ejb_security_interceptors.ServerSecurityInterceptor</interceptor-class>
+            </jee:interceptor-binding>
+        </ci:container-interceptors>
+    </jee:assembly-descriptor>
+</jboss>

--- a/ejb-security-interceptors/src/main/resources/META-INF/jboss-ejb3.xml
+++ b/ejb-security-interceptors/src/main/resources/META-INF/jboss-ejb3.xml
@@ -21,7 +21,8 @@
 
     <jee:assembly-descriptor>
         <ci:container-interceptors>
-            <!-- Class level container-interceptor -->
+            <!-- Class level container-interceptor which will be applicable for all business method
+             invocations on the bean -->
             <jee:interceptor-binding>
                 <ejb-name>IntermediateEJB</ejb-name>
                 <interceptor-class>org.jboss.as.quickstarts.ejb_security_interceptors.ServerSecurityInterceptor</interceptor-class>

--- a/ejb-security-interceptors/src/main/resources/META-INF/services/org.jboss.ejb.client.EJBClientInterceptor
+++ b/ejb-security-interceptors/src/main/resources/META-INF/services/org.jboss.ejb.client.EJBClientInterceptor
@@ -1,0 +1,5 @@
+# EJB client interceptor(s) that will be added to the end of the interceptor chain during an invocation
+# on EJB. If these interceptors are to be added at a specific position, other than last, then use the
+# programmatic API in the application to register it explicitly to the EJBClientContext
+
+org.jboss.as.quickstarts.ejb_security_interceptors.ClientSecurityInterceptor

--- a/ejb-security-interceptors/src/main/resources/delegation-mapping.properties
+++ b/ejb-security-interceptors/src/main/resources/delegation-mapping.properties
@@ -1,0 +1,1 @@
+ConnectionUser@ApplicationRealm=AppUserOne,AppUserTwo

--- a/ejb-security-interceptors/src/main/resources/jboss-ejb-client.properties
+++ b/ejb-security-interceptors/src/main/resources/jboss-ejb-client.properties
@@ -21,8 +21,6 @@ remote.connection.default.port = 4447
 remote.connection.default.username=ConnectionUser
 remote.connection.default.password=ConnectionPassword1!
 
-#remote.connection.default.username=AnotherUser
-#remote.connection.default.password=AnotherPassword1!
 
 
 

--- a/ejb-security-interceptors/src/main/resources/jboss-ejb-client.properties
+++ b/ejb-security-interceptors/src/main/resources/jboss-ejb-client.properties
@@ -1,0 +1,29 @@
+# JBoss, Home of Professional Open Source
+# Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+# contributors by the @authors tag. See the copyright.txt in the 
+# distribution for a full listing of individual contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,  
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=default
+
+remote.connection.default.host=localhost
+remote.connection.default.port = 4447
+remote.connection.default.username=ConnectionUser
+remote.connection.default.password=ConnectionPassword1!
+
+#remote.connection.default.username=AnotherUser
+#remote.connection.default.password=AnotherPassword1!
+
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
                 <module>ejb-in-war</module>
                 <module>ejb-remote</module>
                 <module>ejb-security</module>
+                <module>ejb-security-interceptors</module>
                 <module>greeter</module>
                 <module>helloworld</module>
                 <module>helloworld-errai</module>


### PR DESCRIPTION
This quickstart is to demonstrate how interceptors can be used to facilitate the switching of identities used for EJB invocations and how this capability can also be used to propagate an identity from server to server.
