### PR TITLE
kitchensink-angularjs fix: Change datasource names for application and tests

### DIFF
--- a/kitchensink-angularjs/src/main/resources/META-INF/persistence.xml
+++ b/kitchensink-angularjs/src/main/resources/META-INF/persistence.xml
@@ -25,7 +25,7 @@
          data source, this example data source is just for development and testing! -->
       <!-- The datasource is deployed as WEB-INF/kitchensink-quickstart-ds.xml, you
          can find it in the source at src/main/webapp/WEB-INF/kitchensink-quickstart-ds.xml -->
-      <jta-data-source>java:jboss/datasources/KitchensinkQuickstartDS</jta-data-source>
+      <jta-data-source>java:jboss/datasources/KitchensinkAngularJSQuickstartDS</jta-data-source>
       <properties>
          <!-- Properties for Hibernate -->
          <property name="hibernate.hbm2ddl.auto" value="create-drop" />

--- a/kitchensink-angularjs/src/main/webapp/WEB-INF/kitchensink-quickstart-ds.xml
+++ b/kitchensink-angularjs/src/main/webapp/WEB-INF/kitchensink-quickstart-ds.xml
@@ -23,10 +23,10 @@
     xsi:schemaLocation="http://www.jboss.org/ironjacamar/schema http://docs.jboss.org/ironjacamar/schema/datasources_1_0.xsd">
     <!-- The datasource is bound into JNDI at this location. We reference 
         this in META-INF/persistence.xml -->
-    <datasource jndi-name="java:jboss/datasources/KitchensinkQuickstartDS"
+    <datasource jndi-name="java:jboss/datasources/KitchensinkAngularJSQuickstartDS"
         pool-name="kitchensink-quickstart" enabled="true"
         use-java-context="true">
-        <connection-url>jdbc:h2:mem:kitchensink-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
+        <connection-url>jdbc:h2:mem:kitchensink-angularjs-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
         <driver>h2</driver>
         <security>
             <user-name>sa</user-name>

--- a/kitchensink-angularjs/src/main/webapp/index.html
+++ b/kitchensink-angularjs/src/main/webapp/index.html
@@ -42,7 +42,7 @@
             <img src="gfx/dualbrand_logo.png" />
         </div>
         <div id="content" ng-view>
-            <!-- This div will be tempalted by AngularJS -->
+            <!-- This div will be templated by AngularJS -->
             [Template content will be inserted here]
         </div>
         <div id="aside">

--- a/kitchensink-angularjs/src/test/resources/META-INF/test-persistence.xml
+++ b/kitchensink-angularjs/src/test/resources/META-INF/test-persistence.xml
@@ -26,7 +26,7 @@
          database. Production applications should use a managed datasource. -->
       <!-- The datasource is deployed as WEB-INF/test-ds.xml, 
          you can find it in the source at src/test/resources/test-ds.xml -->
-      <jta-data-source>java:jboss/datasources/KitchensinkQuickstartTestDS</jta-data-source>
+      <jta-data-source>java:jboss/datasources/KitchensinkAngularJSQuickstartTestDS</jta-data-source>
       <properties>
          <!-- Properties for Hibernate -->
          <property name="hibernate.hbm2ddl.auto" value="create-drop" />

--- a/kitchensink-angularjs/src/test/resources/test-ds.xml
+++ b/kitchensink-angularjs/src/test/resources/test-ds.xml
@@ -23,10 +23,10 @@
    xsi:schemaLocation="http://www.jboss.org/ironjacamar/schema http://docs.jboss.org/ironjacamar/schema/datasources_1_0.xsd">
    <!-- The datasource is bound into JNDI at this location. We reference 
       this in META-INF/test-persistence.xml -->
-   <datasource jndi-name="java:jboss/datasources/KitchensinkQuickstartTestDS"
+   <datasource jndi-name="java:jboss/datasources/KitchensinkAngularJSQuickstartTestDS"
       pool-name="kitchensink-quickstart-test" enabled="true"
       use-java-context="true">
-      <connection-url>jdbc:h2:mem:kitchensink-quickstart-test;DB_CLOSE_DELAY=-1</connection-url>
+      <connection-url>jdbc:h2:mem:kitchensink-angularjs-quickstart-test;DB_CLOSE_DELAY=-1</connection-url>
       <driver>h2</driver>
       <security>
          <user-name>sa</user-name>


### PR DESCRIPTION
...so they do not conflict with those used in the kitchensink quickstart
