### PR TITLE
Typo in the URL of AeroGear project site link is fixed.

### DIFF
--- a/kitchensink-html5-mobile/src/main/webapp/index.html
+++ b/kitchensink-html5-mobile/src/main/webapp/index.html
@@ -330,7 +330,7 @@
                 </ul>
                 <p>Learn about <strong>AeroGear</strong> and HTML5/Mobile development on JBoss.</p>
                 <ul>
-                    <li><a href="http://http://aerogear.org" target="_blank">AeroGear Project site</a></li>
+                    <li><a href="http://aerogear.org" target="_blank">AeroGear Project site</a></li>
                     <li><a href="http://aerogear.org/docs/guides/HTML5RESTApps" target="_blank">More on <strong>HTML5 + REST</strong></a></li>
                     <li><a href="http://aerogear.org/docs/guides/GetStartedHTML5MobileWeb/" target="_blank">Get this application</a></li>
                     <li><a href="http://aerogear.org/docs/guides/HTML5MobilQuickstartAndDeepDive" target="_blank">Application deepdive</a></li>


### PR DESCRIPTION
This is a quick fix using Github editor of the broken URL which I have noticed playing with JBoss Developer Studio.
