### PR TITLE
Compatibility updates for asciidoctor

### DIFF
--- a/guide/Archetype.asciidoc
+++ b/guide/Archetype.asciidoc
@@ -1,7 +1,8 @@
 Creating your own application
 =============================
 :Author: Pete Muir
-anchor:Archetype-[]
+
+[[Archetype-]]
 
 What we didn't tell you about the kitchensink quickstart is that it is generated from a Maven archetype. Using this archetype offers you the perfect opportunity to generate your own project. 
 

--- a/guide/GettingStarted.asciidoc
+++ b/guide/GettingStarted.asciidoc
@@ -1,7 +1,8 @@
 Getting started with JBoss Enterprise Application Platform or JBoss AS 7
 ========================================================================
 :Author: Pete Muir
-anchor:GettingStarted-[]
+
+[[GettingStarted-]]
 
 To run the quickstarts with the provided build scripts, you'll need:
 
@@ -61,7 +62,7 @@ server. We use this throughout the quickstarts.
 
 Installing and starting the JBoss server on Linux, Unix or Mac OS X
 -------------------------------------------------------------------
-anchor:GettingStarted-on_linux[]
+[[GettingStarted-on_linux]]
 
 First, let's verify that verify that both Java and Maven are correctly 
 installed. In a console, type:
@@ -104,7 +105,7 @@ covers more on configuring logging.
 
 Installing and starting the JBoss server on Windows
 ---------------------------------------------------
-anchor:GettingStarted-on_windows[]
+[[GettingStarted-on_windows]]
 
 
 First, let's verify that verify that both Java and Maven are correctly installed. In a Command Prompt, type:
@@ -143,7 +144,7 @@ covers more on configuring logging.
 
 Starting the JBoss server from JBDS or Eclipse with JBoss Tools
 ---------------------------------------------------------------
-anchor:GettingStarted-with_jboss_tools[]
+[[GettingStarted-with_jboss_tools]]
 
 You may choose to use JBoss Developer Studio, or Eclipse with JBoss Tools, rather than the command line to run JBoss Enterprise Application Platform 6 or JBoss AS 7, and to deploy the quickstarts. If you don't wish to use Eclipse, you should skip this section.
 
@@ -197,7 +198,7 @@ That's it, we now have the server up and running in Eclipse!
 
 Importing the quickstarts into Eclipse
 --------------------------------------
-anchor:GettingStarted-importing_quickstarts_into_eclipse[]
+[[GettingStarted-importing_quickstarts_into_eclipse]]
 
 In order to import the quickstarts into Eclipse, you will need m2eclipse installed. If you have JBoss Developer Studio, then m2eclipse is already installed.
 

--- a/guide/GreeterQuickstart.asciidoc
+++ b/guide/GreeterQuickstart.asciidoc
@@ -1,7 +1,8 @@
 CDI + JPA + EJB + JTA + JSF: Greeter quickstart
 ===============================================
 :Author: Pete Muir
-anchor:GreeterQuickstart-[]
+
+[[GreeterQuickstart-]]
 
 This quickstart shows you how to create and deploy an application which persists information to a database to JBoss Enterprise Application Platform 6 or JBoss AS 7. Information is displayed using JSF views, business logic is encapsulated in CDI beans, information is persisted using JPA, and transactions can be controlled manually or using EJB.
 
@@ -35,6 +36,7 @@ The quickstart is comprised of two JSF views, an entity, and a number of CDI bea
 `persistence.xml` is pretty straight forward, and links JPA to a datasource: 
 
 .src/main/resources/META-INF/persistence.xml
+[source, xml]
 ------------------------------------------------------------------------
 <persistence version="2.0"
     xmlns="http://java.sun.com/xml/ns/persistence" 

--- a/guide/HelloworldOSGiQuickstart.asciidoc
+++ b/guide/HelloworldOSGiQuickstart.asciidoc
@@ -1,7 +1,8 @@
 OSGi: Helloworld OSGi quickstart
 ================================
 :Author: Pete Muir
-anchor:HelloworldOSGiQuickstart-[]
+
+[[HelloworldOSGiQuickstart-]]
 
 This quickstart shows you how to create and deploy a simple OSGi Bundle.
 

--- a/guide/HelloworldQuickstart.asciidoc
+++ b/guide/HelloworldQuickstart.asciidoc
@@ -1,7 +1,8 @@
 CDI + Servlet: Helloworld quickstart
 ====================================
 :Author: Pete Muir
-anchor:HelloworldQuickstart-[]
+
+[[HelloworldQuickstart-]]
 
 This quickstart shows you how to deploy a simple servlet to JBoss Enterprise Application Platform 6 or JBoss AS 7. The business logic is encapsulated in a service, which is provided as a CDI bean, and injected into the Servlet.
 

--- a/guide/KitchensinkQuickstart.asciidoc
+++ b/guide/KitchensinkQuickstart.asciidoc
@@ -1,7 +1,8 @@
 CDI + JSF + EJB + JTA + Bean Validation + JAX-RS + Arquillian: Kitchensink quickstart
 =====================================================================================
 :Author: Pete Muir
-anchor:KitchensinkQuickstart-[]
+
+[[KitchensinkQuickstart-]]
 
 This quickstart shows off all the new features of Java EE 6, and makes a great starting point for your project.
 
@@ -52,7 +53,7 @@ You may choose to deploy the quickstart using JBoss Developer Studio, or Eclipse
 
 With the quickstarts imported, you can deploy the quickstart by right clicking on the `jboss-as-kitchensink` project, and choosing _Run As -> Run On Server_:
 
-image:gfx/Eclipse_Kitchensink_Deploy_1.jpg[]
+image:gfx/Eclipse_KitchenSink_Deploy_1.jpg[]
 
 Make sure the server is selected, and hit Finish:
  
@@ -60,7 +61,7 @@ image:gfx/Eclipse_Deploy_2.jpg[]
 
 You should see the server start up (unless you already started it in  <<GettingStarted-with_jboss_tools, Starting the JBoss server from JBDS or Eclipse with JBoss Tools>>) and the application deploy in the Console log: 
 
-image:gfx/Eclipse_Kitchensink_Deploy_3.jpg[]
+image:gfx/Eclipse_KitchenSink_Deploy_3.jpg[]
 
 
 The kitchensink quickstart in depth

--- a/guide/NumberguessQuickstart.asciidoc
+++ b/guide/NumberguessQuickstart.asciidoc
@@ -1,7 +1,8 @@
 CDI + JSF: Numberguess quickstart
 =================================
 :Author: Pete Muir
-anchor:NumberguessQuickstart-[]
+
+[[NumberguessQuickstart-]]
 
 This quickstart shows you how to create and deploy a simple application to JBoss Enterprise Application Platform 6 or JBoss AS 7; the application does not persist any information. Information is displayed using a JSF view, and business logic is encapsulated in two CDI beans.
 

--- a/guide/guide.asciidoc
+++ b/guide/guide.asciidoc
@@ -2,6 +2,12 @@ Getting Started Developing Applications
 =======================================
 :Author: Pete Muir
 :doctype: book
+ifdef::asciidoctor[]
+:source-highlighter: highlightjs
+:highlightjs-theme: github
+endif::asciidoctor[]
+:iconsdir: gfx/icons
+:icons:
 
 include::Introduction.asciidoc[]
 


### PR DESCRIPTION
- use [[anchor]] macro instead of anchor:name[]
- asciidoctor-specific rendering options
- set path to icons and enable them
- also fix two invalid image references
