### PR TITLE
Back out the addition of jpp-quickstarts to the complex dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,6 @@
                 <module>jts</module>
                 <module>inter-app</module>                
                 <module>ejb-security-plus</module>
-                <module>jpp-quickstarts</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
Previous commit results in jenkins build failure: http://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jdf-quickstarts-ci/27/changes
