### PR TITLE
Fixed EAP cartridge name to match change in OpenShift

### DIFF
--- a/helloworld-mdb/README.md
+++ b/helloworld-mdb/README.md
@@ -114,13 +114,13 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 ### Create the OpenShift Application
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6.0` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
+Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
 
     rhc app create -a hellworldmdb -t APPLICATION_TYPE
 
 The domain name for this application will be `helloworldmdb-YOUR_DOMAIN_NAME.rhcloud.com`. Here we use the _quickstart_ domain. You will need to replace it with your own OpenShift domain name.
 
-This command creates an OpenShift application called `helloworldmdb` and will run the application inside the `jbosseap-6.0`  or `jbossas-7` container. You should see some output similar to the following:
+This command creates an OpenShift application called `helloworldmdb` and will run the application inside the `jbosseap-6`  or `jbossas-7` container. You should see some output similar to the following:
 
     Creating application: helloworldmdb
     Now your new domain name is being propagated worldwide (this might take a minute)...

--- a/helloworld-rs/README.md
+++ b/helloworld-rs/README.md
@@ -94,13 +94,13 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 ### Create the OpenShift Application
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6.0` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
+Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
 
     rhc app create -a helloworldrs -t APPLICATION_TYPE
 
 _NOTE_: The domain name for this application will be `helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com`. Here we use the _quickstart_ domain. You will need to replace it with your own OpenShift domain name.
 
-This command creates an OpenShift application named `helloworldrs` and will run the application inside the `jbosseap-6.0`  or `jbossas-7` container. You should see some output similar to the following:
+This command creates an OpenShift application named `helloworldrs` and will run the application inside the `jbosseap-6`  or `jbossas-7` container. You should see some output similar to the following:
 
     Creating application: helloworldrs
     Now your new domain name is being propagated worldwide (this might take a minute)...

--- a/helloworld-ws/README.md
+++ b/helloworld-ws/README.md
@@ -119,13 +119,13 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 Note that we use the `jboss-as-quickstart@jboss.org` user for these examples. You need to substitute it with your own user name.
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6.0` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
+Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
 
         rhc app create -a helloworldws -t APPLICATION_TYPE
 
 _NOTE_: The domain name for this application will be `helloworldws-YOUR_DOMAIN_NAME.rhcloud.com`. Here we use the _quickstart_ domain. You will need to replace it with your own OpenShift domain name.
 
-This command creates an OpenShift application called `helloworldws` and will run the application inside a `jbossas-7` or a `jbosseap-6.0` container. You should see some output similar to the following:
+This command creates an OpenShift application called `helloworldws` and will run the application inside a `jbossas-7` or a `jbosseap-6` container. You should see some output similar to the following:
 
     Creating application: helloworldws
     Now your new domain name is being propagated worldwide (this might take a minute)...

--- a/kitchensink-angularjs-topcoat/README.md
+++ b/kitchensink-angularjs-topcoat/README.md
@@ -107,13 +107,13 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 Note that we use the `jboss-as-quickstart@jboss.org` user for these examples. You need to substitute it with your own user name.
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6.0` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
+Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
 
     rhc app create -a kitchensinkangularjstopcoat -t APPLICATION_TYPE
 
 _NOTE_: The domain name for this application will be `kitchensinkangularjstopcoat-YOUR_DOMAIN_NAME.rhcloud.com`. Here we use the _quickstart_ domain. You will need to replace it with your own OpenShift domain name.
 
-This command creates an OpenShift application called `kitchensinkangularjstopcoat` and will run the application inside the `jbosseap-6.0`  or `jbossas-7` container. You should see some output similar to the following:
+This command creates an OpenShift application called `kitchensinkangularjstopcoat` and will run the application inside the `jbosseap-6`  or `jbossas-7` container. You should see some output similar to the following:
 
         Application Options
         -------------------

--- a/kitchensink-angularjs/README.md
+++ b/kitchensink-angularjs/README.md
@@ -106,13 +106,13 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 Note that we use the `jboss-as-quickstart@jboss.org` user for these examples. You need to substitute it with your own user name.
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6.0` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
+Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
 
     rhc app create -a kitchensinkangularjs -t APPLICATION_TYPE
 
 _NOTE_: The domain name for this application will be `kitchensinkangularjs-YOUR_DOMAIN_NAME.rhcloud.com`. Here we use the _quickstart_ domain. You will need to replace it with your own OpenShift domain name.
 
-This command creates an OpenShift application called `kitchensinkangularjs` and will run the application inside the `jbosseap-6.0`  or `jbossas-7` container. You should see some output similar to the following:
+This command creates an OpenShift application called `kitchensinkangularjs` and will run the application inside the `jbosseap-6`  or `jbossas-7` container. You should see some output similar to the following:
 
     Creating application: kitchensinkangularjs
     Now your new domain name is being propagated worldwide (this might take a minute)...

--- a/template/README.md
+++ b/template/README.md
@@ -182,13 +182,13 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 ### Create the OpenShift Application
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6.0` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
+Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
 
     rhc app create -a APPLICATION_NAME -t APPLICATION_TYPE
 
 _NOTE_: The domain name for this application will be APPLICATION_NAME-YOUR_DOMAIN_NAME.rhcloud.com`. Here we use the _quickstart_ domain. You will need to replace it with your own OpenShift domain name.
 
-This command creates an OpenShift application named  and will run the application inside the `jbosseap-6.0`  or `jbossas-7` container. You should see some output similar to the following:
+This command creates an OpenShift application named  and will run the application inside the `jbosseap-6`  or `jbossas-7` container. You should see some output similar to the following:
 
     Creating application: APPLICATION_NAME
     Now your new domain name is being propagated worldwide (this might take a minute)...

--- a/wsat-simple/README.md
+++ b/wsat-simple/README.md
@@ -146,13 +146,13 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 Note that we use the `jboss-as-quickstart@jboss.org` user for these examples. You need to substitute it with your own user name.
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6.0` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
+Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
 
     rhc app create -a wsatsimple -t APPLICATION_TYPE
 
 _NOTE_: The domain name for this application will be `wsatsimple-YOUR_DOMAIN_NAME.rhcloud.com`. Here we use the _quickstart_ domain. You will need to replace it with your own OpenShift domain name.
 
-This command creates an OpenShift application called `wsatsimple` and will run the application inside the `jbosseap-6.0`  or `jbossas-7` container. You should see some output similar to the following:
+This command creates an OpenShift application called `wsatsimple` and will run the application inside the `jbosseap-6`  or `jbossas-7` container. You should see some output similar to the following:
 
     Creating application: wsatsimple
     Now your new domain name is being propagated worldwide (this might take a minute)...


### PR DESCRIPTION
See:

rhc app create -a tmp2 -t jbosseap-6.0

Short Name          Full name
==========          =========
10gen-mms-agent-0.1 10gen Mongo Monitoring Service Agent
cron-1.4            Cron 1.4
diy-0.1             Do-It-Yourself 0.1
jbossas-7           JBoss Application Server 7
jbosseap-6          JBoss Enterprise Application Platform 6.1.0
...

jbosseap-6 .0 is no longer a valid cartridge name.
