### PR TITLE
Fix beans.xml location in deltaspike-beanbuilder and cdi-add-interceptor-binding

### DIFF
--- a/cdi-add-interceptor-binding/src/main/webapp/WEB-INF/beans.xml
+++ b/cdi-add-interceptor-binding/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,27 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee 
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+    <interceptors>
+        <class>org.jboss.as.quickstart.cdi.parameterlogger.model.ParameterLoggerInterceptor</class>
+    </interceptors>
+</beans>
+    

--- a/deltaspike-beanbuilder/src/main/webapp/WEB-INF/beans.xml
+++ b/deltaspike-beanbuilder/src/main/webapp/WEB-INF/beans.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,9 +14,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
+
 <beans xmlns="http://java.sun.com/xml/ns/javaee"
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="       http://java.sun.com/xml/ns/javaee       http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
- <interceptors>
-  <class>org.jboss.as.quickstart.cdi.parameterlogger.model.ParameterLoggerInterceptor</class>
- </interceptors>
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee 
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
 </beans>


### PR DESCRIPTION
- added beans.xml to beanbuilder, it was missing completely
- moved beans.xml in cdi-add-interceptor-binding from src/main/resources to src/main/webapp/WEB-INF as per JSR-299, 12.1; both work in Weld, but the latter prevents JBDS from throwing a warning about missing beans.xml
