### PR TITLE
Fix typo in the URL of the AeroGear project site

### DIFF
--- a/kitchensink-cordova/shared/www/index.html
+++ b/kitchensink-cordova/shared/www/index.html
@@ -272,7 +272,7 @@
                     </ul>
                     <p>Learn about <strong>AeroGear</strong> and HTML5/Mobile development on JBoss.</p>
                     <ul>
-                        <li><a href="http://http://aerogear.org" target="_blank">AeroGear Project site</a></li>
+                        <li><a href="http://aerogear.org" target="_blank">AeroGear Project site</a></li>
                         <li><a href="http://aerogear.org/docs/guides/HTML5RESTApps" target="_blank">More on <strong>HTML5 + REST</strong></a></li>
                         <li><a href="http://aerogear.org/docs/guides/GetStartedHTML5MobileWeb/" target="_blank">Get this application</a></li>
                         <li><a href="http://aerogear.org/docs/guides/HTML5MobilQuickstartAndDeepDive" target="_blank">Application deepdive</a></li>


### PR DESCRIPTION
Discovered this problem when reviewing https://github.com/jboss-jdf/jboss-as-quickstart/pull/498.
