### PR TITLE
Fix the AngularJS Quickstart

### DIFF
--- a/kitchensink-angularjs/src/main/webapp/js/controllers.js
+++ b/kitchensink-angularjs/src/main/webapp/js/controllers.js
@@ -33,6 +33,8 @@ function MembersCtrl($scope, $http, Members) {
     $scope.register = function() {
         $scope.successMessages = '';
         $scope.errorMessages = '';
+        $scope.errors = {};
+
         Members.save($scope.newMember, function(data) {
 
             // mark success on the registration form
@@ -43,11 +45,10 @@ function MembersCtrl($scope, $http, Members) {
 
             // Clear the form
             $scope.reset();
-        }, function(data, status) {
-            if ((status == 409) || (status == 400)) {
-                $scope.errors = data;
+        }, function(result) {
+            if ((result.status == 409) || (result.status == 400)) {
+                $scope.errors = result.data;
             } else {
-                // console.log("error - unknown server issue");
                 $scope.errorMessages = [ 'Unknown  server error' ];
             }
             $scope.$apply();
@@ -57,6 +58,10 @@ function MembersCtrl($scope, $http, Members) {
 
     // Call the refresh() function, to populate the list of members
     $scope.refresh();
+
+    // Initialize newMember here to prevent Angular from sending a request
+    // without a proper Content-Type.
+    $scope.reset();
 
     // Set the default orderBy to the name property
     $scope.orderBy = 'name';

--- a/kitchensink-angularjs/src/main/webapp/partials/home.html
+++ b/kitchensink-angularjs/src/main/webapp/partials/home.html
@@ -52,6 +52,12 @@
             <ul ng-hide="!successMessages" class="success">
                 <li ng-repeat="message in successMessages">{{message}}</li>
             </ul>
+
+            <!-- Output the list of error messages if any. -->
+            <ul ng-hide="!errorMessages" class="error">
+                <li ng-repeat="message in errorMessages">{{message}}</li>
+            </ul>
+
             <!-- There are two buttons, the default submit action (which is bound for the whole form), and a reset button, that clears the form. -->
             <div>
                 <input type="submit" id="register" value="Register" />


### PR DESCRIPTION
The AngularJS Kitchen Sink quickstart had the following problems:
1. Submitting an empty form caused a 415 error.
   - This is due to `newMember` never being initialized and AngularJS deleting the Content-Type header when posting an undefined object. (Safari defaults to "application/xml" and JAX-RS is only set to accept "application/json".)
2. Validation errors do not display.
   - The error callback of `Members.save` was defined as `function(data, status)` but is actually only called with a single parameter that has `data` and `status` fields.
3. The unknown errors list does not display.
   - On a 415 error the `Members.save` error handler set `$scope.errorMessages` but there is no corresponding slot in the view.
- I fixed 1 by adding a call to `$scope.reset()` after the call to `$scope.refresh()` thereby initializing the `newMembers` object on page load.
- I fixed 2 by changing the function to use the correct parameter.
- I fixed 3 by adding a `ul` that displays the `errorMessages` array if present.
