### PR TITLE
Fix placing of xml declaration

### DIFF
--- a/jta-crash-rec/src/main/webapp/WEB-INF/jta-crash-rec-quickstart-ds.xml
+++ b/jta-crash-rec/src/main/webapp/WEB-INF/jta-crash-rec-quickstart-ds.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -14,7 +15,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?> 
 <datasources>
     <xa-datasource jndi-name="java:jboss/datasources/JTACrashRecQuickstartDS" pool-name="JTACrashRecQuickstart" enabled="true" use-ccm="false">
         <xa-datasource-property name="URL">


### PR DESCRIPTION
With current position of xml declaration the jta-crash-rec quickstart is failing to be deployed.
Putting the declaration on the start of the -ds.xml file.
