### PR TITLE
FORGE-875: beans.xml is missing when run in JBoss Tools

### DIFF
--- a/forge-from-scratch/generate.fsh
+++ b/forge-from-scratch/generate.fsh
@@ -11,6 +11,10 @@ set ACCEPT_DEFAULTS true;
 
 @/* Turn our Java project into a Web project with JSF, CDI, EJB, and JPA  */;
 scaffold setup --scaffoldType faces;
+
+@/* Enable CDI if not already done */;
+beans setup;
+
 persistence setup --provider HIBERNATE --container JBOSS_AS7 ;
 
 @/* Create some JPA @Entities on which to base our application */;


### PR DESCRIPTION
This fixes https://issues.jboss.org/browse/FORGE-875

Although the Faces scaffold already requires CDI, beans.xml is strangely not created in some installations. This ensures creation of beans.xml in the correct place.
