### PR TITLE
Kitchensink-Cordova for iOS - remove useSplashScreen deprecated setting

### DIFF
--- a/kitchensink-cordova/ios/KitchensinkCordova/Classes/AppDelegate.m
+++ b/kitchensink-cordova/ios/KitchensinkCordova/Classes/AppDelegate.m
@@ -84,7 +84,7 @@
 #else
         self.viewController = [[[MainViewController alloc] init] autorelease];
 #endif
-    self.viewController.useSplashScreen = YES;
+   // self.viewController.useSplashScreen = YES;
 
     // Set your app's start page by setting the <content src='foo.html' /> tag in config.xml.
     // If necessary, uncomment the line below to override it.

--- a/kitchensink-cordova/ios/KitchensinkCordova/Classes/AppDelegate.m
+++ b/kitchensink-cordova/ios/KitchensinkCordova/Classes/AppDelegate.m
@@ -84,7 +84,8 @@
 #else
         self.viewController = [[[MainViewController alloc] init] autorelease];
 #endif
-   // self.viewController.useSplashScreen = YES;
+    // As of Cordova 2.5.0, this setting is deprecated. You can add or remove the SplashScreen plugin in config.xml. For backward compatibility uncomment this line.
+    // self.viewController.useSplashScreen = YES;
 
     // Set your app's start page by setting the <content src='foo.html' /> tag in config.xml.
     // If necessary, uncomment the line below to override it.


### PR DESCRIPTION
Removed the useSplashScreen deprecated setting
