### PR TITLE
Bump ShrinkWrap Resolver to 2.0.0-beta-5

### DIFF
--- a/cdi-add-interceptor-binding/pom.xml
+++ b/cdi-add-interceptor-binding/pom.xml
@@ -54,7 +54,7 @@
             maven repository. -->
         <!-- <version.jboss.bom>1.0.4.Final-redhat-4</version.jboss.bom> -->
         
-        <version.shrinkwrap.resolver>2.0.0-beta-2</version.shrinkwrap.resolver>
+        <version.shrinkwrap.resolver>2.0.0-beta-5</version.shrinkwrap.resolver>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/deltaspike-beanbuilder/pom.xml
+++ b/deltaspike-beanbuilder/pom.xml
@@ -54,7 +54,7 @@
             maven repository. -->
         <!-- <version.jboss.bom>1.0.4.Final-redhat-4</version.jboss.bom> -->
         
-        <version.shrinkwrap.resolver>2.0.0-beta-2</version.shrinkwrap.resolver>
+        <version.shrinkwrap.resolver>2.0.0-beta-5</version.shrinkwrap.resolver>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/deltaspike-deactivatable/pom.xml
+++ b/deltaspike-deactivatable/pom.xml
@@ -54,7 +54,7 @@
             maven repository. -->
         <!-- <version.jboss.bom>1.0.4.Final-redhat-4</version.jboss.bom> -->
         
-        <version.shrinkwrap.resolver>2.0.0-beta-2</version.shrinkwrap.resolver>
+        <version.shrinkwrap.resolver>2.0.0-beta-5</version.shrinkwrap.resolver>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/kitchensink-deltaspike/pom.xml
+++ b/kitchensink-deltaspike/pom.xml
@@ -53,7 +53,7 @@
             maven repository. -->
         <!-- <version.jboss.bom>1.0.4.Final-redhat-4</version.jboss.bom> -->
         
-        <version.shrinkwrap.resolver>2.0.0-beta-2</version.shrinkwrap.resolver>
+        <version.shrinkwrap.resolver>2.0.0-beta-5</version.shrinkwrap.resolver>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>


### PR DESCRIPTION
Please, pull once beta-5 hits central.
