### PR TITLE
Update temperature-converter error handling and parsing

### DIFF
--- a/temperature-converter/src/main/java/org/jboss/as/quickstarts/temperatureconverter/controller/TemperatureConverter.java
+++ b/temperature-converter/src/main/java/org/jboss/as/quickstarts/temperatureconverter/controller/TemperatureConverter.java
@@ -19,6 +19,8 @@ package org.jboss.as.quickstarts.temperatureconverter.controller;
 import java.io.Serializable;
 
 import javax.enterprise.context.RequestScoped;
+import javax.faces.application.FacesMessage;
+import javax.faces.context.FacesContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -61,7 +63,12 @@ public class TemperatureConverter implements Serializable {
      * @param defaultScale The default source temperature scale
      */
     public void convert() {
-        temperature = temperatureConvertEJB.convert(Temperature.parse(sourceTemperature, defaultScale)).toString();
+        try {
+           temperature = temperatureConvertEJB.convert(Temperature.parse(sourceTemperature, defaultScale)).toString();
+        } catch (IllegalArgumentException e) {
+           temperature = "0.0 Err";
+           FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(e.toString()));
+        }
     }
 
     public String getSourceTemperature() {

--- a/temperature-converter/src/main/java/org/jboss/as/quickstarts/temperatureconverter/ejb/Temperature.java
+++ b/temperature-converter/src/main/java/org/jboss/as/quickstarts/temperatureconverter/ejb/Temperature.java
@@ -35,7 +35,7 @@ public class Temperature {
     /*
      * Create a regular expression to extract the temperature and scale (if passed).
      */
-    private static Pattern PATTERN = Pattern.compile("^([-+]?[0-9]*\\.?[0-9]+)([CF]?)");
+    private static Pattern PATTERN = Pattern.compile("^([-+]?\\d*\\.?\\d+)\\s*([cCfF]?)");
 
     /**
      * Parse a string, with an optional scale suffix. If no scale suffix is on the string, the defaultScale will be used.
@@ -52,23 +52,24 @@ public class Temperature {
          */
         Matcher matcher = PATTERN.matcher(temperature);
 
-        // Extract the temperature
         if (matcher.find()) {
-            t = Double.parseDouble(matcher.group());
+            // Extract the temperature
+            t = Double.parseDouble(matcher.group(1));
+
+            // Use the scale included with the sourceTemperature OR the defaultScale provided.
+            if (!matcher.group(2).isEmpty()) {
+               try {
+                   s = Scale.valueOfAbbreviation(matcher.group(2));
+               } catch (IllegalArgumentException e) {
+                   throw new IllegalArgumentException("You must provide a valid temperature scale- 'C|F'");
+               }
+            } else {
+               s = defaultScale;
+            }
         } else {
             throw new IllegalArgumentException("You must provide a valid temperature to convert- 'XX.XXX'");
         }
 
-        // Use the scale included with the sourceTemperature OR the defaultScale provided.
-        if (matcher.find()) {
-            try {
-                s = Scale.valueOfAbbreviation(matcher.group());
-            } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("You must provide a valid temperature scale- 'C|F'");
-            }
-        } else {
-            s = defaultScale;
-        }
         return new Temperature(t, s);
     }
 

--- a/temperature-converter/src/main/webapp/temperatureconvert.xhtml
+++ b/temperature-converter/src/main/webapp/temperatureconvert.xhtml
@@ -32,14 +32,11 @@
         </h:form>
         <hr />
         <p>How the conversion works:</p>
-        <p>The temperature-string is parsed using two regular expressions that look for the first instance of a valid
-            floating point number, and then, optionally, the first instance of either 'C' or 'F'. It only uses the radio buttons
-            when it cannot find a valid scale in the temperature-string. Consequently, the conversion will work on any string
-            that has a number embedded, and optionally, the letters 'C' or 'F'.</p>
+        <p>The temperature-string is parsed with a regular expression that expects a floating point number followed optionally by a temperature unit ('C' or 'F', case-insensitive).
+            If the temperature unit is missing, the default scale (given by the radio button) is used.</p>
         <p>An 'error message' will be issued if it cannot convert the temperature-string, and '0.0 Err' will be returned as
             the result.</p>
-        <p>Both input temperature and the result are truncated at 3 decimal places only. Scale passed with the temperature
-            will take precedence; case insensitive.</p>
+        <p>Both input temperature and the result are truncated at 3 decimal places only.</p>
 
     </div>
 


### PR DESCRIPTION
this fixes the following issues:
1. on invalid temperature conversion, "0.0 Err" should be printed (currently, a stack trace is shown)
2. the temperature unit should be matched case-insensitively (per the description given in the xhtml)
