### PR TITLE
add cdi-alternative quickstart

### DIFF
--- a/cdi-alternative/README.md
+++ b/cdi-alternative/README.md
@@ -1,0 +1,88 @@
+CDI_Alternative: Demostration of CDI Alternative implementation
+======================================================
+Author: Nevin Zhu
+
+
+What is it?
+-----------
+
+When more than one version of a bean is implemented for different purposes, the ability to switch between the versions during the development phase by injecting one qualifier or another is shown in this demo.
+
+Instead of having to change the source code of the application, one can make the choice at deployment time by using alternatives.
+
+Alternatives are commonly used for purposes like the following:
+
+    *  To handle client-specific business logic that is determined at runtime
+    *  To specify beans that are valid for a particular deployment scenario (for example, when country-specific sales tax laws require country-specific sales tax business logic)
+    *  To create dummy (mock) versions of beans to be used for testing
+
+To make a bean available for lookup, injection, or EL resolution using this mechanism, give it a javax.enterprise.inject.Alternative annotation and then use the alternative element to specify it in the beans.xml file.
+
+
+System requirements
+-------------------
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
+
+The application this project produces is designed to be run on JBoss Enterprise Application Platform 6 or JBoss AS 7. 
+
+ 
+Configure Maven
+---------------
+
+If you have not yet done so, you must [Configure Maven](../README.md#mavenconfiguration) before testing the quickstarts.
+
+
+Start JBoss Enterprise Application Platform 6 or JBoss AS 7
+-------------------------
+
+1. Open a command line and navigate to the root of the JBoss server directory.
+2. The following shows the command line to start the server with the web profile:
+
+        For Linux:   JBOSS_HOME/bin/standalone.sh
+        For Windows: JBOSS_HOME\bin\standalone.bat
+
+
+Build and Deploy the Quickstart
+-------------------------
+
+_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See [Build and Deploy the Quickstarts](../README.md#buildanddeploy) for complete instructions and additional options._
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. Type this command to build and deploy the archive:
+
+        mvn clean package jboss-as:deploy
+        
+4. This will deploy `target/ear/cdi-alternative.ear` to the running instance of the server.
+
+
+Access the application
+---------------------
+
+The application will be running at the following URL <http://localhost:8080/cdi-alternative-web/Demo>.
+
+A message will display for the bean being injected during run time. The alternative version of the beans can be updated in beans.xml
+
+Undeploy the Archive
+--------------------
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. When you are finished testing, type this command to undeploy the archive:
+
+        mvn jboss-as:undeploy
+
+
+Run the Quickstart in JBoss Developer Studio or Eclipse
+-------------------------------------
+You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see [Use JBoss Developer Studio or Eclipse to Run the Quickstarts](../README.md#useeclipse) 
+
+Debug the Application
+------------------------------------
+
+If you want to debug the source code or look at the Javadocs of any library in the project, run either of the following commands to pull them into your local repository. The IDE should then detect them.
+
+    mvn dependency:sources
+    mvn dependency:resolve -Dclassifier=javadoc
+

--- a/cdi-alternative/README.md
+++ b/cdi-alternative/README.md
@@ -2,7 +2,7 @@ cdi-alternative: Demostrates CDI Alternatives
 ======================================================
 Author: Nevin Zhu
 Level: Intermediate
-Technologies: CDI, EJB, Servlet, JSP
+Technologies: CDI, Servlet, JSP
 Summary: Demonstrates the use of CDI Alternatives where the bean is selected during deployment 
 
 What is it?
@@ -20,15 +20,6 @@ Alternatives are commonly used for purposes like the following:
 
 To make a bean available for lookup, injection, or EL resolution using this mechanism, give it a javax.enterprise.inject.Alternative annotation and then use the alternative element to specify it in the beans.xml file.
 
-The example is composed of three maven projects, each with a shared parent. The projects are as follows:
-
-1. `ejb`: This project contains the EJB code and can be built independently to produce the JAR archive.
-
-2. `web`: This project contains a servlet and a JSP page.
-
-3. `ear`: This project builds the EAR artifact and pulls in the ejb and web artifacts.
-
-The root `pom.xml` builds each of the subprojects in the above order and deploys the EAR archive to the server.
 
 System requirements
 -------------------
@@ -71,9 +62,18 @@ _NOTE: The following build command assumes you have configured your Maven user s
 Access the application
 ---------------------
 
-The application will be running at the following URL <http://localhost:8080/cdi-alternative-web/Demo>.
+The application will be running at the following URL <http://localhost:8080/cdi-alternative/Demo>.
 
-A message will display for the bean being injected during run time. The alternative version of the beans can be updated in beans.xml
+A message will display for the bean being injected during run time. 
+
+The alternative version of the beans can be updated in /WEB-INF/beans.xml by removing the <alternative> tag 
+
+or 
+
+change the class name to a different alternative. 
+
+In this quickstart, in order to switch back to the default implementation, 
+comment the <alternative> block. 
 
 Undeploy the Archive
 --------------------

--- a/cdi-alternative/README.md
+++ b/cdi-alternative/README.md
@@ -1,7 +1,9 @@
-CDI_Alternative: Demostration of CDI Alternative implementation
+cdi-alternative: Demostrates CDI Alternatives
 ======================================================
 Author: Nevin Zhu
-
+Level: Intermediate
+Technologies: CDI, EJB, Servlet, JSP
+Summary: Demonstrates the use of CDI Alternatives where the bean is selected during deployment 
 
 What is it?
 -----------
@@ -12,12 +14,21 @@ Instead of having to change the source code of the application, one can make the
 
 Alternatives are commonly used for purposes like the following:
 
-    *  To handle client-specific business logic that is determined at runtime
-    *  To specify beans that are valid for a particular deployment scenario (for example, when country-specific sales tax laws require country-specific sales tax business logic)
-    *  To create dummy (mock) versions of beans to be used for testing
+1)  To handle client-specific business logic that is determined at runtime
+2)  To specify beans that are valid for a particular deployment scenario (for example, when country-specific sales tax laws require country-specific sales tax business logic)
+3)  To create dummy (mock) versions of beans to be used for testing
 
 To make a bean available for lookup, injection, or EL resolution using this mechanism, give it a javax.enterprise.inject.Alternative annotation and then use the alternative element to specify it in the beans.xml file.
 
+The example is composed of three maven projects, each with a shared parent. The projects are as follows:
+
+1. `ejb`: This project contains the EJB code and can be built independently to produce the JAR archive.
+
+2. `web`: This project contains a servlet and a JSP page.
+
+3. `ear`: This project builds the EAR artifact and pulls in the ejb and web artifacts.
+
+The root `pom.xml` builds each of the subprojects in the above order and deploys the EAR archive to the server.
 
 System requirements
 -------------------

--- a/cdi-alternative/ear/pom.xml
+++ b/cdi-alternative/ear/pom.xml
@@ -20,7 +20,6 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>cdi-alternative-ear</artifactId>
-    <version>7.1.1.CR2</version>
     <packaging>ear</packaging>
     <name>JBoss AS Quickstarts: CDI Alternative - EAR</name>
     <description>JBoss AS Quickstarts: CDI Alternative - EAR</description>
@@ -36,8 +35,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>cdi-alternative</artifactId>
-        <version>7.1.1.CR2</version>
-        <relativePath>../pom.xml</relativePath>
+        <version>7.1.2-SNAPSHOT</version>        
     </parent>
 
     <dependencies>
@@ -45,13 +43,13 @@
         <dependency>
             <groupId>org.jboss.as.quickstarts</groupId>
             <artifactId>cdi-alternative-ejb</artifactId>
-            <version>7.1.1.CR2</version>
+            <version>7.1.2-SNAPSHOT</version>
             <type>ejb</type>
         </dependency>
         <dependency>
             <groupId>org.jboss.as.quickstarts</groupId>
             <artifactId>cdi-alternative-web</artifactId>
-            <version>7.1.1.CR2</version>
+            <version>7.1.2-SNAPSHOT</version>
             <type>war</type>
         </dependency>
     </dependencies>
@@ -63,7 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>${version.ear.plugin}</version>
                 <!-- configuring the ear plugin -->
                 <configuration>
                     <!-- Specify the artifact name for the EAR -->
@@ -86,7 +84,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <configuration>
                     <filename>cdi-alternative.ear</filename>
                     <skip>false</skip>
@@ -96,10 +94,10 @@
           annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/cdi-alternative/ear/pom.xml
+++ b/cdi-alternative/ear/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0"?>
+<!-- JBoss, Home of Professional Open Source Copyright 2012, Red Hat, Inc. 
+    and/or its affiliates, and individual contributors by the @authors tag. See 
+    the copyright.txt in the distribution for a full listing of individual contributors. 
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not 
+    use this file except in compliance with the License. You may obtain a copy 
+    of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+    by applicable law or agreed to in writing, software distributed under the 
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+    OF ANY KIND, either express or implied. See the License for the specific 
+    language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!--
+        This pom builds the EAR artifact and includes the ejb and web modules.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.as.quickstarts</groupId>
+    <artifactId>cdi-alternative-ear</artifactId>
+    <version>7.1.1.CR2</version>
+    <packaging>ear</packaging>
+    <name>JBoss AS Quickstarts: CDI Alternative - EAR</name>
+    <description>JBoss AS Quickstarts: CDI Alternative - EAR</description>
+
+    <licenses>
+       <license>
+          <name>Apache License, Version 2.0</name>
+          <distribution>repo</distribution>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+       </license>
+    </licenses>
+
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>cdi-alternative</artifactId>
+        <version>7.1.1.CR2</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <dependencies>
+        <!-- Dependencies on the ejb and web modules so that they can be found by the ear plugin -->
+        <dependency>
+            <groupId>org.jboss.as.quickstarts</groupId>
+            <artifactId>cdi-alternative-ejb</artifactId>
+            <version>7.1.1.CR2</version>
+            <type>ejb</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as.quickstarts</groupId>
+            <artifactId>cdi-alternative-web</artifactId>
+            <version>7.1.1.CR2</version>
+            <type>war</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+
+        <plugins>
+            <!-- Ear plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>2.3.2</version>
+                <!-- configuring the ear plugin -->
+                <configuration>
+                    <!-- Specify the artifact name for the EAR -->
+                    <finalName>cdi-alternative</finalName>
+                    <modules>
+                        <!-- specify which web modules to include in the EAR -->
+                        <webModule>
+                            <groupId>org.jboss.as.quickstarts</groupId>
+                            <artifactId>cdi-alternative-web</artifactId>
+                        </webModule>
+                        <!-- specify which EJB modules to include in the EAR -->
+                        <ejbModule>
+                            <groupId>org.jboss.as.quickstarts</groupId>
+                            <artifactId>cdi-alternative-ejb</artifactId>
+                        </ejbModule>
+                    </modules>
+                </configuration>
+            </plugin>
+            <!-- JBoss AS plugin to deploy ear -->
+            <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <version>7.1.1.Final</version>
+                <configuration>
+                    <filename>cdi-alternative.ear</filename>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <!-- Compiler plugin enforces Java 1.6 compatibility and activates
+          annotation processors -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/cdi-alternative/ejb/pom.xml
+++ b/cdi-alternative/ejb/pom.xml
@@ -20,7 +20,6 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>cdi-alternative-ejb</artifactId>
-    <version>7.1.1.CR2</version>
     <name>JBoss AS Quickstarts: CDI Alternative - EJB</name>
     <description>JBoss AS Quickstarts: CDI Alternative - EJB</description>
 
@@ -35,8 +34,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>cdi-alternative</artifactId>
-        <version>7.1.1.CR2</version>
-        <relativePath>../pom.xml</relativePath>
+        <version>7.1.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -75,10 +73,10 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/cdi-alternative/ejb/pom.xml
+++ b/cdi-alternative/ejb/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<!-- JBoss, Home of Professional Open Source Copyright 2012, Red Hat, Inc. 
+    and/or its affiliates, and individual contributors by the @authors tag. See 
+    the copyright.txt in the distribution for a full listing of individual contributors. 
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not 
+    use this file except in compliance with the License. You may obtain a copy 
+    of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+    by applicable law or agreed to in writing, software distributed under the 
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+    OF ANY KIND, either express or implied. See the License for the specific 
+    language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!--
+        The pom builds the EJB JAR artifact.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.as.quickstarts</groupId>
+    <artifactId>cdi-alternative-ejb</artifactId>
+    <version>7.1.1.CR2</version>
+    <name>JBoss AS Quickstarts: CDI Alternative - EJB</name>
+    <description>JBoss AS Quickstarts: CDI Alternative - EJB</description>
+
+    <licenses>
+       <license>
+          <name>Apache License, Version 2.0</name>
+          <distribution>repo</distribution>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+       </license>
+    </licenses>
+   
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>cdi-alternative</artifactId>
+        <version>7.1.1.CR2</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <dependencies>
+
+        <!-- Import the CDI API, we use provided scope as the API is included
+    in JBoss AS 7 -->
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Import the Common Annotations API (JSR-250), we use provided scope
+            as the API is included in JBoss AS 7 -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Import the EJB API, we use provided scope as the API is included in
+              JBoss AS 7 -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <!-- Specify the artifact name, this is referred to in the EAR's application.xml -->
+        <finalName>cdi-alternative-ejb</finalName>
+        <!-- Compiler plugin enforces Java 1.6 compatibility and activates
+      annotation processors -->
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/cdi-alternative/ejb/src/main/java/org/jboss/as/quickstarts/cdi/alternative/California.java
+++ b/cdi-alternative/ejb/src/main/java/org/jboss/as/quickstarts/cdi/alternative/California.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cdi.alternative;
+
+/**
+ * <p>
+ * Default implementation for StateTax
+ * </p>
+ * 
+ * @author Nevin Zhu
+ * 
+ */
+public class California implements StateTax {
+	public String getRate () {
+		return "California Tax Rate!";
+	}
+}

--- a/cdi-alternative/ejb/src/main/java/org/jboss/as/quickstarts/cdi/alternative/StateTax.java
+++ b/cdi-alternative/ejb/src/main/java/org/jboss/as/quickstarts/cdi/alternative/StateTax.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cdi.alternative;
+
+/**
+ * <p>
+ * Interface declaration for StateTax
+ * </p>
+ * 
+ * @author Nevin Zhu
+ * 
+ */
+public interface StateTax {
+	String getRate ();
+}

--- a/cdi-alternative/ejb/src/main/java/org/jboss/as/quickstarts/cdi/alternative/Tax.java
+++ b/cdi-alternative/ejb/src/main/java/org/jboss/as/quickstarts/cdi/alternative/Tax.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cdi.alternative;
+
+import javax.ejb.Remote;
+
+/**
+ * <p>
+ * EJB Remote Interface
+ * </p>
+ * 
+ * @author Nevin Zhu
+ * 
+ */
+@Remote
+public interface Tax {
+	String getRate ();
+}

--- a/cdi-alternative/ejb/src/main/java/org/jboss/as/quickstarts/cdi/alternative/TaxBean.java
+++ b/cdi-alternative/ejb/src/main/java/org/jboss/as/quickstarts/cdi/alternative/TaxBean.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cdi.alternative;
+
+import javax.ejb.Singleton;
+import javax.inject.Inject;
+
+import org.jboss.as.quickstarts.cdi.alternative.Tax;
+
+/**
+ * <p>
+ * EJB Bean Implementation. 
+ * 
+ * the stateTax attribute will be injected during run time. 
+ * If beans.xml has class Washington defined as an alternative, then that class will be injected.  
+ * Otherwise, the default California is injected. 
+ * </p>
+ * 
+ * @author Nevin Zhu
+ * 
+ */
+public @Singleton class TaxBean implements Tax {
+    @Inject
+    private StateTax stateTax;
+    
+    public String getRate() {
+        return stateTax.getRate();
+    }
+
+}

--- a/cdi-alternative/ejb/src/main/java/org/jboss/as/quickstarts/cdi/alternative/Washington.java
+++ b/cdi-alternative/ejb/src/main/java/org/jboss/as/quickstarts/cdi/alternative/Washington.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cdi.alternative;
+
+import javax.enterprise.inject.Alternative;
+
+/**
+ * Alternative implementation for state tax
+ * 
+ * @author Nevin Zhu
+ * 
+ */
+@Alternative
+public class Washington implements StateTax {
+
+	@Override
+	public String getRate() {
+		// TODO Auto-generated method stub
+		return "Washington Tax Rate! To switch back to the default class, go to /META-INF/beans.xml and comment out the 'alternatives' tag";
+	}
+
+}

--- a/cdi-alternative/ejb/src/main/resources/META-INF/beans.xml
+++ b/cdi-alternative/ejb/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee">
+<alternatives>
+	<class>org.jboss.as.quickstarts.cdi.alternative.Washington</class>
+</alternatives>
+</beans>
+

--- a/cdi-alternative/pom.xml
+++ b/cdi-alternative/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>cdi-alternative</artifactId>
-    <version>7.1.1.CR2</version>
+    <version>7.1.2-SNAPSHOT</version>
     <name>JBoss AS Quickstarts: CDI Alternative - Root pom</name>
     <description>JBoss AS Quickstarts: CDI Alternative in an Root pom</description>
     <packaging>pom</packaging>
@@ -30,11 +30,25 @@
     </licenses>
 
     <properties>
-        <!-- Explicitly declaring the source encoding eliminates the following
-               message: -->
+        <!-- Explicitly declaring the source encoding eliminates the following message: -->
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
                 resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
+        <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
+
+        <!-- other plugin versions -->
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.ear.plugin>2.3.2</version.ear.plugin>
+        <version.ejb.plugin>2.3</version.ejb.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
     <dependencyManagement>
@@ -52,7 +66,7 @@
             <dependency>
                 <groupId>org.jboss.spec</groupId>
                 <artifactId>jboss-javaee-6.0</artifactId>
-                <version>3.0.0.Final-redhat-1</version>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -64,10 +78,10 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 <configuration>
                     <skip>true</skip>
-                </configuration> 
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/cdi-alternative/pom.xml
+++ b/cdi-alternative/pom.xml
@@ -11,39 +11,41 @@
     language governing permissions and limitations under the License. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!--
+        The pom builds the web WAR artifact.
+    -->
+
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>cdi-alternative</artifactId>
     <version>7.1.2-SNAPSHOT</version>
-    <name>JBoss AS Quickstarts: CDI Alternative - Root pom</name>
-    <description>JBoss AS Quickstarts: CDI Alternative in an Root pom</description>
-    <packaging>pom</packaging>
+    <packaging>war</packaging>
+    <name>JBoss AS Quickstarts: CDI Alternative</name>
+    <description>JBoss AS Quickstarts: CDI Alternative</description>
 
     <url>http://jboss.org/jbossas</url>
     <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <distribution>repo</distribution>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-        </license>
+       <license>
+          <name>Apache License, Version 2.0</name>
+          <distribution>repo</distribution>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+       </license>
     </licenses>
-
+   
     <properties>
         <!-- Explicitly declaring the source encoding eliminates the following message: -->
-        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
-                resources, i.e. build is platform dependent! -->
+        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
+            resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
         <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>
-        <version.ear.plugin>2.3.2</version.ear.plugin>
-        <version.ejb.plugin>2.3</version.ejb.plugin>
         <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
@@ -53,9 +55,9 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
-               Any dependencies from org.jboss.spec will have their version defined by this
-               BOM -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import. 
+                Any dependencies from org.jboss.spec will have their version defined by this 
+                BOM -->
             <!-- JBoss distributes a complete set of Java EE 6 APIs including
                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
                 a collection) of artifacts. We use this here so that we always get the correct
@@ -72,25 +74,69 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    
+
+    <dependencies>
+
+          <!-- Import the CDI API, we use provided scope as the API is included
+                    in JBoss AS 7 -->
+          <dependency>
+               <groupId>javax.enterprise</groupId>
+               <artifactId>cdi-api</artifactId>
+               <scope>provided</scope>
+          </dependency>
+
+
+          <!-- Import the Common Annotations API (JSR-250), we use provided scope
+                    as the API is included in JBoss AS 7 -->
+          <dependency>
+               <groupId>org.jboss.spec.javax.annotation</groupId>
+               <artifactId>jboss-annotations-api_1.1_spec</artifactId>
+               <scope>provided</scope>
+          </dependency>
+
+
+          <!-- Import the Servlet API, we use provided scope as the API is included
+                    in JBoss AS 7 -->
+          <dependency>
+               <groupId>org.jboss.spec.javax.servlet</groupId>
+               <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+               <scope>provided</scope>
+          </dependency>        
+        </dependencies>
+
 
     <build>
+        <!-- Set the name of the war, used as the context root when the app
+            is deployed -->
+        <finalName>cdi-alternative</finalName>
         <plugins>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${version.war.plugin}</version>
+                <configuration>
+                    <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+           <!-- JBoss AS plugin to deploy war -->
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
                 <version>${version.org.jboss.as.plugins.maven.plugin}</version>
+            </plugin>            
+            <!-- Compiler plugin enforces Java 1.6 compatibility and activates
+                annotation processors -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
-                    <skip>true</skip>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
-    <modules>
-        <module>ejb</module>
-        <module>web</module>
-        <module>ear</module>
-    </modules>
 
 </project>
 

--- a/cdi-alternative/pom.xml
+++ b/cdi-alternative/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<!-- JBoss, Home of Professional Open Source Copyright 2012, Red Hat, Inc. 
+    and/or its affiliates, and individual contributors by the @authors tag. See 
+    the copyright.txt in the distribution for a full listing of individual contributors. 
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not 
+    use this file except in compliance with the License. You may obtain a copy 
+    of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+    by applicable law or agreed to in writing, software distributed under the 
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+    OF ANY KIND, either express or implied. See the License for the specific 
+    language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.as.quickstarts</groupId>
+    <artifactId>cdi-alternative</artifactId>
+    <version>7.1.1.CR2</version>
+    <name>JBoss AS Quickstarts: CDI Alternative - Root pom</name>
+    <description>JBoss AS Quickstarts: CDI Alternative in an Root pom</description>
+    <packaging>pom</packaging>
+
+    <url>http://jboss.org/jbossas</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <!-- Explicitly declaring the source encoding eliminates the following
+               message: -->
+        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
+                resources, i.e. build is platform dependent! -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+               Any dependencies from org.jboss.spec will have their version defined by this
+               BOM -->
+            <!-- JBoss distributes a complete set of Java EE 6 APIs including
+                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                a collection) of artifacts. We use this here so that we always get the correct
+                versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                use this stack with any version of JBoss AS that implements Java EE 6, not
+                just JBoss AS 7! -->
+            <dependency>
+                <groupId>org.jboss.spec</groupId>
+                <artifactId>jboss-javaee-6.0</artifactId>
+                <version>3.0.0.Final-redhat-1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <version>7.1.1.Final</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration> 
+            </plugin>
+        </plugins>
+    </build>
+
+    <modules>
+        <module>ejb</module>
+        <module>web</module>
+        <module>ear</module>
+    </modules>
+
+</project>
+

--- a/cdi-alternative/src/main/java/org/jboss/as/quickstarts/cdi/alternative/Demo.java
+++ b/cdi-alternative/src/main/java/org/jboss/as/quickstarts/cdi/alternative/Demo.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cdi.alternative;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * <p>
+ * Servlet implementation class Demo
+ * </p>
+ * 
+ * @author Nevin Zhu
+ * 
+ */
+@WebServlet("/Demo")
+public class Demo extends HttpServlet {
+	private static final long serialVersionUID = 1L;
+	
+	/*
+	 * Attribute will be injected during run time. 
+     * If beans.xml has alternative defined, then that class will be injected.  
+     * Otherwise, the default is injected.
+	 */
+    @Inject
+    private Tax tax;       
+    /**
+     * default constructor
+     */
+    public Demo() {
+        super();
+
+    }
+
+	/**
+	 * handles the incoming servlet request
+	 */
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+		try {			 
+			request.setAttribute("type", tax.getRate());
+			RequestDispatcher dispatcher = getServletContext().getRequestDispatcher("/result.jsp");
+			dispatcher.forward(request,response);
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+		}
+	}
+
+
+}

--- a/cdi-alternative/src/main/java/org/jboss/as/quickstarts/cdi/alternative/Tax.java
+++ b/cdi-alternative/src/main/java/org/jboss/as/quickstarts/cdi/alternative/Tax.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cdi.alternative;
+
+/**
+ * <p>
+ * Interface declaration for Tax
+ * </p>
+ * 
+ * @author Nevin Zhu
+ * 
+ */
+public interface Tax {
+	String getRate ();
+}

--- a/cdi-alternative/src/main/java/org/jboss/as/quickstarts/cdi/alternative/TaxImpl_1.java
+++ b/cdi-alternative/src/main/java/org/jboss/as/quickstarts/cdi/alternative/TaxImpl_1.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cdi.alternative;
+
+/**
+ * <p>
+ * Default implementation for Tax
+ * </p>
+ * 
+ * @author Nevin Zhu
+ * 
+ */
+public class TaxImpl_1 implements Tax {
+	public String getRate () {
+		return "Tax_1 Rate!";
+	}
+}

--- a/cdi-alternative/src/main/java/org/jboss/as/quickstarts/cdi/alternative/TaxImpl_2.java
+++ b/cdi-alternative/src/main/java/org/jboss/as/quickstarts/cdi/alternative/TaxImpl_2.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cdi.alternative;
+
+import javax.enterprise.inject.Alternative;
+
+/**
+ * Alternative implementation for Tax
+ * 
+ * @author Nevin Zhu
+ * 
+ */
+@Alternative
+public class TaxImpl_2 implements Tax {
+
+	@Override
+	public String getRate() {
+		// TODO Auto-generated method stub
+		return "Tax_2 Rate! To switch back to the default, go to /META-INF/beans.xml and comment out the 'alternatives' tag";
+	}
+
+}

--- a/cdi-alternative/src/main/webapp/WEB-INF/beans.xml
+++ b/cdi-alternative/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee">
+<alternatives>
+	<class>org.jboss.as.quickstarts.cdi.alternative.TaxImpl_2</class>
+</alternatives>
+</beans>
+

--- a/cdi-alternative/src/main/webapp/result.jsp
+++ b/cdi-alternative/src/main/webapp/result.jsp
@@ -1,0 +1,12 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>CDI Alternative Result</title>
+</head>
+<body>
+The injected value is: <%=request.getAttribute("type")%>
+</body>
+</html>

--- a/cdi-alternative/web/pom.xml
+++ b/cdi-alternative/web/pom.xml
@@ -20,7 +20,6 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>cdi-alternative-web</artifactId>
-    <version>7.1.1.CR2</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: CDI Alternative - WEB</name>
     <description>JBoss AS Quickstarts: CDI Alternative - WEB</description>
@@ -36,8 +35,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>cdi-alternative</artifactId>
-        <version>7.1.1.CR2</version>
-        <relativePath>../pom.xml</relativePath>
+        <version>7.1.2-SNAPSHOT</version>
     </parent>
 
 
@@ -99,7 +97,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>${version.war.plugin}</version>
                 <configuration>
                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -109,10 +107,10 @@
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${version.compiler.plugin}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/cdi-alternative/web/pom.xml
+++ b/cdi-alternative/web/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0"?>
+<!-- JBoss, Home of Professional Open Source Copyright 2012, Red Hat, Inc. 
+    and/or its affiliates, and individual contributors by the @authors tag. See 
+    the copyright.txt in the distribution for a full listing of individual contributors. 
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not 
+    use this file except in compliance with the License. You may obtain a copy 
+    of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+    by applicable law or agreed to in writing, software distributed under the 
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+    OF ANY KIND, either express or implied. See the License for the specific 
+    language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!--
+        The pom builds the web WAR artifact.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.as.quickstarts</groupId>
+    <artifactId>cdi-alternative-web</artifactId>
+    <version>7.1.1.CR2</version>
+    <packaging>war</packaging>
+    <name>JBoss AS Quickstarts: CDI Alternative - WEB</name>
+    <description>JBoss AS Quickstarts: CDI Alternative - WEB</description>
+
+    <licenses>
+       <license>
+          <name>Apache License, Version 2.0</name>
+          <distribution>repo</distribution>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+       </license>
+    </licenses>
+   
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>cdi-alternative</artifactId>
+        <version>7.1.1.CR2</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+
+    <dependencies>
+
+        <!-- Import the ejb project so that the JSF managed bean can use the EJB -->
+        <dependency>
+            <groupId>org.jboss.as.quickstarts</groupId>
+            <artifactId>cdi-alternative-ejb</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Import the CDI API, we use provided scope as the API is included
+            in JBoss AS 7 -->
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <!-- Import the Common Annotations API (JSR-250), we use provided scope
+            as the API is included in JBoss AS 7 -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Import the JSF API, we use provided scope as the API is included
+            in JBoss AS 7 -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.faces</groupId>
+            <artifactId>jboss-jsf-api_2.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Import the Servlet API, we use provided scope as the API is included
+            in JBoss AS 7 -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>        
+        <!-- Import the EJB API, we use provided scope as the API is included in
+              JBoss AS 7 -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <!-- Set the name of the war, used as the context root when the app
+            is deployed -->
+        <finalName>cdi-alternative-web</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.1.1</version>
+                <configuration>
+                    <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+            <!-- Compiler plugin enforces Java 1.6 compatibility and activates
+                annotation processors -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/cdi-alternative/web/src/main/java/org/jboss/as/quickstarts/cdi/alternative/web/Demo.java
+++ b/cdi-alternative/web/src/main/java/org/jboss/as/quickstarts/cdi/alternative/web/Demo.java
@@ -1,0 +1,74 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cdi.alternative.web;
+
+import java.io.IOException;
+
+import javax.naming.InitialContext;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.as.quickstarts.cdi.alternative.Tax;
+
+/**
+ * Servlet implementation class Demo
+ */
+@WebServlet("/Demo")
+public class Demo extends HttpServlet {
+	private static final long serialVersionUID = 1L;
+       
+    /**
+     * @see HttpServlet#HttpServlet()
+     */
+    public Demo() {
+        super();
+        // TODO Auto-generated constructor stub
+    }
+
+	/**
+	 * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
+	 */
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		// TODO Auto-generated method stub
+		try {
+			InitialContext context = new InitialContext ();
+			                                 
+			Tax tax = (Tax) context.lookup("java:global/cdi-alternative/cdi-alternative-ejb/TaxBean!org.jboss.as.quickstarts.cdi.alternative.Tax");
+			tax.getRate();
+			
+			request.setAttribute("type", tax.getRate());
+			RequestDispatcher dispatcher = getServletContext().getRequestDispatcher("/result.jsp");
+			dispatcher.forward(request,response);
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
+	 */
+	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		// TODO Auto-generated method stub
+	}
+
+}

--- a/cdi-alternative/web/src/main/webapp/result.jsp
+++ b/cdi-alternative/web/src/main/webapp/result.jsp
@@ -1,0 +1,12 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>CDI Alternative Result</title>
+</head>
+<body>
+The injected value is: <%=request.getAttribute("type")%>
+</body>
+</html>


### PR DESCRIPTION
This is a Quick-Start showing how CDI-Alternative is implemented. The project consists of an EAR with a nested JAR (ejb) and WAR. 
