### PR TITLE
Extending naming rules for package and artifact id

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,11 +93,11 @@ General Guidelines
  - Code should be well documented with good comments. Please add an author tag (@author) to credit yourself for writing the code.
  - You should use readable variable names to make it easy for users to read the code.
 
-* The package must be *org.jboss.quickstarts.&lt;product&gt;* (i.e. org.jboss.quickstarts.as, org.jboss.quickstarts.fuse, etc...)
+* The package must be `org.jboss.quickstarts.<product-type>`, for example: org.jboss.quickstarts.eap, org.jboss.quickstarts.wfk, org.jboss.quickstarts.jdg, org.jboss.quickstarts.brms, org.jboss.quickstarts.fuse, etc.
 
 * The quickstart project or folder name should match the quickstart name. Each sample project should have a unique name, allowing easy identification by users and developers.
 
-* The quickstart project `<artifactId>` in the `pom.xml` file must be prefixed by `jboss-&lt;product&gt;-`. For example, the `<artifactId>` for the `greeter` quickstart is `jboss-as-greeter` and for the `errors` Fuse project, it will be jboss-fuse-errors.
+* The `<artifactId>` in the quickstart `pom.xml` file should follow the template: `jboss-<product-type>-<quickstart-name>`. For example, the `<artifactId>` for the `greeter` quickstart in the AS 7 project is `jboss-as-greeter`. The `<artifactId>` for `errors` quickstart in the Fuse project is `jboss-fuse-errors`.
 
 * If you create a quickstart that uses a database table, make sure the name you use for the table is unique across all quickstarts. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,11 +93,11 @@ General Guidelines
  - Code should be well documented with good comments. Please add an author tag (@author) to credit yourself for writing the code.
  - You should use readable variable names to make it easy for users to read the code.
 
-* The package must be *org.jboss.as.quickstarts*
+* The package must be *org.jboss.quickstarts.&lt;product&gt;* (i.e. org.jboss.quickstarts.as, org.jboss.quickstarts.fuse, etc...)
 
 * The quickstart project or folder name should match the quickstart name. Each sample project should have a unique name, allowing easy identification by users and developers.
 
-* The quickstart project `<artifactId>` in the `pom.xml` file must be prefixed by `jboss-as-`. For example, the `<artifactId>` for the `greeter` quickstart is `jboss-as-greeter`.
+* The quickstart project `<artifactId>` in the `pom.xml` file must be prefixed by `jboss-&lt;product&gt;-`. For example, the `<artifactId>` for the `greeter` quickstart is `jboss-as-greeter` and for the `errors` Fuse project, it will be jboss-fuse-errors.
 
 * If you create a quickstart that uses a database table, make sure the name you use for the table is unique across all quickstarts. 
 


### PR DESCRIPTION
Working on Fuse quick starts, that have JBoss Fuse as server target, I propose that we extend the naming rules in Guidelines to reflect the example targeted product.
