### PR TITLE
Update QS to use -with-resteasy BOM

### DIFF
--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -41,7 +41,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <version.org.hibernate.validator>4.2.0.Final</version.org.hibernate.validator>
         <version.org.hibernate-jpamodelgen>1.1.1.Final</version.org.hibernate-jpamodelgen>
 

--- a/carmart-tx/pom.xml
+++ b/carmart-tx/pom.xml
@@ -33,7 +33,7 @@
 
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <jboss.bom.version>1.0.4.CR7</jboss.bom.version>
+        <jboss.bom.version>1.0.4.CR8</jboss.bom.version>
 
         <!-- This is the Management URL of EWS/Tomcat, so tomcat-maven-plugin 
             can deploy this quickstart on EWS/Tomcat through this URL -->

--- a/carmart/pom.xml
+++ b/carmart/pom.xml
@@ -37,7 +37,7 @@
 
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <jboss.bom.version>1.0.4.CR7</jboss.bom.version>
+        <jboss.bom.version>1.0.4.CR8</jboss.bom.version>
 
         <!-- other plugin versions -->
         <jboss.as.plugin.version>7.3.Final</jboss.as.plugin.version>

--- a/cdi-add-interceptor-binding/pom.xml
+++ b/cdi-add-interceptor-binding/pom.xml
@@ -38,12 +38,12 @@
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.CR7-redhat-1 which is a release certified 
+            line below to use version 1.0.4.CR8-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <version.org.jboss.bom>1.0.4.CR7-redhat-1</version.org.jboss.bom> -->
+        <!-- <version.org.jboss.bom>1.0.4.CR8-redhat-1</version.org.jboss.bom> -->
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/cdi-portable-extension/pom.xml
+++ b/cdi-portable-extension/pom.xml
@@ -38,12 +38,12 @@
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.CR7-redhat-1 which is a release certified 
+            line below to use version 1.0.4.CR8-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <version.org.jboss.bom>1.0.4.CR7-redhat-1</version.org.jboss.bom> -->
+        <!-- <version.org.jboss.bom>1.0.4.CR8-redhat-1</version.org.jboss.bom> -->
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/cdi-veto/pom.xml
+++ b/cdi-veto/pom.xml
@@ -38,7 +38,7 @@
         <!-- JBoss dependency versions -->
         <jboss.as.plugin.version>7.3.Final</jboss.as.plugin.version>
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the
             line below to use version 1.0.2.Final-redhat-1 which is a release certified
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -37,7 +37,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/deltaspike-authorization/pom.xml
+++ b/deltaspike-authorization/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/deltaspike-beanbuilder/pom.xml
+++ b/deltaspike-beanbuilder/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/deltaspike-beanmanagerprovider/pom.xml
+++ b/deltaspike-beanmanagerprovider/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/deltaspike-deactivatable/pom.xml
+++ b/deltaspike-deactivatable/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/deltaspike-exception-handling/pom.xml
+++ b/deltaspike-exception-handling/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/deltaspike-helloworld-jms/pom.xml
+++ b/deltaspike-helloworld-jms/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- Weld Version -->
         <version.org.jboss.weld>1.1.9.Final</version.org.jboss.weld>

--- a/deltaspike-projectstage/pom.xml
+++ b/deltaspike-projectstage/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/ejb-in-war/pom.xml
+++ b/ejb-in-war/pom.xml
@@ -36,7 +36,7 @@
 
        <!-- JBoss dependency versions -->
        <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-       <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+       <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/helloworld-errai/pom.xml
+++ b/helloworld-errai/pom.xml
@@ -36,7 +36,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.clean.plugin>2.4.1</version.clean.plugin>

--- a/helloworld-jdg/pom.xml
+++ b/helloworld-jdg/pom.xml
@@ -31,7 +31,7 @@
 
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <jboss.bom.version>1.0.4.CR7</jboss.bom.version>
+        <jboss.bom.version>1.0.4.CR8</jboss.bom.version>
 
         <!-- other plugin versions -->
         <compiler.plugin.version>2.3.2</compiler.plugin.version>

--- a/helloworld-singleton/pom.xml
+++ b/helloworld-singleton/pom.xml
@@ -37,7 +37,7 @@
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
         <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/helloworld-ws/pom.xml
+++ b/helloworld-ws/pom.xml
@@ -43,7 +43,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -39,12 +39,12 @@
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want 
             to import. -->
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.CR7-redhat-1 which is a release certified 
+            line below to use version 1.0.4.CR8-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <version.org.jboss.bom>1.0.4.CR7-redhat-1</version.org.jboss.bom> -->
+        <!-- <version.org.jboss.bom>1.0.4.CR8-redhat-1</version.org.jboss.bom> -->
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/hotrod-endpoint/pom.xml
+++ b/hotrod-endpoint/pom.xml
@@ -31,7 +31,7 @@
 
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <jboss.bom.version>1.0.4.CR7</jboss.bom.version>
+        <jboss.bom.version>1.0.4.CR8</jboss.bom.version>
 
         <!-- other plugin versions -->
         <compiler.plugin.version>2.3.2</compiler.plugin.version>

--- a/jax-rs-client/pom.xml
+++ b/jax-rs-client/pom.xml
@@ -27,7 +27,7 @@
         <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
       </license>
     </licenses>
-    
+
     <properties>
         <!-- Explicitly declaring the source encoding eliminates the following 
             message: -->
@@ -36,11 +36,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <version.org.jboss.resteasy>2.3.5.Final</version.org.jboss.resteasy>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- Other dependency versions -->
         <version.org.apache.httpcomponents>4.1.4</version.org.apache.httpcomponents>
-        <version.junit>4.10</version.junit>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>
@@ -52,17 +51,27 @@
         <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.bom</groupId>
+                <artifactId>jboss-javaee-6.0-with-resteasy</artifactId>
+                <version>${version.org.jboss.bom}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>${version.org.jboss.resteasy}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -101,4 +110,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/kitchensink-deltaspike/pom.xml
+++ b/kitchensink-deltaspike/pom.xml
@@ -40,12 +40,12 @@
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.CR7-redhat-1 which is a release certified 
+            line below to use version 1.0.4.CR8-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <version.org.jboss.bom>1.0.4.CR7-redhat-1</version.org.jboss.bom> -->
+        <!-- <version.org.jboss.bom>1.0.4.CR8-redhat-1</version.org.jboss.bom> -->
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/kitchensink-ear/pom.xml
+++ b/kitchensink-ear/pom.xml
@@ -44,12 +44,12 @@
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.CR7-redhat-1 which is a release certified 
+            line below to use version 1.0.4.CR8-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <version.org.jboss.bom>1.0.4.CR7-redhat-1</version.org.jboss.bom> -->
+        <!-- <version.org.jboss.bom>1.0.4.CR8-redhat-1</version.org.jboss.bom> -->
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -40,12 +40,12 @@
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.CR7-redhat-1 which is a release certified 
+            line below to use version 1.0.4.CR8-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <version.org.jboss.bom>1.0.4.CR7-redhat-1</version.org.jboss.bom> -->
+        <!-- <version.org.jboss.bom>1.0.4.CR8-redhat-1</version.org.jboss.bom> -->
 
         <version.org.hibernate-jpamodelgen>1.1.1.Final</version.org.hibernate-jpamodelgen>
 

--- a/kitchensink-ml-ear/pom.xml
+++ b/kitchensink-ml-ear/pom.xml
@@ -44,12 +44,12 @@
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.CR7-redhat-1 which is a release certified 
+            line below to use version 1.0.4.CR8-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <version.org.jboss.bom>1.0.4.CR7-redhat-1</version.org.jboss.bom> -->
+        <!-- <version.org.jboss.bom>1.0.4.CR8-redhat-1</version.org.jboss.bom> -->
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/kitchensink-ml/pom.xml
+++ b/kitchensink-ml/pom.xml
@@ -40,12 +40,12 @@
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.CR7-redhat-1 which is a release certified 
+            line below to use version 1.0.4.CR8-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <version.org.jboss.bom>1.0.4.CR7-redhat-1</version.org.jboss.bom> -->
+        <!-- <version.org.jboss.bom>1.0.4.CR8-redhat-1</version.org.jboss.bom> -->
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -39,12 +39,12 @@
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.CR7-redhat-1 which is a release certified 
+            line below to use version 1.0.4.CR8-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <version.org.jboss.bom>1.0.4.CR7-redhat-1</version.org.jboss.bom> -->
+        <!-- <version.org.jboss.bom>1.0.4.CR8-redhat-1</version.org.jboss.bom> -->
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/logging-tools/pom.xml
+++ b/logging-tools/pom.xml
@@ -36,7 +36,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/payment-cdi-event/pom.xml
+++ b/payment-cdi-event/pom.xml
@@ -40,12 +40,12 @@
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.CR7-redhat-1 which is a release certified 
+            line below to use version 1.0.4.CR8-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <version.org.jboss.bom>1.0.4.CR7-redhat-1</version.org.jboss.bom> -->
+        <!-- <version.org.jboss.bom>1.0.4.CR8-redhat-1</version.org.jboss.bom> -->
         <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- other plugin versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <!-- JBoss dependency versions -->
         <version.org.jboss.as>7.3.Final</version.org.jboss.as>
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <version.org.jboss.ejb.client>7.1.1.Final</version.org.jboss.ejb.client>
         <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
         <version.org.jboss.logging>3.1.1.GA</version.org.jboss.logging>

--- a/richfaces-validation/pom.xml
+++ b/richfaces-validation/pom.xml
@@ -41,7 +41,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <version.org.hibernate-jpamodelgen>1.1.1.Final</version.org.hibernate-jpamodelgen>
         <version.org.hibernate.validator>4.2.0.Final</version.org.hibernate.validator>

--- a/tasks-jsf/pom.xml
+++ b/tasks-jsf/pom.xml
@@ -41,12 +41,12 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the line below to
-        use version 1.0.4.CR7-redhat-1 which is a release certified
+        use version 1.0.4.CR8-redhat-1 which is a release certified
         to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 maven repository. -->
         <!--
-        <version.org.jboss.bom>1.0.4.CR7-redhat-1</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8-redhat-1</version.org.jboss.bom>
         -->
 
         <!-- other plugin versions -->

--- a/tasks-rs/pom.xml
+++ b/tasks-rs/pom.xml
@@ -30,12 +30,12 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the line below to
-            use version 1.0.4.CR7-redhat-1 which is a release certified
+            use version 1.0.4.CR8-redhat-1 which is a release certified
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 maven repository. -->
         <!--
-        <version.org.jboss.bom>1.0.4.CR7-redhat-1</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8-redhat-1</version.org.jboss.bom>
         -->
 
         <!-- other plugin versions -->

--- a/tasks/pom.xml
+++ b/tasks/pom.xml
@@ -43,12 +43,12 @@
         <!-- JBoss dependency versions -->
         <version.org.jboss.as>7.1.1.Final</version.org.jboss.as>
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.CR7-redhat-1 which is a release certified 
+            line below to use version 1.0.4.CR8-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <!-- <version.org.jboss.bom>1.0.4.CR7-redhat-1</version.org.jboss.bom> -->
+        <!-- <version.org.jboss.bom>1.0.4.CR8-redhat-1</version.org.jboss.bom> -->
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -37,7 +37,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -37,7 +37,7 @@
 
         <!-- JBoss dependency versions -->
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
-        <version.org.jboss.bom>1.0.4.CR7</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.CR8</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>


### PR DESCRIPTION
Update jax-rs-client to use the new -with-resteasy BOM. This makes necessary to use 1.0.4.CR8 BOM that was updated on all QSs
