### PR TITLE
Pass additional security tokens for authentication before EJB invocation.

### DIFF
--- a/ejb-security-plus/README.md
+++ b/ejb-security-plus/README.md
@@ -1,0 +1,246 @@
+ejb-security-plus:  Using client and server side interceptors to supply additional information for authentication before EJB calls.
+====================
+Author: Darran Lofthouse
+Level: Advanced
+Technologies: EJB, Security
+Summary: Demonstrates how interceptors can be used to supply additional information to be used for authentication before EJB calls.
+Target Product: EAP
+Source: <https://github.com/jboss-jdf/jboss-as-quickstart/>
+
+What is it?
+-----------
+
+By default, when you make a remote call to an EJB deployed to the application server, the connection to the server is authenticated and any request received over this connection is executed as the identity that authenticated the connection. The authentication at the connection level is dependent on the capabilities of the underlying SASL mechanisms.
+
+Rather than writing custom SASL mechanisms or combining multiple parameters into one this quickstart demonstrates how username / password authentication can be used to open the connection to the server and subsequently supply an additional security token for authentication before the EJB invocation. This is achieved with the addition of the following three components: 
+
+1. A client side interceptor to pass the additional token to the remote server.
+2. A server side interceptor to receive the security token and ensure this is passes to the JAAS domain for verification.
+3. A JAAS LoginModule to perform authentication taking into account the authenticated user of the connection and the additional security token.
+ 
+The quickstart then makes use of a single remote EJB, `SecuredEJB` to verify that the propagation and verification of the security token is correct and a `RemoteClient` standalone client. 
+
+### SecuredEJB
+
+For this quickstart the `SecuredEJB` only has the following method: -
+
+    String getPrincipalInformation();
+
+This method is used to confirm the identity of the authenticated user, on the client side changing either the users password or the additional authentication token will cause access to this method to be unavailable.  The output from a successfull call to this method will typically look like: -
+
+	[Principal={quickstartUser}]
+
+### RemoteClient
+
+Finally there is the `RemoteClient` stand-alone client. The client demonstrates how a Principal with a custom credential can be set using the `SecurityContextAssociation` and how this can subsequently be used by a `CallbackHandler` for the username/password authentication required for the SASL authentication and subsequently how the additional token can be picked up by a client side interceptor and passed to the server with the invocation.
+
+
+Note on EJB client interceptors
+-----------------------
+
+JBoss Enterprise Application Platform 6.1 and JBoss AS 7.2 allow client side interceptors for EJB invocations. Such interceptors are expected to implement the `org.jboss.ejb.client.EJBClientInterceptor` interface. User applications can then plug in such interceptors in the 'EJBClientContext' either programatically or through the ServiceLoader mechanism.
+
+- The programmatic way involves calling the `org.jboss.ejb.client.EJBClientContext.registerInterceptor(int order, EJBClientInterceptor interceptor)` API and passing the 'order' and the 'interceptor' instance. The 'order' is used to decide where exactly in the client interceptor chain, this 'interceptor' is going to be placed.
+- The ServiceLoader mechanism is an alternate approach which involves creating a `META-INF/services/org.jboss.ejb.client.EJBClientInterceptor` file and placing/packaging it in the classpath of the client application. The rules for such a file are dictated by the [Java ServiceLoader Mechanism](http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html). This file is expected to contain in each separate line the fully qualified class name of the EJB client interceptor implementation, which is expected to be available in the classpath. EJB client interceptors added via the ServiceLoader mechanism are added to the end of the client interceptor chain, in the order they were found in the classpath.
+
+This quickstart uses the ServiceLoader mechanism for registering the EJB client interceptor and places the `META-INF/services/org.jboss.ejb.client.EJBClientInterceptor` in the classpath, with the following content:
+
+	# EJB client interceptor(s) that will be added to the end of the interceptor chain during an invocation
+	# on EJB. If these interceptors are to be added at a specific position, other than last, then use the
+	# programmatic API in the application to register it explicitly to the EJBClientContext
+
+	org.jboss.as.quickstarts.ejb_security_plus.ClientSecurityInterceptor
+
+
+System requirements
+-------------------
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
+
+The application this project produces is designed to be run on JBoss Enterprise Application Platform 6.1 or JBoss AS 7.2. 
+
+Configure Maven
+---------------
+
+If you have not yet done so, you must [Configure Maven](../README.md#mavenconfiguration) before testing the quickstarts.
+
+Prerequisites
+-------------
+
+_Note_: Unlike most of the quickstarts, this one requires JBoss Enterprise Application Platform 6.1 or JBoss AS 7.2 or later.
+
+This quickstart uses the default standalone configuration plus the modifications described here.
+
+It is recommended that you test this approach in a separate and clean environment before you attempt to port the changes in your own environment.
+
+Configure the JBoss Enterprise Application Platform 6.1 server or JBoss AS 7.2  server
+---------------------------
+
+These steps asume that you are running the server in standalone mode and using the default standalone.xml supplied with the distribution.
+
+You can either edit the standalone.xml configuration before starting the server or you can start the server and execute a series of commands using the JBoss CLI tool, both approaches are described below.  Whichever approach you choose it must be completed before deploying the quickstart.
+
+After the server is configured you will then need to define four user accounts, this can be achieved either by using the add-user tool included with the server or by copying and pasting the appropriate entries into the properties files.  Both of these approaches are described below and whichever approach is chosen it must be completed before running the quickstart - the users can be added before or after starting the server.
+
+### Modify the Server Configuration using the JBoss CLI Tool
+
+1. Start the JBoss Enterprise Application Platform 6 or JBoss AS 7 Server by typing the following: 
+
+		For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh
+		For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat
+2. To start the JBoss CLI tool, open a new command line, navigate to the JBOSS_HOME directory, and type the following:
+    
+		For Linux: bin/jboss-cli.sh --connect
+		For Windows: bin\jboss-cli.bat --connect
+3. At the prompt, enter the following series of commands:
+
+		[standalone@localhost:9999 /] ./subsystem=security/security-domain=quickstart-domain:add(cache-type=default)
+		[standalone@localhost:9999 /] ./subsystem=security/security-domain=quickstart-domain/authentication=classic:add
+		[standalone@localhost:9999 /] ./subsystem=security/security-domain=quickstart-domain/authentication=classic/login-module=DelegationLoginModule:add(code=org.jboss.as.quickstarts.ejb_security_plus.SaslPlusLoginModule,flag=optional,module-options={password-stacking=useFirstPass})    
+		[standalone@localhost:9999 /] ./subsystem=security/security-domain=quickstart-domain/authentication=classic/login-module=RealmDirect:add(code=RealmDirect,flag=required,module-options={password-stacking=useFirstPass})
+
+This block of commands added a new security realm that is used by the quickstart, for this scenario the Remoting login module is no longer used, instead a custom module `SaslPlusLoginModule` is used instead to perform authentication based on the authenticated user of the connection AND the supplied authentication token.  The `RealmDirect` login module is last in the configuration so that roles can be loaded after the user has been verified.
+
+	[standalone@localhost:9999 /] :reload
+
+Finally the server is reloaded to pick up these changes.
+
+### Modify the Server Configuration Manually
+
+1. Open the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
+2. Make the additions described below.
+
+The EJB side of this quickstart makes use of a new security domain called `quickstart-domain`, which delegates to the `ApplicationRealm`. In order to support identity switching we use the `SaslPlusLoginModule` from this quickstart.
+
+	<security-domain name="quickstart-domain" cache-type="default">
+	    <authentication>
+	        <login-module code="org.jboss.as.quickstarts.ejb_security_plus.SaslPlusLoginModule" flag="required">
+	            <module-option name="password-stacking" value="useFirstPass"/>
+	        </login-module>
+	        <login-module code="RealmDirect" flag="required">
+	            <module-option name="password-stacking" value="useFirstPass"/>
+	        </login-module>
+	    </authentication>
+	</security-domain>
+
+This login module MUST be before the existing `RealmDirect` login module, this means that the `SaslPlusLoginModule` can perform the verification of the remote user whilst the `RealmDirect` login module can load the users roles.
+
+If this approach is used and the majority of requests will involve an identity switch, then it is recommended to have this module as the first module in the list. However, if the majority of requests will run as the connection user with occasional switches, it is recommended to place the `Remoting` login module first and this one second.
+
+This login module will load the properties file `additional-secret.properties` from the deployment. The location of this properties file can be overridden with the module-option `additionalSecretProperties`.
+
+At runtime, this login module is used to obtain the current user from the Remoting connection and verify that an additional supplied authentication token matches the value for that user in the properties file.
+
+For this quickstart we use the following entry: 
+
+	quickstartUser=7f5cc521-5061-4a5b-b814-bdc37f021acc
+
+This means that for quickstartUser to be able to call the EJB the specified authentication token must also be supplied with the request.
+
+Add the Application Users
+---------------
+
+This quickstart is built around the default `ApplicationRealm` as configured in the JBoss Enterprise Application  Platform 6.1 or JBoss AS 7.2 server distribution. Using the add-user utility script, you must add the following user to the `ApplicationRealm`:
+
+| **UserName** | **Realm** | **Password** | **Roles** |
+|:-----------|:-----------|:-----------|:-----------|
+| quickstartUser| ApplicationRealm | quiskstartPwd1!| User |
+
+This user is used to both connect to the server and is used for the actual EJB invocation.
+
+For an example of how to use the add-user utility, see instructions in the root README file located here: [Add User](../README.md#addapplicationuser).
+
+### Add Users Manually
+
+Alternatively you can edit the properties file for the users and manually add the required entry:
+
+1. Add the user accounts by editing the file `{jboss.home}/standalone/configuration/application-users.properties` and pasting in the following line:
+
+		quickstartUser=c2d60ae3c894489fa59196c192e351ca
+
+2. Add the users roles by editing the file {jboss.home}/standalone/configuration/application-roles.properties and pasting in the following line: -
+
+		quickstartUser=User
+
+The application server checks the properties files for modifications at runtime so there is no need to restart the server after changing these files.
+
+
+Start JBoss Enterprise Application Platform 6.1 or JBoss AS 7.2
+-------------------------
+
+1. Open a command line and navigate to the root of the JBoss server directory.
+2. The following shows the command line to start the server with the web profile:
+
+		For Linux:   JBOSS_HOME/bin/standalone.sh
+		For Windows: JBOSS_HOME\bin\standalone.bat
+
+
+Build and Deploy the Quickstart
+-------------------------
+
+_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See [Build and Deploy the Quickstarts](../README.md#buildanddeploy) for complete instructions and additional options._
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. Type this command to build and deploy the archive:
+
+		mvn clean package jboss-as:deploy
+
+4. This will deploy `target/jboss-as-ejb-security-plus.jar` to the running instance of the server.
+
+
+Run the client
+---------------------
+
+The step here assumes you have already successfully deployed the EJB to the server in the previous step and that your command prompt is still in the same folder.
+
+1.  Type this command to execute the client:
+
+		mvn exec:exec
+
+
+Investigate the Console Output
+----------------------------
+
+When you run the `mvn exec:exec` command, you see the following output.
+
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    [Principal={quickstartUser}]
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+This output is only displayed when the client has supplied the correct username, password and authentication token combination.
+
+Re-Run the client
+---------------------
+
+You can edit the class `RemoteClient` and update any one of username, password or authentication token.
+
+1.  Type this command to execute the client:
+
+		mvn compile exec:exec
+
+At this point instead of the message shown above you should see a failure.
+
+Undeploy the Archive
+--------------------
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. When you are finished testing, type this command to undeploy the archive:
+
+		mvn jboss-as:undeploy
+
+
+Run the Quickstart in JBoss Developer Studio or Eclipse
+-------------------------------------
+
+You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see [Use JBoss Developer Studio or Eclipse to Run the Quickstarts](../README.md#useeclipse) 
+
+
+Debug the Application
+------------------------------------
+
+If you want to debug the source code or look at the Javadocs of any library in the project, run either of the following commands to pull them into your local repository. The IDE should then detect them.
+
+	mvn dependency:sources
+	mvn dependency:resolve -Dclassifier=javadoc

--- a/ejb-security-plus/pom.xml
+++ b/ejb-security-plus/pom.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.as.quickstarts</groupId>
+    <artifactId>jboss-as-ejb-security-plus</artifactId>
+    <version>7.1.2-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>JBoss AS Quickstarts: EJB Security Plus</name>
+    <description>JBoss AS Quickstarts: EJB Security Plus</description>
+
+    <url>http://jboss.org/jbossas</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <!-- Explicitly declaring the source encoding eliminates the following 
+            message: -->
+        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
+            resources, i.e. build is platform dependent! -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+
+        <version.jboss.maven.plugin>7.3.Final</version.jboss.maven.plugin>
+
+        <version.jboss.as>7.2.0.Final</version.jboss.as>
+        <!-- Alternatively, comment out the above line, and un-comment the 
+            line below to use version 7.2.0.Final-redhat-1 which is a release certified 
+            to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
+            maven repository. -->
+        <!-- <version.jboss.as>7.2.0.Final-redhat-1</version.jboss.as> -->
+
+        <version.jboss.spec.javaee.6.0>3.0.2.Final</version.jboss.spec.javaee.6.0>
+        <!-- Alternatively, comment out the above line, and un-comment the 
+            line below to use version 3.0.2.Final-redhat-2 which is a release certified 
+            to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
+            maven repository. -->
+        <!-- <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-2</version.jboss.spec.javaee.6.0> -->
+
+        <!-- other plugin versions -->
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.exec.plugin>1.2.1</version.exec.plugin>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+                <!-- Define the version of JBoss' Java EE 6 APIs we want to use -->
+                <!-- JBoss distributes a complete set of Java EE 6 APIs including a Bill 
+                    of Materials (BOM). A BOM specifies the versions of a "stack" (or a collection) 
+                    of artifacts. We use this here so that we always get the correct versions 
+                    of artifacts. Here we use the jboss-javaee-6.0 stack (you can read this as 
+                    the JBoss stack of the Java EE 6 APIs). You can actually use this stack with 
+                    any version of JBoss AS that implements Java EE 6, not just JBoss AS 7! -->
+            <dependency>
+                <groupId>org.jboss.spec</groupId>
+                <artifactId>jboss-javaee-6.0</artifactId>
+                <version>${version.jboss.spec.javaee.6.0}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-ejb-client-bom</artifactId>
+                <version>${version.jboss.as}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-security</artifactId>
+        </dependency>
+
+          <!-- Import the CDI API, we use provided scope as the API is included in 
+              JBoss AS 7 -->
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+        </dependency>
+
+          <!-- Import the Common Annotations API (JSR-250), we use provided scope 
+              as the API is included in JBoss AS 7 -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.1_spec</artifactId>
+        </dependency>
+
+          <!-- Import the Servlet API, we use provided scope as the API is included 
+              in JBoss AS 7 -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.ejb3</groupId>
+            <artifactId>jboss-ejb3-ext-api</artifactId>
+        </dependency>
+
+          <!-- JBoss EJB client API jar. We use runtime scope because the EJB client 
+              API isn't directly used in this example. We just need it in our runtime classpath -->
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-ejb-client</artifactId>
+        </dependency>
+
+          <!-- client communications with the server use XNIO -->
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-nio</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+          <!-- data serialization for invoking remote EJBs -->
+        <dependency>
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling-river</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+          <!-- Import the transaction spec API, we use runtime scope because we aren't 
+              using any direct reference to the spec API in our client code -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+          <!-- Set the name of the war, used as the context root when the app is 
+              deployed -->
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+                <!-- Add the maven exec plugin to allow us to run a java program via maven -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${version.exec.plugin}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>java</executable>
+                    <workingDirectory>${project.build.directory}/exec-working-directory</workingDirectory>
+                    <arguments>
+                                  <!-- automatically creates the classpath using all project dependencies, 
+                                      also adding the project build directory -->
+                        <argument>-classpath</argument>
+                        <classpath>
+                        </classpath>
+                        <argument>org.jboss.as.quickstarts.ejb_security_plus.RemoteClient</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
+
+                <!-- JBoss AS plugin to deploy war -->
+            <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <version>${version.jboss.maven.plugin}</version>
+            </plugin>
+                <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation 
+                    processors -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.compiler.plugin}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/ClientSecurityInterceptor.java
+++ b/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/ClientSecurityInterceptor.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_plus;
+
+import java.util.Map;
+
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+
+/**
+ * Client side interceptor responsible for propagating the authentication token.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ClientSecurityInterceptor implements EJBClientInterceptor {
+
+    public void handleInvocation(EJBClientInvocationContext context) throws Exception {
+        Object credential = SecurityActions.securityContextGetCredential();
+
+        if (credential != null && credential instanceof PasswordPlusCredential) {
+            PasswordPlusCredential ppCredential = (PasswordPlusCredential) credential;
+            Map<String, Object> contextData = context.getContextData();
+            contextData.put(ServerSecurityInterceptor.SECURITY_TOKEN_KEY, ppCredential.getAuthToken());
+        }
+
+        context.sendRequest();
+    }
+
+    public Object handleInvocationResult(EJBClientInvocationContext context) throws Exception {
+        return context.getResult();
+    }
+
+}

--- a/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/EJBUtil.java
+++ b/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/EJBUtil.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_plus;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+/**
+ * Utility class for looking up EJBs
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class EJBUtil {
+
+    static SecuredEJBRemote lookupSecuredEJB() throws Exception {
+        final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        final Context context = new InitialContext(jndiProperties);
+
+        return (SecuredEJBRemote) context.lookup("ejb:/jboss-as-ejb-security-plus/SecuredEJB!"
+            + SecuredEJBRemote.class.getName());
+    }
+
+}

--- a/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/OuterUserPlusCredential.java
+++ b/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/OuterUserPlusCredential.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_plus;
+
+import org.jboss.as.domain.management.security.RealmUser;
+
+/**
+ * A wrapper around the user from the incoming connection plus some additional secret to authenticate the incoming user.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public final class OuterUserPlusCredential {
+
+    private final RealmUser user;
+    private final String authToken;
+
+    OuterUserPlusCredential(final RealmUser user, final String authToken) {
+        if (user == null) {
+            throw new IllegalArgumentException("RealmUser can not be null.");
+        }
+        if (authToken == null) {
+            throw new IllegalArgumentException("Auth token can not be null.");
+        }
+        this.user = user;
+        this.authToken = authToken;
+    }
+
+    String getName() {
+        return user.getName();
+    }
+
+    String getRealm() {
+        return user.getRealm();
+    }
+
+    String getAuthToken() {
+        return authToken;
+    }
+
+    @Override
+    public int hashCode() {
+        return user.hashCode() * authToken.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof OuterUserPlusCredential && equals((OuterUserPlusCredential) other);
+    }
+
+    public boolean equals(OuterUserPlusCredential other) {
+        return this == other || other != null && user.equals(other.user) && authToken.equals(other.authToken);
+    }
+
+}

--- a/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/PasswordPlusCredential.java
+++ b/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/PasswordPlusCredential.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_plus;
+
+/**
+ * A credential that is represented by a password and an additional secret token.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class PasswordPlusCredential {
+
+    private final char[] password;
+    private final String authToken;
+
+    public PasswordPlusCredential(final char[] password, final String authToken) {
+        this.password = password;
+        this.authToken = authToken;
+    }
+
+    public char[] getPassword() {
+        return password;
+    }
+
+    public String getAuthToken() {
+        return authToken;
+    }
+
+}

--- a/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/RemoteClient.java
+++ b/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/RemoteClient.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_plus;
+
+import static org.jboss.as.quickstarts.ejb_security_plus.EJBUtil.lookupSecuredEJB;
+
+import org.jboss.security.SimplePrincipal;
+
+/**
+ * The remote client responsible for making a number of calls to the server to demonstrate the capabilities of the interceptors.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class RemoteClient {
+
+    /**
+     * @param args
+     */
+    public static void main(String[] args) throws Exception {
+        System.out.println("\n\n\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n\n");
+
+        SimplePrincipal principal = new SimplePrincipal("quickstartUser");
+        Object credential = new PasswordPlusCredential("quickstartPwd1!".toCharArray(), "7f5cc521-5061-4a5b-b814-bdc37f021acc");
+
+        SecurityActions.securityContextSetPrincipalCredential(principal, credential);
+
+        SecuredEJBRemote secured = lookupSecuredEJB();
+
+        System.out.println(secured.getPrincipalInformation());
+
+        System.out.println("\n\n\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n\n");
+    }
+
+}

--- a/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/SaslPlusLoginModule.java
+++ b/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/SaslPlusLoginModule.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_plus;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.security.acl.Group;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.login.LoginException;
+
+import org.jboss.security.SimpleGroup;
+import org.jboss.security.SimplePrincipal;
+import org.jboss.security.auth.callback.ObjectCallback;
+import org.jboss.security.auth.spi.AbstractServerLoginModule;
+
+/**
+ * A specialised login module to authenticate the user by taking the previously authenticated identity from the connection and
+ * verifying it with additional data.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class SaslPlusLoginModule extends AbstractServerLoginModule {
+
+    private static final String ADDITIONAL_SECRET_PROPERTIES = "additionalSecretProperties";
+
+    private static final String DEFAULT_AS_PROPERTIES = "additional-secret.properties";
+
+    private Properties additionalSecrets;
+
+    private Principal identity;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        addValidOptions(new String[] { ADDITIONAL_SECRET_PROPERTIES });
+        super.initialize(subject, callbackHandler, sharedState, options);
+
+        String propertiesName;
+        if (options.containsKey(ADDITIONAL_SECRET_PROPERTIES)) {
+            propertiesName = (String) options.get(ADDITIONAL_SECRET_PROPERTIES);
+        } else {
+            propertiesName = DEFAULT_AS_PROPERTIES;
+        }
+        try {
+            additionalSecrets = SecurityActions.loadProperties(propertiesName);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(String.format("Unable to load properties '%s'", propertiesName), e);
+        }
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        if (super.login() == true) {
+            log.debug("super.login()==true");
+            return true;
+        }
+
+        // Time to see if this is a delegation request.
+        NameCallback ncb = new NameCallback("Username:");
+        ObjectCallback ocb = new ObjectCallback("Password:");
+
+        try {
+            callbackHandler.handle(new Callback[] { ncb, ocb });
+        } catch (Exception e) {
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            }
+            return false; // If the CallbackHandler can not handle the required callbacks then no chance.
+        }
+
+        String name = ncb.getName();
+        Object credential = ocb.getCredential();
+
+        if (credential instanceof OuterUserPlusCredential) {
+
+            OuterUserPlusCredential oupc = (OuterUserPlusCredential) credential;
+
+            if (verify(name, oupc.getName(), oupc.getAuthToken())) {
+                identity = new SimplePrincipal(name);
+                if (getUseFirstPass()) {
+                    String userName = identity.getName();
+                    if (log.isDebugEnabled())
+                        log.debug("Storing username '" + userName + "' and empty password");
+                    // Add the username and an empty password to the shared state map
+                    sharedState.put("javax.security.auth.login.name", identity);
+                    sharedState.put("javax.security.auth.login.password", oupc);
+                }
+                loginOk = true;
+                return true;
+            }
+        }
+
+        return false; // Attempted login but not successful.
+    }
+
+    private boolean verify(final String authName, final String connectionUser, final String authToken) {
+        // For the purpose of this quick start we are not supporting switching users, this login module is validation an
+        // additional security token for a user that has already passed the sasl process.
+        return authName.equals(connectionUser) && authToken.equals(additionalSecrets.getProperty(authName));
+    }
+
+    @Override
+    protected Principal getIdentity() {
+        return identity;
+    }
+
+    @Override
+    protected Group[] getRoleSets() throws LoginException {
+        Group roles = new SimpleGroup("Roles");
+        Group callerPrincipal = new SimpleGroup("CallerPrincipal");
+        Group[] groups = { roles, callerPrincipal };
+        callerPrincipal.addMember(getIdentity());
+        return groups;
+    }
+
+}

--- a/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/SecuredEJB.java
+++ b/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/SecuredEJB.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_plus;
+
+import javax.annotation.Resource;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Remote;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * A secured EJB which is used to test the identity and roles of the current user during a request.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Stateless
+@Remote(SecuredEJBRemote.class)
+@SecurityDomain("quickstart-domain")
+public class SecuredEJB implements SecuredEJBRemote {
+
+    @Resource
+    private SessionContext context;
+
+    @RolesAllowed("User")
+    public String getPrincipalInformation() {
+        StringBuilder sb = new StringBuilder("[");
+        sb.append("Principal={").append(context.getCallerPrincipal().getName()).append("}]");
+
+        return sb.toString();
+    }
+
+}

--- a/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/SecuredEJBRemote.java
+++ b/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/SecuredEJBRemote.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_plus;
+
+/**
+ * The interface used to access the SecuredEJB
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface SecuredEJBRemote {
+
+    /**
+     * @return A String containing the name of the current principal.
+     */
+    String getPrincipalInformation();
+
+}

--- a/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/SecurityActions.java
+++ b/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/SecurityActions.java
@@ -1,0 +1,403 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_plus;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.AccessController;
+import java.security.Principal;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Properties;
+
+import javax.security.auth.Subject;
+
+import org.jboss.as.security.remoting.RemotingContext;
+import org.jboss.remoting3.Connection;
+import org.jboss.security.SecurityContext;
+import org.jboss.security.SecurityContextAssociation;
+import org.jboss.security.SecurityContextFactory;
+
+/**
+ * Security actions for this package only.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+final class SecurityActions {
+
+    private SecurityActions() {
+    }
+
+    /*
+     * RemotingContext Actions
+     */
+
+    static void remotingContextClear() {
+        remotingContextActions().clear();
+    }
+
+    static Connection remotingContextGetConnection() {
+        return remotingContextActions().getConnection();
+    }
+
+    static boolean remotingContextIsSet() {
+        return remotingContextActions().isSet();
+    }
+
+    private static RemotingContextActions remotingContextActions() {
+        return System.getSecurityManager() == null ? RemotingContextActions.NON_PRIVILEGED : RemotingContextActions.PRIVILEGED;
+    }
+
+    private interface RemotingContextActions {
+
+        void clear();
+
+        Connection getConnection();
+
+        boolean isSet();
+
+        RemotingContextActions NON_PRIVILEGED = new RemotingContextActions() {
+
+            public void clear() {
+                RemotingContext.clear();
+            }
+
+            public boolean isSet() {
+                return RemotingContext.isSet();
+            }
+
+            public Connection getConnection() {
+                return RemotingContext.getConnection();
+            }
+        };
+
+        RemotingContextActions PRIVILEGED = new RemotingContextActions() {
+
+            PrivilegedAction<Void> CLEAR_ACTION = new PrivilegedAction<Void>() {
+
+                public Void run() {
+                    NON_PRIVILEGED.clear();
+                    return null;
+                }
+            };
+
+            PrivilegedAction<Boolean> IS_SET_ACTION = new PrivilegedAction<Boolean>() {
+
+                public Boolean run() {
+                    return NON_PRIVILEGED.isSet();
+                }
+            };
+
+            PrivilegedAction<Connection> GET_CONNECTION_ACTION = new PrivilegedAction<Connection>() {
+
+                public Connection run() {
+                    return NON_PRIVILEGED.getConnection();
+                }
+            };
+
+            public void clear() {
+                AccessController.doPrivileged(CLEAR_ACTION);
+            }
+
+            public boolean isSet() {
+                return AccessController.doPrivileged(IS_SET_ACTION);
+            }
+
+            public Connection getConnection() {
+                return AccessController.doPrivileged(GET_CONNECTION_ACTION);
+            }
+        };
+
+    }
+
+    /*
+     * SecurityContext Actions
+     */
+
+    static SecurityContext securityContextSetPrincipalCredential(final Principal principal, final Object credential)
+            throws Exception {
+        return securityContextActions().setPrincipalCredential(principal, credential);
+    }
+
+    static Principal securityContextGetPrincipal() {
+        return securityContextActions().getPrincipal();
+    }
+
+    static Object securityContextGetCredential() {
+        return securityContextActions().getCredential();
+    }
+
+    static void securityContextSet(final SecurityContext securityContext) {
+
+    }
+
+    private static SecurityContextActions securityContextActions() {
+        return System.getSecurityManager() == null ? SecurityContextActions.NON_PRIVILEGED : SecurityContextActions.PRIVILEGED;
+    }
+
+    private interface SecurityContextActions {
+
+        SecurityContext setPrincipalCredential(final Principal principal, final Object credential) throws Exception;
+
+        Principal getPrincipal();
+
+        Object getCredential();
+
+        void set(final SecurityContext securityContext);
+
+        SecurityContextActions NON_PRIVILEGED = new SecurityContextActions() {
+
+            @Override
+            public SecurityContext setPrincipalCredential(Principal principal, Object credential) throws Exception {
+                SecurityContext current = SecurityContextAssociation.getSecurityContext();
+
+                SecurityContext nextContext = SecurityContextFactory.createSecurityContext(principal, credential,
+                        new Subject(), "USER_DELEGATION");
+                SecurityContextAssociation.setSecurityContext(nextContext);
+
+                return current;
+
+            }
+
+            @Override
+            public Principal getPrincipal() {
+                return SecurityContextAssociation.getPrincipal();
+            }
+
+            @Override
+            public Object getCredential() {
+                return SecurityContextAssociation.getCredential();
+            }
+
+            @Override
+            public void set(SecurityContext securityContext) {
+                SecurityContextAssociation.setSecurityContext(securityContext);
+            }
+
+        };
+
+        SecurityContextActions PRIVILEGED = new SecurityContextActions() {
+
+            PrivilegedAction<Principal> GET_PRINCIPAL_ACTION = new PrivilegedAction<Principal>() {
+
+                @Override
+                public Principal run() {
+                    return NON_PRIVILEGED.getPrincipal();
+                }
+            };
+
+            PrivilegedAction<Object> GET_CREDENTIAL_ACTION = new PrivilegedAction<Object>() {
+
+                @Override
+                public Object run() {
+                    return NON_PRIVILEGED.getCredential();
+                }
+            };
+
+            @Override
+            public SecurityContext setPrincipalCredential(final Principal principal, final Object credential) throws Exception {
+                try {
+                    return AccessController.doPrivileged(new PrivilegedExceptionAction<SecurityContext>() {
+
+                        @Override
+                        public SecurityContext run() throws Exception {
+                            return NON_PRIVILEGED.setPrincipalCredential(principal, credential);
+                        }
+                    });
+                } catch (PrivilegedActionException e) {
+                    throw e.getException();
+                }
+
+            }
+
+            @Override
+            public Principal getPrincipal() {
+                return AccessController.doPrivileged(GET_PRINCIPAL_ACTION);
+            }
+
+            @Override
+            public Object getCredential() {
+                return AccessController.doPrivileged(GET_CREDENTIAL_ACTION);
+            }
+
+            @Override
+            public void set(final SecurityContext securityContext) {
+                AccessController.doPrivileged(new PrivilegedAction<Void>() {
+
+                    @Override
+                    public Void run() {
+                        NON_PRIVILEGED.set(securityContext);
+                        return null;
+                    }
+                });
+            }
+
+        };
+
+    }
+
+    /*
+     * void setSecurityContext(final SecurityContext context);
+     *
+     * void clear();
+     *
+     * Principal getPrincipal();
+     *
+     * void setPrincipal(final Principal principal);
+     *
+     * SecurityContext setPrincipalInfo(final Principal principal, final OuterUserCredential credential) throws Exception;
+     *
+     * SecurityContextActions NON_PRIVILEGED = new SecurityContextActions() {
+     *
+     * public void setSecurityContext(SecurityContext context) { SecurityContextAssociation.setSecurityContext(context); }
+     *
+     * public void clear() { SecurityContextAssociation.clearSecurityContext(); }
+     *
+     * public Principal getPrincipal() { return SecurityContextAssociation.getPrincipal(); }
+     *
+     * public void setPrincipal(final Principal principal) { SecurityContextAssociation.setPrincipal(principal); }
+     *
+     * public SecurityContext setPrincipalInfo(Principal principal, OuterUserCredential credential) throws Exception {
+     * SecurityContext currentContext = SecurityContextAssociation.getSecurityContext();
+     *
+     * SecurityContext nextContext = SecurityContextFactory.createSecurityContext(principal, credential, new Subject(),
+     * "USER_DELEGATION"); SecurityContextAssociation.setSecurityContext(nextContext);
+     *
+     * return currentContext; }
+     *
+     * };
+     *
+     * SecurityContextActions PRIVILEGED = new SecurityContextActions() {
+     *
+     * PrivilegedAction<Principal> GET_PRINCIPAL_ACTION = new PrivilegedAction<Principal>() {
+     *
+     * public Principal run() { return NON_PRIVILEGED.getPrincipal(); } };
+     *
+     * PrivilegedAction<Void> CLEAR_ACTION = new PrivilegedAction<Void>() {
+     *
+     * public Void run() { NON_PRIVILEGED.clear(); return null; } };
+     *
+     * public void setSecurityContext(final SecurityContext context) { AccessController.doPrivileged(new
+     * PrivilegedAction<Void>() {
+     *
+     * public Void run() { NON_PRIVILEGED.setSecurityContext(context); return null; } }); }
+     *
+     * public void clear() { AccessController.doPrivileged(CLEAR_ACTION); }
+     *
+     * public Principal getPrincipal() { return AccessController.doPrivileged(GET_PRINCIPAL_ACTION); }
+     *
+     * public void setPrincipal(final Principal principal) { AccessController.doPrivileged(new PrivilegedAction<Void>() {
+     *
+     * public Void run() { NON_PRIVILEGED.setPrincipal(principal); return null; } }); }
+     *
+     * public SecurityContext setPrincipalInfo(final Principal principal, final OuterUserCredential credential) throws Exception
+     * { try { return AccessController.doPrivileged(new PrivilegedExceptionAction<SecurityContext>() {
+     *
+     * public SecurityContext run() throws Exception { return NON_PRIVILEGED.setPrincipalInfo(principal, credential); } }); }
+     * catch (PrivilegedActionException e) { throw e.getException(); } }
+     *
+     * };
+     *
+     * }
+     */
+
+    /*
+     * ClassLoader Actions
+     */
+
+    static ClassLoader getContextClassLoader() {
+        return (System.getSecurityManager() == null ? ContextClassLoaderAction.NON_PRIVILEGED
+                : ContextClassLoaderAction.PRIVILEGED).getContextClassLoader();
+    }
+
+    private interface ContextClassLoaderAction {
+
+        ClassLoader getContextClassLoader();
+
+        ContextClassLoaderAction NON_PRIVILEGED = new ContextClassLoaderAction() {
+
+            public ClassLoader getContextClassLoader() {
+                return Thread.currentThread().getContextClassLoader();
+            }
+        };
+
+        ContextClassLoaderAction PRIVILEGED = new ContextClassLoaderAction() {
+
+            private PrivilegedAction<ClassLoader> GET_CONTEXT_CLASS_LOADER = new PrivilegedAction<ClassLoader>() {
+
+                public ClassLoader run() {
+                    return NON_PRIVILEGED.getContextClassLoader();
+                }
+            };
+
+            public ClassLoader getContextClassLoader() {
+                return AccessController.doPrivileged(GET_CONTEXT_CLASS_LOADER);
+            }
+        };
+    }
+
+    static Properties loadProperties(final String name) throws IOException {
+        return propertiesAction().loadProperties(name);
+    }
+
+    static PropertiesAction propertiesAction() {
+        return System.getSecurityManager() == null ? PropertiesAction.NON_PRIVILEGED : PropertiesAction.PRIVILEGED;
+    }
+
+    private interface PropertiesAction {
+
+        Properties loadProperties(final String name) throws IOException;
+
+        PropertiesAction NON_PRIVILEGED = new PropertiesAction() {
+
+            @Override
+            public Properties loadProperties(final String name) throws IOException {
+                ClassLoader classLoader = SecurityActions.getContextClassLoader();
+                URL url = classLoader.getResource(name);
+                InputStream is = url.openStream();
+                try {
+                    Properties props = new Properties();
+                    props.load(is);
+                    return props;
+
+                } finally {
+                    is.close();
+                }
+            }
+        };
+
+        PropertiesAction PRIVILEGED = new PropertiesAction() {
+
+            @Override
+            public Properties loadProperties(final String name) throws IOException {
+                try {
+                    return AccessController.doPrivileged(new PrivilegedExceptionAction<Properties>() {
+
+                        @Override
+                        public Properties run() throws IOException {
+                            return NON_PRIVILEGED.loadProperties(name);
+                        }
+                    });
+                } catch (PrivilegedActionException e) {
+                    throw (IOException) e.getException();
+                }
+            }
+        };
+    }
+}

--- a/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/SecurityContextCallbackHandler.java
+++ b/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/SecurityContextCallbackHandler.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_plus;
+
+import java.io.IOException;
+import java.security.Principal;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.RealmCallback;
+
+/**
+ * A {@link CallbackHandler} implementation to take the username and credential from the SecurityContextAssociation.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class SecurityContextCallbackHandler implements CallbackHandler {
+
+    @Override
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        Principal principal = SecurityActions.securityContextGetPrincipal();
+        Object credential = SecurityActions.securityContextGetCredential();
+        if (principal == null) {
+            throw new IllegalStateException("No Principal set.");
+        }
+        if (credential == null) {
+            throw new IllegalStateException("No credential set.");
+        }
+        if (credential instanceof PasswordPlusCredential == false) {
+            throw new IllegalStateException("Invalid credential type.");
+        }
+        PasswordPlusCredential ppCredential = (PasswordPlusCredential) credential;
+
+        for (Callback current : callbacks) {
+            if (current instanceof NameCallback) {
+                NameCallback ncb = (NameCallback) current;
+                ncb.setName(principal.getName());
+            } else if (current instanceof PasswordCallback) {
+                PasswordCallback pcb = (PasswordCallback) current;
+                pcb.setPassword(ppCredential.getPassword());
+            } else if (current instanceof RealmCallback) {
+                RealmCallback rcb = (RealmCallback) current;
+                rcb.setText(rcb.getDefaultText());
+            } else {
+                UnsupportedCallbackException e = new UnsupportedCallbackException(current);
+                e.printStackTrace();
+                throw e;
+            }
+        }
+    }
+
+}

--- a/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/ServerSecurityInterceptor.java
+++ b/ejb-security-plus/src/main/java/org/jboss/as/quickstarts/ejb_security_plus/ServerSecurityInterceptor.java
@@ -1,0 +1,104 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_plus;
+
+import java.security.Principal;
+import java.util.Map;
+
+import javax.ejb.EJBAccessException;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.InvocationContext;
+import javax.resource.spi.IllegalStateException;
+
+import org.jboss.as.controller.security.SubjectUserInfo;
+import org.jboss.as.domain.management.security.RealmUser;
+import org.jboss.logging.Logger;
+import org.jboss.remoting3.Connection;
+import org.jboss.remoting3.security.UserInfo;
+import org.jboss.security.SecurityContext;
+import org.jboss.security.SimplePrincipal;
+
+/**
+ * The server side security interceptor responsible for handling any security token propagated from the client.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ServerSecurityInterceptor {
+
+    private static final Logger logger = Logger.getLogger(ServerSecurityInterceptor.class);
+
+    static final String SECURITY_TOKEN_KEY = ServerSecurityInterceptor.class.getName() + ".SecurityToken";
+
+    @AroundInvoke
+    public Object aroundInvoke(final InvocationContext invocationContext) throws Exception {
+        Principal userPrincipal = null;
+        RealmUser connectionUser = null;
+        String authToken = null;
+
+        Map<String, Object> contextData = invocationContext.getContextData();
+        if (contextData.containsKey(SECURITY_TOKEN_KEY)) {
+            authToken = (String) contextData.get(SECURITY_TOKEN_KEY);
+
+            Connection con = SecurityActions.remotingContextGetConnection();
+
+            if (con != null) {
+                UserInfo userInfo = con.getUserInfo();
+                if (userInfo instanceof SubjectUserInfo) {
+                    SubjectUserInfo sinfo = (SubjectUserInfo) userInfo;
+                    for (Principal current : sinfo.getPrincipals()) {
+                        if (current instanceof RealmUser) {
+                            connectionUser = (RealmUser) current;
+                            break;
+                        }
+                    }
+                }
+                userPrincipal = new SimplePrincipal(connectionUser.getName());
+
+            } else {
+                throw new IllegalStateException("Token authentication requested but no user on connection found.");
+            }
+        }
+
+        SecurityContext cachedSecurityContext = null;
+        boolean contextSet = false;
+        try {
+            if (userPrincipal != null && connectionUser != null && authToken != null) {
+                try {
+                    // We have been requested to use an authentication token
+                    // so now we attempt the switch.
+                    cachedSecurityContext = SecurityActions.securityContextSetPrincipalCredential(userPrincipal,
+                            new OuterUserPlusCredential(connectionUser, authToken));
+                    // keep track that we switched the security context
+                    contextSet = true;
+                    SecurityActions.remotingContextClear();
+                } catch (Exception e) {
+                    logger.error("Failed to switch security context for user", e);
+                    // Don't propagate the exception stacktrace back to the client for security reasons
+                    throw new EJBAccessException("Unable to attempt switching of user.");
+                }
+            }
+
+            return invocationContext.proceed();
+        } finally {
+            // switch back to original security context
+            if (contextSet) {
+                SecurityActions.securityContextSet(cachedSecurityContext);
+            }
+        }
+    }
+
+}

--- a/ejb-security-plus/src/main/resources/META-INF/jboss-deployment-structure.xml
+++ b/ejb-security-plus/src/main/resources/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+  <deployment>
+    <dependencies>
+      <module name="org.jboss.remoting3" />
+      <module name="org.jboss.as.domain-management" />
+      <module name="org.jboss.as.controller" />
+    </dependencies>
+  </deployment>
+  
+</jboss-deployment-structure>

--- a/ejb-security-plus/src/main/resources/META-INF/jboss-ejb3.xml
+++ b/ejb-security-plus/src/main/resources/META-INF/jboss-ejb3.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<jboss xmlns="http://www.jboss.com/xml/ns/javaee"
+       xmlns:jee="http://java.sun.com/xml/ns/javaee"
+       xmlns:ci ="urn:container-interceptors:1.0">
+
+    <jee:assembly-descriptor>
+        <ci:container-interceptors>
+            <!-- Class level container-interceptor which will be applicable for all business method
+             invocations on the bean -->            
+            <jee:interceptor-binding>
+                <ejb-name>SecuredEJB</ejb-name>
+                <interceptor-class>org.jboss.as.quickstarts.ejb_security_plus.ServerSecurityInterceptor</interceptor-class>
+            </jee:interceptor-binding>
+        </ci:container-interceptors>
+    </jee:assembly-descriptor>
+</jboss>

--- a/ejb-security-plus/src/main/resources/META-INF/services/org.jboss.ejb.client.EJBClientInterceptor
+++ b/ejb-security-plus/src/main/resources/META-INF/services/org.jboss.ejb.client.EJBClientInterceptor
@@ -1,0 +1,5 @@
+# EJB client interceptor(s) that will be added to the end of the interceptor chain during an invocation
+# on EJB. If these interceptors are to be added at a specific position, other than last, then use the
+# programmatic API in the application to register it explicitly to the EJBClientContext
+
+org.jboss.as.quickstarts.ejb_security_plus.ClientSecurityInterceptor

--- a/ejb-security-plus/src/main/resources/additional-secret.properties
+++ b/ejb-security-plus/src/main/resources/additional-secret.properties
@@ -1,0 +1,1 @@
+quickstartUser=7f5cc521-5061-4a5b-b814-bdc37f021acc

--- a/ejb-security-plus/src/main/resources/jboss-ejb-client.properties
+++ b/ejb-security-plus/src/main/resources/jboss-ejb-client.properties
@@ -1,0 +1,31 @@
+#
+# JBoss, Home of Professional Open Source
+# Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+# contributors by the @authors tag. See the copyright.txt in the
+# distribution for a full listing of individual contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=default
+
+remote.connection.default.host=localhost
+remote.connection.default.port = 4447
+remote.connection.default.callback.handler.class=org.jboss.as.quickstarts.ejb_security_plus.SecurityContextCallbackHandler
+remote.connection.default.connect.options.org.xnio.Options.SASL_DISALLOWED_MECHANISMS=JBOSS-LOCAL-USER
+
+
+
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
                 <module>ejb-in-war</module>
                 <module>ejb-remote</module>
                 <module>ejb-security</module>
+                <module>ejb-security-plus</module>
                 <module>ejb-security-interceptors</module>
                 <module>greeter</module>
                 <module>helloworld</module>


### PR DESCRIPTION
An additional quick start to demonstrate passing an additional security token used for authentication of the remote user before the call is accepted for the EJB invocation.
