### PR TITLE
Missing forward slash breaks MemberResourceRESTService#lookupMemberById

### DIFF
--- a/kitchensink-angularjs/src/main/webapp/js/services.js
+++ b/kitchensink-angularjs/src/main/webapp/js/services.js
@@ -17,5 +17,5 @@
 // Define the REST resource service, allowing us to interact with it as a high level service
 angular.module('membersService', ['ngResource']).
     factory('Members', function($resource){
-  return $resource('rest/members:memberId', {});
+  return $resource('rest/members/:memberId', {});
 });


### PR DESCRIPTION
The problem is that if AngularJS calls MemberResourceRESTService#lookupMemberById via the service defined in services.js, it will use this url, for a member with id '0':

http://localhost:8080/jboss-as-kitchensink-angularjs/rest/members0

This is fixed by adding the forward slash. 

This issue only arrises if you try and build on the Quickstart, as the AngularJS controller never looks up an individual member.
