### PR TITLE
JDF-351 - Update existing Shrinkwrap examples to use 2.0.0-beta5 (BOM 1.0.7.CR3) and add a new shrinkwrap-resolver quickstart

### DIFF
--- a/cdi-add-interceptor-binding/pom.xml
+++ b/cdi-add-interceptor-binding/pom.xml
@@ -15,9 +15,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.as.quickstarts</groupId>
@@ -43,19 +42,17 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         
         <!-- JBoss dependency versions -->
-        
+
         <version.jboss.maven.plugin>7.3.Final</version.jboss.maven.plugin>
         
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom>1.0.6.Final</version.jboss.bom>
+        <version.jboss.bom>1.0.7.CR3</version.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.4.Final-redhat-4 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
         <!-- <version.jboss.bom>1.0.4.Final-redhat-4</version.jboss.bom> -->
         
-        <version.shrinkwrap.resolver>2.0.0-beta-2</version.shrinkwrap.resolver>
-
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>
         <version.surefire.plugin>2.10</version.surefire.plugin>
@@ -68,13 +65,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-bom</artifactId>
-                <version>${version.shrinkwrap.resolver}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
                  Any dependencies from org.jboss.spec will have their version defined by this BOM
 
@@ -145,14 +135,13 @@
             <groupId>org.jboss.arquillian.protocol</groupId>
             <artifactId>arquillian-protocol-servlet</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-depchain</artifactId>
             <type>pom</type>
             <scope>test</scope>
         </dependency>
-        
     </dependencies>
     <build>
         <finalName>${project.artifactId}</finalName>

--- a/cdi-add-interceptor-binding/src/test/java/org/jboss/as/quickstart/cdi/extension/test/ParameterLoggerTest.java
+++ b/cdi-add-interceptor-binding/src/test/java/org/jboss/as/quickstart/cdi/extension/test/ParameterLoggerTest.java
@@ -16,8 +16,9 @@
  */
 package org.jboss.as.quickstart.cdi.extension.test;
 
-import java.io.File;
 import static org.junit.Assert.assertTrue;
+
+import java.io.File;
 
 import javax.enterprise.inject.spi.Extension;
 import javax.inject.Inject;

--- a/deltaspike-authorization/pom.xml
+++ b/deltaspike-authorization/pom.xml
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.3.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom>1.0.7.CR2</version.jboss.bom>
+        <version.jboss.bom>1.0.7.CR3</version.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.4.Final-redhat-4 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 

--- a/deltaspike-beanbuilder/pom.xml
+++ b/deltaspike-beanbuilder/pom.xml
@@ -47,15 +47,13 @@
         <version.jboss.maven.plugin>7.3.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom>1.0.7.CR2</version.jboss.bom>
+        <version.jboss.bom>1.0.7.CR3</version.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.4.Final-redhat-4 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
         <!-- <version.jboss.bom>1.0.4.Final-redhat-4</version.jboss.bom> -->
         
-        <version.shrinkwrap.resolver>2.0.0-beta-2</version.shrinkwrap.resolver>
-
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>
         <version.war.plugin>2.1.1</version.war.plugin>
@@ -69,13 +67,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-bom</artifactId>
-                <version>${version.shrinkwrap.resolver}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <!-- JBoss distributes a complete set of Java EE 6 APIs including 
                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or 
                 a collection) of artifacts. We use this here so that we always get the correct 

--- a/deltaspike-beanmanagerprovider/pom.xml
+++ b/deltaspike-beanmanagerprovider/pom.xml
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.3.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom>1.0.7.CR2</version.jboss.bom>
+        <version.jboss.bom>1.0.7.CR3</version.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.4.Final-redhat-4 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 

--- a/deltaspike-deactivatable/pom.xml
+++ b/deltaspike-deactivatable/pom.xml
@@ -47,14 +47,12 @@
         <version.jboss.maven.plugin>7.3.Final</version.jboss.maven.plugin>
  
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom>1.0.7.CR2</version.jboss.bom>
+        <version.jboss.bom>1.0.7.CR3</version.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.4.Final-redhat-4 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
         <!-- <version.jboss.bom>1.0.4.Final-redhat-4</version.jboss.bom> -->
-
-        <version.shrinkwrap.resolver>2.0.0-beta-2</version.shrinkwrap.resolver>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>
@@ -69,13 +67,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-bom</artifactId>
-                <version>${version.shrinkwrap.resolver}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <!-- JBoss distributes a complete set of Java EE 6 APIs including 
                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or 
                 a collection) of artifacts. We use this here so that we always get the correct 

--- a/deltaspike-exception-handling/pom.xml
+++ b/deltaspike-exception-handling/pom.xml
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.3.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom>1.0.7.CR2</version.jboss.bom>
+        <version.jboss.bom>1.0.7.CR3</version.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.4.Final-redhat-4 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 

--- a/deltaspike-helloworld-jms/pom.xml
+++ b/deltaspike-helloworld-jms/pom.xml
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.3.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom>1.0.7.CR2</version.jboss.bom>
+        <version.jboss.bom>1.0.7.CR3</version.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.4.Final-redhat-4 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 

--- a/deltaspike-projectstage/pom.xml
+++ b/deltaspike-projectstage/pom.xml
@@ -46,7 +46,7 @@
         <version.jboss.maven.plugin>7.3.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom>1.0.7.CR2</version.jboss.bom>
+        <version.jboss.bom>1.0.7.CR3</version.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.4.Final-redhat-4 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 

--- a/kitchensink-deltaspike/pom.xml
+++ b/kitchensink-deltaspike/pom.xml
@@ -46,15 +46,13 @@
         <version.jboss.maven.plugin>7.3.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom>1.0.6.Final</version.jboss.bom>
+        <version.jboss.bom>1.0.7.CR3</version.jboss.bom>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.4.Final-redhat-4 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
         <!-- <version.jboss.bom>1.0.4.Final-redhat-4</version.jboss.bom> -->
         
-        <version.shrinkwrap.resolver>2.0.0-beta-2</version.shrinkwrap.resolver>
-
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>
         <version.surefire.plugin>2.10</version.surefire.plugin>
@@ -68,13 +66,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-bom</artifactId>
-                <version>${version.shrinkwrap.resolver}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <!-- JBoss distributes a complete set of Java EE 6 APIs including 
                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or 
                 a collection) of artifacts. We use this here so that we always get the correct 

--- a/kitchensink-deltaspike/src/main/java/org/jboss/as/quickstarts/kitchensink/exception/handlers/FacesExceptionHandler.java
+++ b/kitchensink-deltaspike/src/main/java/org/jboss/as/quickstarts/kitchensink/exception/handlers/FacesExceptionHandler.java
@@ -19,8 +19,8 @@ package org.jboss.as.quickstarts.kitchensink.exception.handlers;
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
 
-import org.apache.deltaspike.core.api.exception.control.annotation.ExceptionHandler;
-import org.apache.deltaspike.core.api.exception.control.annotation.Handles;
+import org.apache.deltaspike.core.api.exception.control.ExceptionHandler;
+import org.apache.deltaspike.core.api.exception.control.Handles;
 import org.apache.deltaspike.core.api.exception.control.event.ExceptionEvent;
 import org.jboss.as.quickstarts.kitchensink.exception.annotation.FacesRequest;
 

--- a/kitchensink-deltaspike/src/main/java/org/jboss/as/quickstarts/kitchensink/exception/handlers/RestExceptionHandler.java
+++ b/kitchensink-deltaspike/src/main/java/org/jboss/as/quickstarts/kitchensink/exception/handlers/RestExceptionHandler.java
@@ -30,8 +30,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 
-import org.apache.deltaspike.core.api.exception.control.annotation.ExceptionHandler;
-import org.apache.deltaspike.core.api.exception.control.annotation.Handles;
+import org.apache.deltaspike.core.api.exception.control.ExceptionHandler;
+import org.apache.deltaspike.core.api.exception.control.Handles;
 import org.apache.deltaspike.core.api.exception.control.event.ExceptionEvent;
 import org.jboss.as.quickstarts.kitchensink.exception.annotation.RestRequest;
 

--- a/kitchensink-deltaspike/src/main/java/org/jboss/as/quickstarts/kitchensink/util/Resources.java
+++ b/kitchensink-deltaspike/src/main/java/org/jboss/as/quickstarts/kitchensink/util/Resources.java
@@ -29,7 +29,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceUnit;
 
-import org.apache.deltaspike.core.api.config.annotation.ConfigProperty;
+import org.apache.deltaspike.core.api.config.ConfigProperty;
 
 /**
  * This class uses CDI to alias Java EE resources, such as the persistence context, to CDI beans

--- a/kitchensink-deltaspike/src/test/java/org/jboss/as/quickstarts/kitchensink/test/MemberRegistrationTest.java
+++ b/kitchensink-deltaspike/src/test/java/org/jboss/as/quickstarts/kitchensink/test/MemberRegistrationTest.java
@@ -16,9 +16,9 @@
  */
 package org.jboss.as.quickstarts.kitchensink.test;
 
-import java.io.File;
 import static org.junit.Assert.assertNotNull;
 
+import java.io.File;
 import java.util.logging.Logger;
 
 import javax.inject.Inject;

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
                 <module>servlet-async</module>
                 <module>servlet-filterlistener</module>
                 <module>servlet-security</module>
+                <module>shrinkwrap-resolver</module>
                 <module>shopping-cart</module>
                 <module>tasks</module>
                 <module>tasks-jsf</module>

--- a/shrinkwrap-resolver/README.md
+++ b/shrinkwrap-resolver/README.md
@@ -1,0 +1,108 @@
+shrinkwrap-resolver: Demonstrate usage of Shrinkwrap resolver
+==============================================================
+Author: Rafael Benevides
+Level: Beginner
+Technologies: CDI, Arquillian, Shrinkwrap
+Summary: Demonstrate usage of some Shrinkwrap resolver use cases
+Target Product: WFK
+Source: https://github.com/jboss-jdf/jboss-as-quickstart/shrinkwrap-resolver
+
+
+What is it?
+-----------
+
+With the advent of Maven and other build systems, typically thirdparty libraries and our own dependent modules are obtained from a backing software repository. In this case we supply a series of coordinates which uniquely identifies an artifact in the repository, and resolve the target files from there.
+
+That is precisely the aim of the ShrinkWrap Resolver project; it is a Java API to obtain artifacts from a repository system. 
+
+This quickstart demonstrate various use cases for ShrinkWrap Resolver. This Quickstart has 3 Test Classes that demonstrates the following Shrinkwrap use cases:
+
+* ShrinkwrapResolveGAVWithoutTransitiveDepsTest
+  - resolve an artifact via G:A:V without transitive dependencies
+  - return resolution results as single java.io.File
+  
+* ShrinkwrapImportFromPomTest
+  - loading pom.xml from file activating and deactivating profiles
+  - importing dependencies of specified scope into list of artifacts to be resolved
+  - return resolution results as a java.io.File array
+  
+* ShrinkwrapResolveGAPCVCustomRepoWithoutCentralTest
+  - resolve an artifact via G:A:P:C:V without transitive dependencies 
+  - resolve an artifact with classifer
+  - disabling Maven Central
+  - loading settings.xml from file (with custom repository)
+  - return resolution results as a java.io.File array
+
+
+System requirements
+-------------------
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
+
+The application this project produces is designed to be run on JBoss Enterprise Application Platform 6 or JBoss AS 7. 
+
+ 
+Configure Maven
+---------------
+
+If you have not yet done so, you must [Configure Maven](../README.md#mavenconfiguration) before testing the quickstarts.
+
+
+Start JBoss Enterprise Application Platform 6 or JBoss AS 7
+-------------------------
+
+1. Open a command line and navigate to the root of the JBoss server directory.
+2. The following shows the command line to start the server with the web profile:
+
+        For Linux:   JBOSS_HOME/bin/standalone.sh
+        For Windows: JBOSS_HOME\bin\standalone.bat
+
+Run the Arquillian Tests 
+-------------------------
+
+This quickstart provides Arquillian tests. By default, these tests are configured to be skipped as Arquillian tests require the use of a container. 
+
+_NOTE: The following commands assume you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See [Run the Arquillian Tests](../README.md#arquilliantests) for complete instructions and additional options._
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. Type the following command to run the test goal with the following profile activated:
+
+        mvn clean test -Parq-jbossas-remote 
+
+Run tests from JBDS
+-----------------------
+
+To be able to run the tests from JBDS, first set the active Maven profile in project properties to be either 'arq-jbossas-managed' for running on managed server or 'arq-jbossas-remote' for running on remote server.
+
+To run the tests, right click on the project or individual classes and select Run As --> JUnit Test in the context menu.
+
+
+Investigate the Console Output
+------------------------------
+
+
+### Maven
+-------------------------------------------------------
+ T E S T S
+-------------------------------------------------------
+Running org.jboss.as.quickstarts.shrinkwrap.resolver.ShrinkwrapImportFromPomTest
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.633 sec
+Running org.jboss.as.quickstarts.shrinkwrap.resolver.ShrinkwrapResolveGAPCVCustomRepoWithoutCentralTest
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.439 sec
+Running org.jboss.as.quickstarts.shrinkwrap.resolver.ShrinkwrapResolveGAVWithoutTransitiveDepsTest
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.016 sec
+
+Results :
+
+Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
+
+
+Debug the Application
+------------------------------------
+
+If you want to debug the source code or look at the Javadocs of any library in the project, run either of the following commands to pull them into your local repository. The IDE should then detect them.
+
+    mvn dependency:sources
+    mvn dependency:resolve -Dclassifier=javadoc
+

--- a/shrinkwrap-resolver/README.md
+++ b/shrinkwrap-resolver/README.md
@@ -68,7 +68,11 @@ _NOTE: The following commands assume you have configured your Maven user setting
 2. Open a command line and navigate to the root directory of this quickstart.
 3. Type the following command to run the test goal with the following profile activated:
 
-        mvn clean test -Parq-jbossas-remote 
+        mvn clean test -Parq-jbossas-remote
+
+_NOTE: If you use the Maven settings command line argument with this quickstart, you need to pass an additional argument to allow ShrinkWrap Resolver to function properly:_
+
+    mvn clean test -Parq-jbossas-remote -s /path/to/custom/settings.xml -Dorg.apache.maven.user-settings=/path/to/custom/settings.xml
 
 Run tests from JBDS
 -----------------------

--- a/shrinkwrap-resolver/pom.xml
+++ b/shrinkwrap-resolver/pom.xml
@@ -245,6 +245,9 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${version.surefire.plugin}</version>
                         <configuration>
+                            <systemPropertyVariables>
+                                <org.apache.maven.user-settings>${org.apache.maven.user-settings}</org.apache.maven.user-settings>
+                            </systemPropertyVariables>
                             <skip>true</skip>
                         </configuration>
                     </plugin>

--- a/shrinkwrap-resolver/pom.xml
+++ b/shrinkwrap-resolver/pom.xml
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.as.quickstarts</groupId>
+    <artifactId>jboss-as-shrinkwrap-resolver</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <name>jboss-as-shrinkwrap-resolver</name>
+    <description>A starter Java EE 6 webapp project for use on JBoss AS 7 / EAP 6, generated from the jboss-javaee6-webapp archetype</description>
+
+    <url>http://jboss.org/jbossas</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <!-- Explicitly declaring the source encoding eliminates the following 
+            message: -->
+        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
+            resources, i.e. build is platform dependent! -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <version.jboss.maven.plugin>7.3.Final</version.jboss.maven.plugin>
+
+        <!-- Define the version of the JBoss BOMs we want to import to specify 
+            tested stacks. -->
+        <version.jboss.bom>1.0.7.CR3</version.jboss.bom>
+        <!-- Alternatively, comment out the above line, and un-comment the line
+            below to use version 1.0.2.Final-redhat-1 which is a release certified to
+            work with JBoss EAP 6. It requires you have access to the JBoss EAP 6
+            maven repository. -->
+        <!-- <version.jboss.bom>1.0.2.Final-redhat-1</version.jboss.bom>> -->
+
+        <!-- other plugin versions -->
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.surefire.plugin>2.10</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
+    </properties>
+
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- JBoss distributes a complete set of Java EE 6 APIs including 
+                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or 
+                a collection) of artifacts. We use this here so that we always get the correct 
+                versions of artifacts. Here we use the jboss-javaee-6.0-with-deltaspike and 
+                jboss-javaee-6.0-with-tools with extras from the DeltaSpike project . You 
+                can actually use this stack with any version of JBoss AS that implements 
+                Java EE 6, not just JBoss AS 7! -->
+
+            <dependency>
+                <groupId>org.jboss.bom</groupId>
+                <artifactId>jboss-javaee-6.0-with-deltaspike</artifactId>
+                <version>${version.jboss.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.bom</groupId>
+                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
+                <version>${version.jboss.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+    
+         <!-- First declare the APIs we depend on and need for compilation. All 
+            of them are provided by JBoss AS 7 -->
+
+        <!-- Import the CDI API, we use provided scope as the API is included in 
+            JBoss AS 7 -->
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Import the Common Annotations API (JSR-250), we use provided scope 
+            as the API is included in JBoss AS 7 -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <!-- Import the JPA API, we use provided scope as the API is included in 
+            JBoss AS 7 -->
+        <dependency>
+            <groupId>org.hibernate.javax.persistence</groupId>
+            <artifactId>hibernate-jpa-2.0-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Import the EJB API, we use provided scope as the API is included in 
+            JBoss AS 7 -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <!-- Import the JSF API, we use provided scope as the API is included in 
+            JBoss AS 7 -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.faces</groupId>
+            <artifactId>jboss-jsf-api_2.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Now we declare any tools needed -->
+
+        <!-- Needed for running tests (you may also use TestNG) -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Shrinkwrap resolver depchain -->
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-depchain</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Optional, but highly recommended -->
+        <!-- Arquillian allows you to test enterprise code such as EJBs and Transactional(JTA) 
+            JPA from JUnit/TestNG -->
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Dependencies that will be resolved on tests by Shrinkwrap resolver -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
+        </dependency>
+
+        <!-- Deltaspike API. We use compile scope as we need it to compile the project against the API -->
+        <dependency>
+            <groupId>org.apache.deltaspike.core</groupId>
+            <artifactId>deltaspike-core-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Deltaspike Impl. We use runtime scope as we only need the implementation 
+            classes at runtime -->
+        <dependency>
+            <groupId>org.apache.deltaspike.core</groupId>
+            <artifactId>deltaspike-core-impl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <!-- Maven will append the version to the finalName (which is the name 
+            given to the generated war, and hence the context root) -->
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation 
+                processors -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.compiler.plugin}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${version.war.plugin}</version>
+                <configuration>
+                    <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+            <!-- The JBoss AS plugin deploys your war to a local JBoss AS container -->
+            <!-- To use, run: mvn package jboss-as:deploy -->
+            <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <version>${version.jboss.maven.plugin}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <!-- The default profile skips all tests, though you can tune it to run 
+                just unit tests based on a custom pattern -->
+            <!-- Seperate profiles are provided for running all tests, including Arquillian 
+                tests that execute in the specified container -->
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${version.surefire.plugin}</version>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <!-- An optional Arquillian testing profile that executes tests in your 
+                JBoss AS instance -->
+            <!-- This profile will start a new JBoss AS instance, and execute the 
+                test, shutting it down when done -->
+            <!-- Run with: mvn clean test -Parq-jbossas-managed -->
+            <id>arq-jbossas-managed</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-arquillian-container-managed</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <!-- An optional Arquillian testing profile that executes tests in a remote 
+                JBoss AS instance -->
+            <!-- Run with: mvn clean test -Parq-jbossas-remote -->
+            <id>arq-jbossas-remote</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-arquillian-container-remote</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <!-- When built in OpenShift the 'openshift' profile will be used when 
+                invoking mvn. -->
+            <!-- Use this profile for any OpenShift specific customization your app 
+                will need. -->
+            <!-- By default that is to put the resulting archive into the 'deployments' 
+                folder. -->
+            <!-- http://maven.apache.org/guides/mini/guide-building-for-different-environments.html -->
+            <id>openshift</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>${version.war.plugin}</version>
+                        <configuration>
+                            <outputDirectory>deployments</outputDirectory>
+                            <warName>ROOT</warName>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
+</project>

--- a/shrinkwrap-resolver/src/main/java/org/jboss/as/quickstarts/shrinkwrap/resolver/MyBean.java
+++ b/shrinkwrap-resolver/src/main/java/org/jboss/as/quickstarts/shrinkwrap/resolver/MyBean.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.shrinkwrap.resolver;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * This is a simple CDI Bean that will be injected on test cases
+ * 
+ * @author Rafael Benevides
+ * 
+ */
+public class MyBean {
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/shrinkwrap-resolver/src/main/java/org/jboss/as/quickstarts/shrinkwrap/resolver/MyDeltaspikeBean.java
+++ b/shrinkwrap-resolver/src/main/java/org/jboss/as/quickstarts/shrinkwrap/resolver/MyDeltaspikeBean.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.shrinkwrap.resolver;
+
+import javax.inject.Inject;
+
+import org.apache.deltaspike.core.api.projectstage.ProjectStage;
+
+/**
+ * Simple class that uses Deltaspike that will be resolved by Shrinkwrap-resolver during tests
+ * 
+ * @author Rafael Benevides
+ * 
+ */
+public class MyDeltaspikeBean {
+
+    @Inject
+    private ProjectStage deltaSpikeProjectStage;
+
+    public ProjectStage getActualProjectStage() {
+        return deltaSpikeProjectStage;
+    }
+
+}

--- a/shrinkwrap-resolver/src/main/resources/META-INF/persistence.xml
+++ b/shrinkwrap-resolver/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<persistence version="2.0"
+   xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+        http://java.sun.com/xml/ns/persistence
+        http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+   <persistence-unit name="primary">
+      <!-- If you are running in a production environment, add a managed 
+         data source, this example data source is just for development and testing! -->
+      <!-- The datasource is deployed as WEB-INF/jboss-as-shrinkwrap-resolver-ds.xml, you
+         can find it in the source at src/main/webapp/WEB-INF/jboss-as-shrinkwrap-resolver-ds.xml -->
+      <jta-data-source>java:jboss/datasources/jboss-as-shrinkwrap-resolverDS</jta-data-source>
+      <properties>
+         <!-- Properties for Hibernate -->
+         <property name="hibernate.hbm2ddl.auto" value="create-drop" />
+         <property name="hibernate.show_sql" value="false" />
+      </properties>
+   </persistence-unit>
+</persistence>

--- a/shrinkwrap-resolver/src/main/webapp/WEB-INF/beans.xml
+++ b/shrinkwrap-resolver/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- This file can be an empty text file (0 bytes) -->
+<!-- We're declaring the schema to save you time if you do have to configure 
+    this in the future -->
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://java.sun.com/xml/ns/javaee 
+        http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/shrinkwrap-resolver/src/main/webapp/WEB-INF/faces-config.xml
+++ b/shrinkwrap-resolver/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- This file is not required if you don't need any extra configuration. -->
+<faces-config version="2.0" xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://java.sun.com/xml/ns/javaee
+        http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd">
+
+    <!-- This descriptor activates the JSF 2.0 Servlet -->
+
+    <!-- Write your navigation rules here. You are encouraged to use CDI 
+        for creating @Named managed beans. -->
+
+</faces-config>

--- a/shrinkwrap-resolver/src/main/webapp/WEB-INF/jboss-as-shrinkwrap-resolver-ds.xml
+++ b/shrinkwrap-resolver/src/main/webapp/WEB-INF/jboss-as-shrinkwrap-resolver-ds.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- This is an unmanaged datasource. It should be used for proofs of concept 
+    or testing only. It uses H2, an in memory database that ships with JBoss 
+    AS. -->
+<datasources xmlns="http://www.jboss.org/ironjacamar/schema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.jboss.org/ironjacamar/schema http://docs.jboss.org/ironjacamar/schema/datasources_1_0.xsd">
+    <!-- The datasource is bound into JNDI at this location. We reference 
+        this in META-INF/persistence.xml -->
+    <datasource jndi-name="java:jboss/datasources/jboss-as-shrinkwrap-resolverDS"
+        pool-name="jboss-as-shrinkwrap-resolver" enabled="true"
+        use-java-context="true">
+        <connection-url>jdbc:h2:mem:jboss-as-shrinkwrap-resolver;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
+        <driver>h2</driver>
+        <security>
+            <user-name>sa</user-name>
+            <password>sa</password>
+        </security>
+    </datasource>
+</datasources>
+ 

--- a/shrinkwrap-resolver/src/test/java/org/jboss/as/quickstarts/shrinkwrap/resolver/ShrinkwrapImportFromPomTest.java
+++ b/shrinkwrap-resolver/src/test/java/org/jboss/as/quickstarts/shrinkwrap/resolver/ShrinkwrapImportFromPomTest.java
@@ -1,0 +1,74 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.shrinkwrap.resolver;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.apache.deltaspike.core.api.projectstage.ProjectStage;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This test demonstrates how to use Shrinkwrap-resolver to import dependencies specified in the pom.xml file. You can control
+ * what dependencies will be imported based on its scope and you can also define what profiles can be active or inactive. It
+ * returns a file array with the dependencies.
+ * 
+ * 
+ * @author Rafael Benevides
+ * 
+ */
+@RunWith(Arquillian.class)
+public class ShrinkwrapImportFromPomTest {
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+
+        File[] libs = Maven.resolver()
+            // This will load the pom.xml file. For example purpose, the pom file had the arq-jbossas-remote profile
+            // activated and default profile deactivated (which was active by default)
+            .loadPomFromFile("pom.xml", "arq-jbossas-remote", "!default")
+            .importCompileAndRuntimeDependencies().resolve().withoutTransitivity().asFile();
+
+        return ShrinkWrap.create(WebArchive.class, "test.war")
+            .addClasses(MyDeltaspikeBean.class)
+            .addAsResource("META-INF/test-persistence.xml", "META-INF/persistence.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsLibraries(libs)
+            // Deploy our test datasource
+            .addAsWebInfResource("test-ds.xml");
+    }
+
+    @Inject
+    private MyDeltaspikeBean myDeltaspikeBean;
+
+    // Basic test to demonstrate that the Arquillian is working with the Shrinkwrap resolver use case in this class
+    @Test
+    public void test() {
+        // getActualProjectStage uses Deltaspike that was resolved by Shrinkwrap-resolver through pom.xml
+        Assert.assertEquals(myDeltaspikeBean.getActualProjectStage(), ProjectStage.Production);
+    }
+}

--- a/shrinkwrap-resolver/src/test/java/org/jboss/as/quickstarts/shrinkwrap/resolver/ShrinkwrapResolveGAPCVCustomRepoWithoutCentralTest.java
+++ b/shrinkwrap-resolver/src/test/java/org/jboss/as/quickstarts/shrinkwrap/resolver/ShrinkwrapResolveGAPCVCustomRepoWithoutCentralTest.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.quickstarts.shrinkwrap.resolver;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This test demonstrates how to use Shrinkwrap-resolver to resolve artifacts using G:A:V (GroupId, ArtifactId and Version) and
+ * also shows how to use G:A:P:C:V (GroupId, ArtifactId, Packaging, Classifier and Version) dependencies as a file array.
+ * 
+ * The Shrinkwrap-resolver also was customized to use a custom maven settings xml file and disable the Maven Central repository.
+ * 
+ * @author Rafael Benevides
+ * 
+ */
+@RunWith(Arquillian.class)
+public class ShrinkwrapResolveGAPCVCustomRepoWithoutCentralTest {
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+
+        String[] deps = {
+            // GroupId, ArtifactId and Version
+            "org.apache.commons:commons-lang3:3.1",
+            // GroupId, ArtifactId, Packaging, Classifier and Version can also be used when necessary
+            "org.apache.commons:commons-lang3:jar:sources:3.1"
+        };
+
+        File[] libs = Maven.
+            // Configure to use repository specified on a maven custom settings file
+            configureResolver().fromClassloaderResource("custom-settings.xml")
+            .resolve(deps)
+            // disabled Maven Central repository
+            .withMavenCentralRepo(false)
+            .withoutTransitivity().asFile();
+
+        return ShrinkWrap.create(WebArchive.class, "test.war")
+            .addClasses(MyBean.class)
+            .addAsResource("META-INF/test-persistence.xml", "META-INF/persistence.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsLibraries(libs)
+            // Deploy our test datasource
+            .addAsWebInfResource("test-ds.xml");
+    }
+
+    @Inject
+    private MyBean myBean;
+
+    // Basic test to demonstrate that the Arquillian is working with the Shrinkwrap resolver use case in this class
+    @Test
+    public void test() {
+        // toString uses commons-lang that was resolved by Shrinkwrap-resolver
+        assertNotNull(myBean.toString());
+    }
+}

--- a/shrinkwrap-resolver/src/test/java/org/jboss/as/quickstarts/shrinkwrap/resolver/ShrinkwrapResolveGAVWithoutTransitiveDepsTest.java
+++ b/shrinkwrap-resolver/src/test/java/org/jboss/as/quickstarts/shrinkwrap/resolver/ShrinkwrapResolveGAVWithoutTransitiveDepsTest.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.quickstarts.shrinkwrap.resolver;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This test demonstrates how to use Shrinkwrap-resolver to resolve an artifact via G:A:V without transitive dependencies as a
+ * single file
+ * 
+ * @author Rafael Benevides
+ * 
+ */
+@RunWith(Arquillian.class)
+public class ShrinkwrapResolveGAVWithoutTransitiveDepsTest {
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+
+        File lib = Maven.resolver().resolve("org.apache.commons:commons-lang3:3.1").withoutTransitivity().asSingleFile();
+
+        return ShrinkWrap.create(WebArchive.class, "test.war")
+            .addClasses(MyBean.class)
+            .addAsResource("META-INF/test-persistence.xml", "META-INF/persistence.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsLibraries(lib)
+            // Deploy our test datasource
+            .addAsWebInfResource("test-ds.xml");
+    }
+
+    @Inject
+    private MyBean myBean;
+
+    // Basic test to demonstrate that the Arquillian is working with the Shrinkwrap resolver use case in this class
+    @Test
+    public void test() {
+        // toString uses commons-lang that was resolved by Shrinkwrap-resolver
+        assertNotNull(myBean.toString());
+    }
+}

--- a/shrinkwrap-resolver/src/test/resources/META-INF/test-persistence.xml
+++ b/shrinkwrap-resolver/src/test/resources/META-INF/test-persistence.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<persistence version="2.0"
+   xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+        http://java.sun.com/xml/ns/persistence
+        http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+   <persistence-unit name="primary">
+      <!-- We use a different datasource for tests, so as to not overwrite 
+         production data. This is an unmanaged data source, backed by H2, an in memory 
+         database. Production applications should use a managed datasource. -->
+      <!-- The datasource is deployed as WEB-INF/test-ds.xml, 
+         you can find it in the source at src/test/resources/test-ds.xml -->
+      <jta-data-source>java:jboss/datasources/jboss-as-shrinkwrap-resolverTestDS</jta-data-source>
+      <properties>
+         <!-- Properties for Hibernate -->
+         <property name="hibernate.hbm2ddl.auto" value="create-drop" />
+         <property name="hibernate.show_sql" value="false" />
+      </properties>
+   </persistence-unit>
+</persistence>

--- a/shrinkwrap-resolver/src/test/resources/arquillian.xml
+++ b/shrinkwrap-resolver/src/test/resources/arquillian.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+   <!-- Uncomment to have test archives exported to the file system for inspection -->
+<!--    <engine>  -->
+<!--       <property name="deploymentExportPath">target/</property>  -->
+<!--    </engine> -->
+
+   <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
+   <defaultProtocol type="Servlet 3.0" />
+
+     <!-- Example configuration for a remote JBoss Enterprise Application Platform 6 or AS 7 instance -->
+   <container qualifier="jboss" default="true">
+        <!-- By default, arquillian will use the JBOSS_HOME environment variable.  Alternatively, the configuration below can be uncommented. -->
+        <!--<configuration> -->
+        <!--<property name="jbossHome">/path/to/jboss/as</property> -->
+        <!--</configuration> -->
+   </container>
+
+</arquillian>

--- a/shrinkwrap-resolver/src/test/resources/custom-settings.xml
+++ b/shrinkwrap-resolver/src/test/resources/custom-settings.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+
+
+    <profiles>
+        <!-- Configure Custom Maven repositories -->
+        <profile>
+            <id>custom-repositories</id>
+            <repositories>
+                <repository>
+                    <id>custom-maven-repo</id>
+                    <name>Ibiblio Mirror</name>
+                    <url>http://mirrors.ibiblio.org/maven2/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+            </pluginRepositories>
+        </profile>
+
+    </profiles>
+
+    <activeProfiles>
+        <activeProfile>custom-repositories</activeProfile>
+    </activeProfiles>
+
+</settings>

--- a/shrinkwrap-resolver/src/test/resources/test-ds.xml
+++ b/shrinkwrap-resolver/src/test/resources/test-ds.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- This is an unmanaged datasource. It should be used for proofs of concept 
+   or testing only. It uses H2, an in memory database that ships with JBoss 
+   AS. -->
+<datasources xmlns="http://www.jboss.org/ironjacamar/schema"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.jboss.org/ironjacamar/schema http://docs.jboss.org/ironjacamar/schema/datasources_1_0.xsd">
+   <!-- The datasource is bound into JNDI at this location. We reference 
+      this in META-INF/test-persistence.xml -->
+   <datasource jndi-name="java:jboss/datasources/jboss-as-shrinkwrap-resolverTestDS"
+      pool-name="jboss-as-shrinkwrap-resolver-test" enabled="true"
+      use-java-context="true">
+      <connection-url>jdbc:h2:mem:jboss-as-shrinkwrap-resolver-test;DB_CLOSE_DELAY=-1</connection-url>
+      <driver>h2</driver>
+      <security>
+         <user-name>sa</user-name>
+         <password>sa</password>
+      </security>
+   </datasource>
+</datasources>
+ 


### PR DESCRIPTION
Since Pete said that it is quit urgent I'm sending this PR with the existing quickstarts updated in one commit and the new quickstart in another commit.
