### PR TITLE
Bugfix in kitchensink MemberRepository type-safe criteria query example

### DIFF
--- a/kitchensink/src/main/java/org/jboss/as/quickstarts/kitchensink/data/MemberRepository.java
+++ b/kitchensink/src/main/java/org/jboss/as/quickstarts/kitchensink/data/MemberRepository.java
@@ -42,7 +42,7 @@ public class MemberRepository {
         Root<Member> member = criteria.from(Member.class);
         // Swap criteria statements if you would like to try out type-safe criteria queries, a new
         // feature in JPA 2.0
-        // criteria.select(member).where(cb.equal(member.get(Member_.name), email));
+        // criteria.select(member).where(cb.equal(member.get(Member_.email), email));
         criteria.select(member).where(cb.equal(member.get("email"), email));
         return em.createQuery(criteria).getSingleResult();
     }


### PR DESCRIPTION
stumbled across this in kitchensink-rf
