### PR TITLE
Merge from master to 6.2.x for ER5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Introduction
 ------------
 
 
-These quickstarts run on Red Hat JBoss Enterprise Application Platform 6.1 or later. We recommend using the JBoss EAP 6.1 ZIP file. This version uses the correct dependencies and ensures you test and compile against your runtime environment. 
+These quickstarts run on Red Hat JBoss Enterprise Application Platform 6.1 or later. We recommend using the JBoss EAP ZIP file. This version uses the correct dependencies and ensures you test and compile against your runtime environment. 
 
 Be sure to read this entire document before you attempt to work with the quickstarts. It contains the following information:
 
@@ -28,7 +28,7 @@ Be sure to read this entire document before you attempt to work with the quickst
 Available Quickstarts
 ---------------------
 
-The following is a list of the currently available quickstarts. The table lists each quickstart name, the technologies it demonstrates, gives a brief description of the quickstart, and the level of experience required to set it up. For more detailed information about a quickstart, click on the quickstart name.
+The list of all currently available quickstarts can be found here: <http://site-jdf.rhcloud.com/quickstarts/get-started/>. The table lists each quickstart name, the technologies it demonstrates, gives a brief description of the quickstart, and the level of experience required to set it up. For more detailed information about a quickstart, click on the quickstart name.
 
 Some quickstarts are designed to enhance or extend other quickstarts. These are noted in the **Prerequisites** column. If a quickstart lists prerequisites, those must be installed or deployed before working with the quickstart.
 
@@ -67,6 +67,8 @@ Git submodules allow you clone another repository as a subdirectory in your proj
 System Requirements
 -------------------
 
+The applications these projects produce are designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
 To run these quickstarts with the provided build scripts, you need the following:
 
 1. Java 1.6, to run JBoss AS and Maven. You can choose from the following:
@@ -80,7 +82,7 @@ To run these quickstarts with the provided build scripts, you need the following
 
             mvn --version 
 
-3. The JBoss EAP 6.1 distribution ZIP.
+3. The JBoss EAP distribution ZIP.
     * For information on how to install and run JBoss, refer to the product documentation.
 
 4. You can also use [JBoss Developer Studio or Eclipse](#use-jBoss-developer-studio-or-eclipse-to-run-the-quickstarts) to run the quickstarts. 
@@ -114,8 +116,8 @@ _Note: If you do not wish to configure the Maven settings, you must pass the con
 4. Copy the `settings.xml` file from the root of the quickstarts directory to your Maven install directory.
  
             For Linux or Mac:  cp QUICKSTART_HOME/settings.xml  ~/.m2/settings.xml
-            For Windows: cp QUICKSTART_HOME/settings.xml \Documents and Settings\USER_NAME\.m2\settings.xml 
-                    -or- cp QUICKSTART_HOME/settings.xml \Users\USER_NAME\.m2\settings.xml
+            For Windows: copy QUICKSTART_HOME/settings.xml \Documents and Settings\USER_NAME\.m2\settings.xml 
+                    -or- copy QUICKSTART_HOME/settings.xml \Users\USER_NAME\.m2\settings.xml
 
 ### Restore Your Maven Configuration When You Finish Testing the Quickstarts
 
@@ -160,19 +162,19 @@ The root folder of each individual quickstart contains a README file with specif
 
 ### Start the JBoss Server
 
-Before you deploy a quickstart, in most cases you need a running JBoss EAP 6.1 server. A few of the Arquillian tests do not require a running server. This will be noted in the README for that quickstart. 
+Before you deploy a quickstart, in most cases you need a running JBoss EAP server. A few of the Arquillian tests do not require a running server. This will be noted in the README for that quickstart. 
 
 The JBoss server can be started a few different ways.
 
-* [Start the JBoss Server With the _web_ profile](#start-the-jboss-server-with-the-web-profile): This is the default configuration. It defines minimal subsystems and services.
+* [Start the Default JBoss Server](#start-the-default-jboss-server): This is the default configuration. It defines minimal subsystems and services.
 * [Start the JBoss Server with the _full_ profile](#start-the-jboss-server-with-the-full-profile): This profile configures many of the commonly used subsystems and services.
 * [Start the JBoss Server with a custom configuration](#start-the-jboss-server-with-custom-configuration-options): Custom configuration parameters can be specified on the command line when starting the server.
 
 The README for each quickstart will specify which configuration is required to run the example.
 
-#### Start the JBoss Server
+#### Start the Default JBoss Server
 
-To start JBoss EAP 6.1:
+To start JBoss EAP:
 
 1. Open a command line and navigate to the root of the JBoss server directory.
 2. The following shows the command line to start the JBoss server:
@@ -182,7 +184,7 @@ To start JBoss EAP 6.1:
 
 #### Start the JBoss Server with the Full Profile
 
-To start JBoss EAP 6.1 with the Full Profile:
+To start JBoss EAP with the Full Profile:
 
 1. Open a command line and navigate to the root of the JBoss server directory.
 2. The following shows the command line to start the JBoss server with the full profile:
@@ -192,7 +194,7 @@ To start JBoss EAP 6.1 with the Full Profile:
 
 #### Start the JBoss Server with Custom Configuration Options
 
-To start JBoss EAP 6.1 with custom configuration options:
+To start JBoss EAP with custom configuration options:
 
 1. Open a command line and navigate to the root of the JBoss server directory.
 2. The following shows the command line to start the JBoss server. Replace the CUSTOM_OPTIONS with the custom optional parameters specified in the quickstart.
@@ -265,47 +267,49 @@ To undeploy any quickstarts that fail due to complex dependencies, follow the un
 ### Run the Arquillian Tests
 ----------------------------
 
-Some of the quickstarts provide Arquillian tests. By default, these tests are configured to be skipped, as Arquillian tests require the use of a container. 
+Some of the quickstarts provide Arquillian tests. By default, these tests are configured to be skipped, as Arquillian tests an application on a real server, not just in a mocked environment.
 
-You can run these tests using either a remote or managed container. The quickstart README should tell you what you should expect to see in the console output and server log when you run the test.
+You can either start the server yourself or let Arquillian manage its lifecycle during the testing. The individual quickstart README should tell you what to expect in the console output and the server log when you run the test.
 
 
-1. Test the quickstart on a Remote Server
-    * A remote container requires you start the JBoss EAP 6.1 server before running the test. [Start the JBoss server](#start-the-jboss-server) as described in the quickstart README file.
+1. Test the quickstart on a remote server
+    * Arquillian's remote container adapter expects a JBoss server instance to be already started prior to the test execution. You must [Start the JBoss server](#start-the-jboss-server) as described in the quickstart README file.
+    * If you need to run the tests on a JBoss server running on a machine other than localhost, you can configure this, along with other options, in the `src/test/resources/arquillian.xml` file using the following properties:
+        
+            <container qualifier="jboss" default="true">
+                <configuration>
+                    <property name="managementAddress">myhost.example.com</property>
+                    <property name="managementPort">9999</property>
+                    <property name="username">customAdminUser</property>
+                    <property name="password">myPassword</property>
+                </configuration>
+            </container>    
     * Run the test goal with the following profile activated:
 
-            mvn clean test -Parq-jbossas-remote 
-2. Test the quickstart on Managed Server
+            mvn clean test -Parq-jbossas-remote     
+2. Test the quickstart on a managed server
 
-    _Note: This test requires that your server is not running. Arquillian will start the container for you, however, you must first let it know where to find the remote JBoss container._
-    * Open the test/resources/arquillian.xml file located in the quickstart directory. 
-    * Find the configuration for the remote JBoss container. It should look like this:
+    Arquillian's managed container adapter requires that your server is not running as it will start the container for you. However, you must first let it know where to find the JBoss server directory. The simplest way to do this is to set the `JBOSS_HOME` environment variable to the full path to your JBoss server directory. Alternatively, you can set the path in the `jbossHome` property in the Arquillian configuration file.
+    * Open the `src/test/resources/arquillian.xml` file located in the quickstart directory.
+    * Find the configuration for the JBoss container. It should look like this:
 
-            <!-- Example configuration for a remote JBoss EAP 6.1 instance -->
+            <!-- Example configuration for a managed/remote JBoss AS 7 instance -->
             <container qualifier="jboss" default="true">
-                <!-- By default, arquillian will use the JBOSS_HOME environment variable.  Alternatively, the configuration below can be uncommented. -->
+                <!-- If you want to use the JBOSS_HOME environment variable, just delete the jbossHome property -->
                 <!--<configuration> -->
                 <!--<property name="jbossHome">/path/to/jboss/as</property> -->
                 <!--</configuration> -->
-            </container>
-    * Remove the comments from the `<configuration>` elements.
-
-            <!-- Example configuration for a remote JBoss EAP 6.1 instance -->
-            <container qualifier="jboss" default="true">
-                <!-- By default, arquillian will use the JBOSS_HOME environment variable.  Alternatively, the configuration below can be uncommented. -->
-                <configuration>
-                    <property name="jbossHome">/path/to/jboss/as</property>
-                </configuration>
-            </container>
-    * Find the "jbossHome" property and replace the "/path/to/jboss/as" value with the actual path to your JBoss EAP 6.1 server.
+            </container>           
+    * Uncomment the `configuration` element, find the `jbossHome` property and replace the "/path/to/jboss/as" value with the actual path to your JBoss EAP server.
     * Run the test goal with the following profile activated:
 
             mvn clean test -Parq-jbossas-managed
 
+
 Use JBoss Developer Studio or Eclipse to Run the Quickstarts
 ------------------------------------------------------------
 
-You can also deploy the quickstarts from Eclipse using JBoss tools. For more information on how to set up Maven and the JBoss tools, refer to the [JBoss Enterprise Application Platform 6.1 Development Guide](https://access.redhat.com/site/documentation/JBoss_Enterprise_Application_Platform/) or [Get Started Developing Applications](http://www.jboss.org/jdf/quickstarts/jboss-as-quickstart/guide/Introduction/ "Get Started Developing Applications").
+You can also deploy the quickstarts from Eclipse using JBoss tools. For more information on how to set up Maven and the JBoss tools, refer to the [JBoss Enterprise Application Platform Development Guide](https://access.redhat.com/site/documentation/JBoss_Enterprise_Application_Platform/) or [Get Started Developing Applications](http://www.jboss.org/jdf/quickstarts/jboss-as-quickstart/guide/Introduction/ "Get Started Developing Applications").
 
 
 Optional Components
@@ -321,7 +325,7 @@ The following components are needed for only a small subset of the quickstarts. 
 
 ### Add a Management or Application User
 
-By default, JBoss EAP 6.1 is now distributed with security enabled for the management interfaces. A few of the quickstarts use these management interfaces and require that you create a management or application user to access the running application. A script is provided in the `JBOSS_HOME/bin` directory for that purpose.
+By default, JBoss EAP is now distributed with security enabled for the management interfaces. A few of the quickstarts use these management interfaces and require that you create a management or application user to access the running application. A script is provided in the `JBOSS_HOME/bin` directory for that purpose.
 
 The following procedures describe how to add a user with the appropriate permissions to run the quickstarts that depend on them.
 
@@ -538,14 +542,14 @@ You can configure the driver by running the `configure-postgresql.cli` script pr
 
 _NOTE - Before you begin:_
 
-1. If it is running, stop the JBoss EAP 6.1 Server.
+1. If it is running, stop the JBoss EAP server.
 2. Backup the file: `JBOSS_HOME/standalone/configuration/standalone-full.xml`
 3. After you have completed testing the quickstarts, you can replace this file to restore the server to its original configuration.
 
  
 ##### Configure the Driver By Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss EAP server by typing the following: 
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml
@@ -561,7 +565,7 @@ This script adds the PostgreSQL driver to the datasources subsystem in the serve
 
 ##### Configure the Driver Using the JBoss CLI Interactively
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss EAP server by typing the following: 
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml
@@ -572,11 +576,13 @@ This script adds the PostgreSQL driver to the datasources subsystem in the serve
 3. At the prompt, type the following:
 
         [standalone@localhost:9999 /] /subsystem=datasources/jdbc-driver=postgresql:add(driver-name=postgresql,driver-module-name=org.postgresql,driver-xa-datasource-class-name=org.postgresql.xa.PGXADataSource)
+4. Tell the server to reload the configuration:
 
+         [standalone@localhost:9999 /] :reload
 
 ##### Configure the Driver By Manually Editing the Configuration File
 
-1.  If it is running, stop the JBoss EAP 6.1 Server.
+1.  If it is running, stop the JBoss EAP server.
 2.  Backup the file: `JBOSS_HOME/standalone/configuration/standalone-full.xml`
 3.  Open the `JBOSS_HOME/standalone/configuration/standalone-full.xml` file in an editor and locate the subsystem `urn:jboss:domain:datasources:1.0`. 
 4.  Add the following driver to the `<drivers>` section that subsystem. You may need to merge with other drivers in that section:
@@ -592,7 +598,7 @@ When you are done testing the quickstarts, you can remove the PostgreSQL configu
 
 ##### Remove the PostgreSQL Configuration by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss EAP server by typing the following: 
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml
@@ -607,7 +613,7 @@ This script removes PostgreSQL from the `datasources` subsystem in the server co
 
 
 ##### Remove the PostgreSQL Configuration Manually
-1. If it is running, stop the JBoss EAP 6.1 Server.
+1. If it is running, stop the JBoss EAP server.
 2. Replace the `JBOSS_HOME/standalone/configuration/standalone-full.xml` file with the back-up copy of the file.
 
 

--- a/bean-validation/README.md
+++ b/bean-validation/README.md
@@ -5,6 +5,7 @@ Level: Beginner
 Technologies: Bean Validation, JPA
 Summary: Shows how to use Arquillian to test Bean Validation
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -18,9 +19,9 @@ This quickstart does not contain a user interface layer. The purpose of this pro
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -29,7 +30,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/bmt/README.md
+++ b/bmt/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: EJB, Bean Managed Transactions (BMT)
 Summary: EJB that demonstrates bean-managed transactions (BMT)
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -12,13 +13,13 @@ What is it?
 
 On occasion, the application developer requires finer grained control over the lifecycle of JTA transactions and JPA Entity Managers than the defaults provided by the Java EE container. This example shows how the developer can override these defaults and take control of aspects of the lifecycle of JPA and transactions.
 
-This example demonstrates how to manually manage transaction demarcation while accessing JPA entities in Red Hat JBoss Enterprise Application Platform 6.1 or later.
+This example demonstrates how to manually manage transaction demarcation while accessing JPA entities in Red Hat JBoss Enterprise Application Platform.
 
 When you run this example, you will be provided with a `Use bean managed Entity Managers` checkbox.
 * If you check the checkbox, it shows the developer responsibilities when injecting an Entity Manager into a managed (stateless) bean.
 * If you uncheck the checkbox, shows the developer responsibilities when using JPA and transactions with an unmanaged component.
 
-JBoss EAP 6.1 ships with H2, an in-memory database written in Java. This example shows how to transactionally insert key value pairs into the H2 database and demonstrates the requirements on the developer with respect to the JPA Entity Manager.
+JBoss EAP ships with H2, an in-memory database written in Java. This example shows how to transactionally insert key value pairs into the H2 database and demonstrates the requirements on the developer with respect to the JPA Entity Manager.
 
 _NOTE: A Java EE container is designed with robustness in mind, so you should carefully analyse the scaleabiltiy, concurrency and performance needs of you application before taking advantage of these techniques in your own applications._
 
@@ -26,9 +27,9 @@ _NOTE: A Java EE container is designed with robustness in mind, so you should ca
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -37,7 +38,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/cdi-alternative/README.md
+++ b/cdi-alternative/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: CDI, Servlet, JSP
 Summary: Demonstrates the use of CDI Alternatives where the bean is selected during deployment 
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -27,9 +28,9 @@ For EL resolution, it must contain @Named
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -38,7 +39,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/cdi-decorator/README.md
+++ b/cdi-decorator/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: CDI
 Summary: Demonstrates the use of CDI Decorator where the bean is can be decorated.
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -19,9 +20,9 @@ By default, all decorators are disabled, so application will run without using d
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -30,7 +31,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/cdi-injection/README.md
+++ b/cdi-injection/README.md
@@ -5,20 +5,22 @@ Level: Beginner
 Technologies: CDI
 Summary: Demonstrates the use of CDI 1.0 Injection and Qualifiers with JSF as the front-end client.
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the use of *CDI 1.0 Injection and Qualifiers* in *Red Hat JBoss Enterprise Application Platform 6.1* or later with JSF as the front-end client.
+This example demonstrates the use of *CDI 1.0 Injection and Qualifiers* in Red Hat JBoss Enterprise Application Platform with JSF as the front-end client.
 
 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
+
 
 Configure Maven
 ---------------
@@ -26,7 +28,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/cdi-interceptors/README.md
+++ b/cdi-interceptors/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: JPA,JSF,EJB
 Summary: Demonstrates using cdi-interceptors for logging and auditing
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -19,16 +20,16 @@ To enable an interceptor, you must add the interceptor class to the WEB-INF/bean
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
 
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
  
 Configure Maven
 ---------------
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/cdi-interceptors/pom.xml
+++ b/cdi-interceptors/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/cdi-portable-extension/README.md
+++ b/cdi-portable-extension/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: CDI
 Summary: Creating a basic CDI extension to provide injection of fields from an XML file.
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -15,7 +16,7 @@ to complete that task. This particular extension explores the ProcessInjectionTa
 InjectionTarget spi classes of CDI. To demonstrate a possible way to seed data into beans.
 
 A Portable Extension is essentially an extension to Java EE 6+ which is tailored to a specific
-use case which will run on any Java EE 6 or higher implementation. There may be something that the
+use case which will run on any Java EE 6 or later implementation. There may be something that the
 specifications don't support just yet, but could be implemented via a portable extension such as
 type safe messages or external configuration of beans.
 
@@ -28,9 +29,9 @@ correctly.
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later.
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven
@@ -40,7 +41,7 @@ Contributor: You can copy or link to the Maven configuration information in the 
 
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/cdi-portable-extension/pom.xml
+++ b/cdi-portable-extension/pom.xml
@@ -15,9 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/cdi-stereotype/README.md
+++ b/cdi-stereotype/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: JPA,JSF,EJB
 Summary: Demonstrates using cdi-stereotype for logging and auditing
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -22,9 +23,9 @@ Arquillian tests added in cdi-interceptors quickstart.
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or higher. 
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -33,7 +34,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/cdi-stereotype/pom.xml
+++ b/cdi-stereotype/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/cdi-veto/README.md
+++ b/cdi-veto/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: CDI
 Summary: Creating a basic CDI extension to demonstrate vetoing beans.
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -16,7 +17,7 @@ InjectionTarget SPI classes of CDI to demonstrate removing a bean from CDI's kno
 correctly injecting JPA entities in your application.
 
 A Portable Extension is a user extension to Java EE 6 or above which is tailored to a specific
-use case which will run on any Java EE 6 or higher implementation. This may be something that the
+use case which will run on any Java EE 6 or later implementation. This may be something that the
 specifications don't support just yet, but could be implemented via a portable extension such as
 type-safe messages or external configuration of beans.
 
@@ -29,9 +30,9 @@ correctly.
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later.
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven
@@ -39,7 +40,7 @@ Configure Maven
 
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/cdi-veto/pom.xml
+++ b/cdi-veto/pom.xml
@@ -15,9 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/cluster-ha-singleton/README.md
+++ b/cluster-ha-singleton/README.md
@@ -5,6 +5,7 @@ Level: Advanced
 Technologies: EJB, HASingleton, JNDI
 Summary: A SingletonService deployed in a JAR started by SingletonStartup and accessed by an EJB
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -24,9 +25,9 @@ The root `pom.xml` builds each of the subprojects in the above order and deploys
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -37,7 +38,7 @@ You can copy or link to the Maven configuration information in the README file i
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1 with a HA profile
+Start the JBoss Server with a HA profile
 -------------------------
 
 If you run a non HA profile the singleton service will not start correctly. To run the example one instance must be started, to see the singleton behaviour at minimum two instances

--- a/cmt/README.md
+++ b/cmt/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: EJB, Container Managed Transactions (CMT)
 Summary: EJB that demonstrates container-managed transactions (CMT)
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 ## What is it?
@@ -45,9 +46,9 @@ The available options for this annotation are as follows:
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -67,7 +68,7 @@ _Note_: For the purpose of this quickstart, replace the word QUICKSTART_DATABASE
 2. [Add the PostgreSQL Module](../README.md#add-the-postgresql-module-to-the-jboss-server) to the JBoss server `modules/` directory.
 3. [Add the PostgreSQL driver](../README.md#add-the-postgresql-driver-configuration-to-the-jboss-server) to the JBoss server configuration file.
 
-Start JBoss EAP 6.1 with the Full Profile
+Start the JBoss Server with the Full Profile
 ---------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.quickstarts.eap</groupId>
     <artifactId>jboss-cmt</artifactId>

--- a/ejb-asynchronous/README.md
+++ b/ejb-asynchronous/README.md
@@ -5,6 +5,7 @@ Level: Advanced
 Technologies: EJB 
 Summary: Demonstrates asynchronous EJB invocations.
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -23,9 +24,9 @@ The root `pom.xml` builds each of the submodules in the above order and deploys 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -37,7 +38,7 @@ If you have not yet done so, you must [Configure Maven](../README.md#configure-m
 
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/ejb-in-ear/README.md
+++ b/ejb-in-ear/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: EJB, EAR
 Summary: Packages an EJB JAR and WAR in an EAR
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -34,9 +35,9 @@ The example follows the common "Hello World" pattern. These are the steps that o
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven 
@@ -45,7 +46,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/ejb-in-war/README.md
+++ b/ejb-in-war/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: EJB, JSF, WAR
 Summary: Packages an EJB JAR in a WAR
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the deployment of an *EJB 3.1* bean bundled in a war archive for deployment to *Red Hat JBoss Enterprise Application Platform 6.1* or later. The project also includes a set of Aquillian tests for the managed bean and EJB.
+This example demonstrates the deployment of an *EJB 3.1* bean bundled in a war archive for deployment to Red Hat JBoss Enterprise Application Platform. The project also includes a set of Aquillian tests for the managed bean and EJB.
 
 The example follows the common "Hello World" pattern. These are the steps that occur:
 
@@ -23,9 +24,9 @@ The example follows the common "Hello World" pattern. These are the steps that o
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven 
@@ -34,7 +35,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/ejb-in-war/pom.xml
+++ b/ejb-in-war/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual

--- a/ejb-multi-server/README.md
+++ b/ejb-multi-server/README.md
@@ -5,6 +5,7 @@ Level: Advanced
 Technologies: EJB, EAR
 Summary: EJB applications deployed to different servers that communicate via EJB remote calls
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 
@@ -31,9 +32,9 @@ The server configuration is done using CLI batch scripts located in the root of 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later.
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven
@@ -42,11 +43,11 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#mavenconfiguration) before testing the quickstarts.
 
 
-Back Up the JBoss EAP 6.1 Server Configuration Files
+Back Up the JBoss EAP Server Configuration Files
 -----------------------------
 _NOTE - Before you begin:_
 
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss EAP server.
 2. Backup the following files, replacing JBOSS_HOME with the path to your server: 
 
         JBOSS_HOME/domain/configuration/domain.xml
@@ -55,16 +56,16 @@ _NOTE - Before you begin:_
 3. After you have completed testing and undeployed this quickstart, you can replace these files to restore the server to its original configuration.
 
 
-Start JBoss EAP 6.1 Server
+Start JBoss EAP Server
 ---------------------------
 
 
-1. Unzip or install a fresh JBoss EAP 6.1 instance.
+1. Unzip or install a fresh JBoss EAP instance.
 2. Open a command line and navigate to the root of the server directory. Start the server using the following command:
 
         bin/domain.sh    
 
-Configure the JBoss EAP 6.1 Server
+Configure the JBoss EAP Server
 ---------------------------
 
    Open a new command line, navigate to the root directory of this quickstart, and run the following command:
@@ -85,7 +86,7 @@ The following users must be added to the `ApplicationRealm` to run this quicksta
 | quickuser1 | ApplicationRealm | quick123+ | _leave blank for none_ |
 | quickuser2 | ApplicationRealm | quick+123 | _leave blank for none_ |
 
-If you are running JBoss Enterprise Application Platform 6.1, you can add the users using the following commands:
+Add the users using the following commands:
 
         bin/add-user.sh -a -u quickuser -p quick-123 --silent
         bin/add-user.sh -a -u quickuser1 -p quick123+ --silent
@@ -118,8 +119,8 @@ _NOTE: If ERRORs appear in the server.log when the installing or deploying the q
 Access the Remote Client Application
 ---------------------
 
-This example will show how the EJB can be invoked from a remote standalone application.
-Also the client show how to invoke an EJB by using the scoped-context introduced with EAP6.1 to invoke the EJB without properties file by pass all necessary parameter to the InitialContext.
+This example shows how to invoke an EJB from a remote standalone application. 
+It also demonstrates how to invoke an EJB from a client using a scoped-context rather than a properties file containing the parameters required by the InitialContext. 
 
 1. Make sure that the deployments are successful as described above.
 2. Navigate to the quickstart `client/` subdirectory.
@@ -163,7 +164,7 @@ Also the client show how to invoke an EJB by using the scoped-context introduced
 _NOTE:_
  
 * _If exec is called multiple times, the invocation for `app1` might use `app-oneA` and `app-oneB` node due to cluster loadbalancing._
-* _A new feature in JBoss Enterprise Platform 6.1 will deny the invocation of unsecured methods of `appOne`/`appTwo` since security is enabled but the method does not include @Roles. You need to set 'default-missing-method-permissions-deny-access = false' for the `ejb3` subsystem within the domain profile "ha" and "default" to allow the method invocation. See the install-domain.cli script._
+* _A new feature introduced in JBoss EAP 6.1 or later will deny the invocation of unsecured methods of `appOne`/`appTwo` since security is enabled but the method does not include @Roles. You need to set 'default-missing-method-permissions-deny-access = false' for the `ejb3` subsystem within the domain profile "ha" and "default" to allow the method invocation. See the install-domain.cli script._
 
 
 Access the JSF application inside the main-application
@@ -179,8 +180,6 @@ The JSF example shows different annotations to inject the EJB. Also how to handl
 _NOTE :_
 
 * _If you try to invoke `MainEjbClient34App` you need to update the user `quickuser1` and `quickuser2` and give them one of the Roles `AppTwo` or `Intern`._
-* _Remember that the scoped-client will be implemented at first with EAP6.1 and will not work before._
-
 
 Access the Servlet application deployed as a WAR inside a minimal server
 ---------------------
@@ -191,7 +190,7 @@ An example how to access EJB's from a separate instance which only contains a we
 2. Use a browser to access the Servlet at the following URL: <http://localhost:8380/appweb/>
 3. The Servlet will invoke the remote EJBs directly and show the results, compare that the invocation is successful
 
-_NOTE : If a version from JBoss EAP6.1 is used, a new feature will deny the invocation of unsecured methods of `appOne`/`appTwo` since security is enabled but the method does not include @Roles. You need to set 'default-missing-method-permissions-deny-access = false' for the `ejb3` subsystem within the domain profile "ha" and "default" to allow the method invocation._
+_NOTE : A new feature in EAP 6.1 or later will deny the invocation of unsecured methods of `appOne`/`appTwo` since security is enabled but the method does not include @Roles. You need to set 'default-missing-method-permissions-deny-access = false' for the `ejb3` subsystem within the domain profile "ha" and "default" to allow the method invocation.  See the install-domain.cli script._
 
 
 Undeploy the Archives
@@ -210,14 +209,14 @@ Remove the Server Domain Configuration
 You can remove the domain configuration by manually restoring the back-up copies the configuration files or by running the JBoss CLI Script. 
 
 ### Remove the Server Domain Configuration Manually           
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss EAP server.
 2. Restore the `JBOSS_HOME/domain/configuration/domain.xml` and `JBOSS_HOME/domain/configuration/host.xml` files with the back-up copies of the files. Be sure to replace JBOSS_HOME with the path to your server.
 
 ### Remove the Security Domain Configuration by Running the JBoss CLI Script
 
 _Note: This script returns the server to a default configuration and the result may not match the server configuration prior to testing this quickstart. If you were not running with the default configuration before testing this quickstart, you should follow the intructions above to manually restore the configuration to its previous state._
 
-1. Start the JBoss EAP 6.1erver by typing the following: 
+1. Start the JBoss EAP server by typing the following: 
 
         For Linux:   JBOSS_HOME/bin/domain.sh
         For Windows: JBOSS_HOME\bin\domain.bat

--- a/ejb-remote/README.md
+++ b/ejb-remote/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: EJB
 Summary: Shows how to access an EJB from a remote Java client program using JNDI
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example shows how to access an EJB from a remote Java client application. It demonstrates the use of *EJB 3.1* and *JNDI* in *Red Hat JBoss Enterprise Application Platform 6.1* or later.
+This example shows how to access an EJB from a remote Java client application. It demonstrates the use of *EJB 3.1* and *JNDI* in Red Hat JBoss Enterprise Application Platform.
 
 There are two components to this example: 
 
@@ -27,9 +28,9 @@ Each component is defined in its own standalone Maven module. The quickstart pro
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -38,7 +39,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/ejb-security-interceptors/README.md
+++ b/ejb-security-interceptors/README.md
@@ -5,6 +5,7 @@ Level: Advanced
 Technologies: EJB, Security
 Summary: Demonstrates how interceptors can be used to switch the identity for EJB calls on a call by call basis.
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -47,7 +48,7 @@ In the real world, remote calls between servers in the servers-to-server scenari
 Note on EJB client interceptors
 -----------------------
 
-JBoss EAP 6.1 allows client side interceptors for EJB invocations. Such interceptors are expected to implement the `org.jboss.ejb.client.EJBClientInterceptor` interface. User applications can then plug in such interceptors in the 'EJBClientContext' either programatically or through the ServiceLoader mechanism.
+JBoss EAP allows client side interceptors for EJB invocations. Such interceptors are expected to implement the `org.jboss.ejb.client.EJBClientInterceptor` interface. User applications can then plug in such interceptors in the 'EJBClientContext' either programatically or through the ServiceLoader mechanism.
 
 - The programmatic way involves calling the `org.jboss.ejb.client.EJBClientContext.registerInterceptor(int order, EJBClientInterceptor interceptor)` API and passing the 'order' and the 'interceptor' instance. The 'order' is used to decide where exactly in the client interceptor chain, this 'interceptor' is going to be placed.
 - The ServiceLoader mechanism is an alternate approach which involves creating a `META-INF/services/org.jboss.ejb.client.EJBClientInterceptor` file and placing/packaging it in the classpath of the client application. The rules for such a file are dictated by the [Java ServiceLoader Mechanism](http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html). This file is expected to contain in each separate line the fully qualified class name of the EJB client interceptor implementation, which is expected to be available in the classpath. EJB client interceptors added via the ServiceLoader mechanism are added to the end of the client interceptor chain, in the order they were found in the classpath.
@@ -64,9 +65,9 @@ This quickstart uses the ServiceLoader mechanism for registering the EJB client 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 Configure Maven
 ---------------
@@ -76,13 +77,11 @@ If you have not yet done so, you must [Configure Maven](../README.md#configure-m
 Prerequisites
 -------------
 
-_Note_: This quickstart requires Red Hat JBoss Enterprise Application Platform 6.1  or later.
-
 This quickstart uses the default standalone configuration plus the modifications described here.
 
 It is recommended that you test this approach in a separate and clean environment before you attempt to port the changes in your own environment.
 
-Configure the JBoss EAP 6.1 server
+Configure the JBoss server
 ---------------------------
 
 These steps asume that you are running the server in standalone mode and using the default standalone.xml supplied with the distribution.
@@ -93,13 +92,13 @@ After the server is configured you will then need to define four user accounts, 
 
 _NOTE - Before you begin:_
 
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Backup the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
 3. After you have completed testing this quickstart, you can replace this file to restore the server to its original configuration.
 
 #### Configure the Security Domain by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME/bin/standalone.sh 
         For Windows:  JBOSS_HOME\bin\standalone.bat
@@ -124,7 +123,7 @@ This script adds the `quickstart-domain` domain to the `security` subsystem in t
 
 ### Configure the Security Domain Using the JBoss CLI Interactively
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
 		For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh
 		For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat
@@ -162,7 +161,7 @@ Finally the server is reloaded to pick up these changes.
 
 ### Configure the Security Domain by Manually Editing the Server Configuration File
 
-1.  If it is running, stop the JBoss EAP 6.1 server.
+1.  If it is running, stop the JBoss server.
 2.  Backup the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
 3. Open the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
 4. Make the additions described below.
@@ -247,7 +246,7 @@ Within the Remoting susbsytem add the following outbound connection:
 Add the Application Users
 ---------------
 
-This quickstart is built around the default `ApplicationRealm` as configured in the JBoss Enterprise Application  Platform 6.1 server distribution. Using the add-user utility script, you must add the following users to the `ApplicationRealm`:
+This quickstart is built around the default `ApplicationRealm` as configured in the JBoss EAP server distribution. Using the add-user utility script, you must add the following users to the `ApplicationRealm`:
 
 | **UserName** | **Realm** | **Password** | **Roles** |
 |:-----------|:-----------|:-----------|:-----------|
@@ -283,7 +282,7 @@ Alternatively you can edit the properties file for the users and manually add th
 The application server checks the properties files for modifications at runtime so there is no need to restart the server after changing these files.
 
 
-Start JBoss EAP 6.1 
+Start the JBoss Server 
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.
@@ -496,7 +495,7 @@ You can remove the security domain configuration by running the  `remove-securit
 
 ### Remove the Security Domain Configuration by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat
@@ -514,7 +513,7 @@ This script removes the `test` queue from the `messaging` subsystem in the serve
 
 
 ### Remove the Security Domain Configuration Manually
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Replace the `JBOSS_HOME/standalone/configuration/standalone.xml` file with the back-up copy of the file.
 
 

--- a/ejb-security-plus/README.md
+++ b/ejb-security-plus/README.md
@@ -5,6 +5,7 @@ Level: Advanced
 Technologies: EJB, Security
 Summary: Demonstrates how interceptors can be used to supply additional information to be used for authentication before EJB calls.
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -38,7 +39,7 @@ Finally there is the `RemoteClient` stand-alone client. The client demonstrates 
 Note on EJB client interceptors
 -----------------------
 
-Red Hat JBoss Enterprise Application Platform 6.1 allows client side interceptors for EJB invocations. Such interceptors are expected to implement the `org.jboss.ejb.client.EJBClientInterceptor` interface. User applications can then plug in such interceptors in the 'EJBClientContext' either programatically or through the ServiceLoader mechanism.
+Red Hat JBoss Enterprise Application Platform allows client side interceptors for EJB invocations. Such interceptors are expected to implement the `org.jboss.ejb.client.EJBClientInterceptor` interface. User applications can then plug in such interceptors in the 'EJBClientContext' either programatically or through the ServiceLoader mechanism.
 
 - The programmatic way involves calling the `org.jboss.ejb.client.EJBClientContext.registerInterceptor(int order, EJBClientInterceptor interceptor)` API and passing the 'order' and the 'interceptor' instance. The 'order' is used to decide where exactly in the client interceptor chain, this 'interceptor' is going to be placed.
 - The ServiceLoader mechanism is an alternate approach which involves creating a `META-INF/services/org.jboss.ejb.client.EJBClientInterceptor` file and placing/packaging it in the classpath of the client application. The rules for such a file are dictated by the [Java ServiceLoader Mechanism](http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html). This file is expected to contain in each separate line the fully qualified class name of the EJB client interceptor implementation, which is expected to be available in the classpath. EJB client interceptors added via the ServiceLoader mechanism are added to the end of the client interceptor chain, in the order they were found in the classpath.
@@ -55,9 +56,9 @@ This quickstart uses the ServiceLoader mechanism for registering the EJB client 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1. 
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 Configure Maven
 ---------------
@@ -67,14 +68,12 @@ If you have not yet done so, you must [Configure Maven](../README.md#configure-m
 Prerequisites
 -------------
 
-_Note_: Unlike most of the quickstarts, this one requires JBoss EAP 6.1 or later.
-
 This quickstart uses the default standalone configuration plus the modifications described here.
 
 It is recommended that you test this approach in a separate and clean environment before you attempt to port the changes in your own environment.
 
 
-Configure the JBoss EAP 6.1 server
+Configure the JBoss server
 ---------------------------
 
 These steps asume that you are running the server in standalone mode and using the default standalone.xml supplied with the distribution.
@@ -85,13 +84,13 @@ After the server is configured you will then need to define four user accounts, 
 
 _NOTE - Before you begin:_
 
-1. If it is running, stop the JBoss EAP 6.1 Server.
+1. If it is running, stop the JBoss server.
 2. Backup the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
 3. After you have completed testing this quickstart, you can replace this file to restore the server to its original configuration.
 
 #### Configure the Security Domain by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 Server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME/bin/standalone.sh 
         For Windows:  JBOSS_HOME\bin\standalone.bat
@@ -110,7 +109,7 @@ This script adds the `quickstart-domain` domain to the `security` subsystem in t
 
 ### Configure the Security Domain Using the JBoss CLI Interactively
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
 		For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh
 		For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat
@@ -131,7 +130,7 @@ Finally, restart the server to pick up these changes.
 
 ### Configure the Security Domain by Manually Editing the Server Configuration File
 
-1.  If it is running, stop the JBoss EAP 6.1 Server.
+1.  If it is running, stop the JBoss server.
 2.  Backup the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
 3.  Open the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
 4.  Make the additions described below.
@@ -166,7 +165,7 @@ This means that for quickstartUser to be able to call the EJB the specified auth
 Add the Application Users
 ---------------
 
-This quickstart is built around the default `ApplicationRealm` as configured in the JBoss EAP 6.1 server distribution. Using the add-user utility script, you must add the following user to the `ApplicationRealm`:
+This quickstart is built around the default `ApplicationRealm` as configured in the JBoss server distribution. Using the add-user utility script, you must add the following user to the `ApplicationRealm`:
 
 | **UserName** | **Realm** | **Password** | **Roles** |
 |:-----------|:-----------|:-----------|:-----------|
@@ -191,7 +190,7 @@ Alternatively you can edit the properties file for the users and manually add th
 The application server checks the properties files for modifications at runtime so there is no need to restart the server after changing these files.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.
@@ -264,7 +263,7 @@ You can remove the security domain configuration by running the  `remove-securit
 
 ### Remove the Security Domain Configuration by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 Server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat
@@ -279,7 +278,7 @@ This script removes the `test` queue from the `messaging` subsystem in the serve
 
 
 ### Remove the Security Domain Configuration Manually
-1. If it is running, stop the JBoss EAP 6.1 Server.
+1. If it is running, stop the JBoss server.
 2. Replace the `JBOSS_HOME/standalone/configuration/standalone.xml` file with the back-up copy of the file.
 
 

--- a/ejb-security-propagation/README.md
+++ b/ejb-security-propagation/README.md
@@ -5,6 +5,7 @@ Level: Advanced
 Technologies: EJB, Servlets, Security
 Summary: Security context propagation between JBoss server instances, when using EJB calls. 
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -28,24 +29,19 @@ The root `pom.xml` builds each of the subprojects in an appropriate order.
 
 This quickstart runs in a managed domain and uses the `domain.xml` and `host.xml`. 
 
-_Note: JBoss EAP 6.1 or later is necessary to work with this quickstart._
 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
+The application this project produces is designed to be run on JBoss Enterprise Application Platform 6.1 or later.
 
-The application this project produces is designed to be run on JBoss Enterprise Application Platform 6.1.
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
  
 Configure Maven
 ---------------
 
 If you have not yet done so, you must [Configure Maven](../README.md#mavenconfiguration) before testing the quickstarts.
 
-Prerequisites
--------------
-
-_Note_: Unlike most of the quickstarts, this one requires JBoss Enterprise Application Platform 6.1.
 
 Add an Application User
 ----------------
@@ -76,14 +72,14 @@ Configure H2 database server
         For Windows:  %JAVA_HOME%\bin\java -classpath JBOSS_HOME\modules\system\layers\base\com\h2database\h2\main\h2-1.3.168-redhat-2.jar org.h2.tools.RunScript -url jdbc:h2:tcp://localhost/qs_ejb -user sa -script ejb\src\main\resources\import.sql
 
 
-Configure the JBoss Enterprise Application Platform 6.1 server
+Configure the JBoss EAP server
 -------------------------
 
 You can configure the server by running the  `configure-server.cli` script provided in the root directory of this quickstart, by using the JBoss CLI interactively, or by manually editing the configuration file.
 
 _NOTE - Before you begin:_
 
-1. If it is running, stop the JBoss Enterprise Application Platform 6.1 server.
+1. If it is running, stop the JBoss EAP server.
 2. Backup the following files, replacing JBOSS_HOME with the path to your server.: 
 
         JBOSS_HOME/domain/configuration/domain.xml
@@ -94,7 +90,7 @@ _NOTE - Before you begin:_
 
 #### Configure the Server by Running the JBoss CLI Script
 
-1. Start the JBoss Enterprise Application Platform 6.1 Server by typing the following command, replacing JBOSS_HOME with the path to your server. 
+1. Start the JBoss EAP server by typing the following command, replacing JBOSS_HOME with the path to your server. 
 
         For Linux:  JBOSS_HOME/bin/domain.sh 
         For Windows:  JBOSS_HOME\bin\domain.bat
@@ -114,12 +110,12 @@ _NOTE - Before you begin:_
 
 #### Configure the Server by Running the JBoss CLI Interactively
 
-1. If it is running, stop the JBoss Enterprise Application Platform 6.1 server.
+1. If it is running, stop the JBoss EAP server.
 2. Backup the following files, replacing JBOSS_HOME with the path to your server: 
 
         JBOSS_HOME/domain/configuration/domain.xml
         JBOSS_HOME/domain/configuration/host.xml
-3. Start the JBoss Enterprise Application Platform 6 Server by typing the following: 
+3. Start the JBoss EAP server by typing the following: 
 
         For Linux:  JBOSS_HOME/bin/domain.sh 
         For Windows:  JBOSS_HOME\bin\domain.bat
@@ -180,7 +176,7 @@ _NOTE - Before you begin:_
 
 #### Configure the Server by Manually Editing the Server Configuration File
 
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Backup the following files, replacing JBOSS_HOME with the path to your server: 
 
         JBOSS_HOME/domain/configuration/domain.xml
@@ -190,7 +186,7 @@ _NOTE - Before you begin:_
 
 #####  Manually Configure the Server Groups
 
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Open the `host.xml` file and find the 'servers' section. For the `server-two`, associate the server-group to "other-server-group". Save it. The result should be:
 
         <server name="server-one" group="main-server-group">
@@ -325,7 +321,7 @@ _NOTE: The following build command assumes you have configured your Maven user s
 
 4. If JBoss is running, restart it, so the module can be loaded.
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.
@@ -412,13 +408,13 @@ Remove the Security Domain Configuration
 You can remove the security domain configuration by manually restoring the back-up copy the configuration file. 
 
 ### Remove the Security Domain Configuration Manually           
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Restore the `JBOSS_HOME/domain/configuration/domain.xml` and `JBOSS_HOME/domain/configuration/host.xml` files with the back-up copies of the files. Be sure to replace JBOSS_HOME with the path to your server.
 
 
 ### Remove the Security Domain Configuration by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 Server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:   JBOSS_HOME/bin/domain.sh
         For Windows: JBOSS_HOME\bin\domain.bat
@@ -435,7 +431,7 @@ This script removes the server configuration that was done by the `configure-ser
         #6 /profile=full/subsystem=security/security-domain=security-propagation-quickstart:remove
         #7 /profile=full-ha/subsystem=security/security-domain=security-propagation-quickstart:remove
         The batch executed successfully.
-3. Restart the JBoss EAP 6.1 server, as described above, for the changes to take effect.
+3. Restart the JBoss server, as described above, for the changes to take effect.
 
 Run the Quickstart in JBoss Developer Studio or Eclipse
 -------------------------------------

--- a/ejb-security/README.md
+++ b/ejb-security/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: EJB, Security
 Summary: Shows how to use Java EE Declarative Security to Control Access to EJB 3
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the use of Java EE declarative security to control access to Servlets and EJBs in *Red Hat JBoss Enterprise Application Platform 6.1*.
+This example demonstrates the use of Java EE declarative security to control access to Servlets and EJBs in Red Hat JBoss Enterprise Application Platform.
 
 This quickstart takes the following steps to implement EJB security:
 
@@ -38,9 +39,9 @@ This quickstart takes the following steps to implement EJB security:
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven
@@ -61,7 +62,7 @@ After you add the default `quickstartUser`, use the same steps to add a second a
         Roles:    app-user
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/ejb-throws-exception/README.md
+++ b/ejb-throws-exception/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: EJB, EAR
 Summary: Shows how to handle Exceptions across JARs in an EAR
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -36,9 +37,9 @@ The example follows the common "Hello World" pattern. These are the steps that o
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven 
@@ -47,7 +48,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/ejb-throws-exception/pom.xml
+++ b/ejb-throws-exception/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>
@@ -149,3 +148,4 @@
     </build>
 
 </project>
+

--- a/ejb-timer/README.md
+++ b/ejb-timer/README.md
@@ -5,6 +5,7 @@ Level: Beginner
 Technologies: EJB 3.1 Timer
 Summary: Demonstrates how to use EJB 3.1 Timer (@Schedule and @Timeout) with the JBoss AS server.
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -22,9 +23,9 @@ Features used:
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -33,7 +34,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#mavenconfiguration) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/forge-from-scratch/README.md
+++ b/forge-from-scratch/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: Forge
 Summary: Demonstrates how to generate a fully Java EE compliant project using nothing but JBoss Forge
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2, Forge 1.0.0.Final
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -21,7 +22,7 @@ System requirements
 
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later.
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, and an JBoss Developer Studio 5 or JBoss Forge version 1.0.0.Final (or higher).
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, and a JBoss Developer Studio 5 or JBoss Forge version 1.0.0.Final (or later).
 
 
 ### JBoss Developer Studio 5
@@ -30,9 +31,9 @@ Forge is available in JBoss Developer Studio 5.
 
 To show the Forge Console, navigate to _Window -> Show View -> Other_, locate _Forge Console_ and click _OK_. Then click the _Start_ button in top right corner of the view.
 
-### JBoss Enterprise Application Platform 6.1
+### JBoss Enterprise Application Platform
 
-If you do not plan to use JBoss Developer Studio, you should install JBoss Forge version 1.0.0.Final or higher. Follow the instructions at [Installing Forge](https://docs.jboss.org/author/display/FORGE/Installation).
+If you do not plan to use JBoss Developer Studio, you should install JBoss Forge version 1.0.0.Final or later. Follow the instructions at [Installing Forge](https://docs.jboss.org/author/display/FORGE/Installation).
 
 Open a command line and navigate to the root directory of this quickstart. 
 
@@ -72,10 +73,8 @@ Configure Maven
 
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts. 
 
-_NOTE: If you are using JBoss EAP 6.1, you can not append the path to the Maven settings on the Forge command line. You must configure the Maven user settings as noted in step 4 of the instructions._
 
-
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/greeter/README.md
+++ b/greeter/README.md
@@ -5,12 +5,13 @@ Level: Beginner
 Technologies: CDI, JSF, JPA, EJB, JTA
 Summary: Demonstrates the use of CDI 1.0, JPA 2.0, JTA 1.1, EJB 3.1 and JSF 2.0
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the use of *CDI 1.0*, *JPA 2.0*, *JTA 1.1*, *EJB 3.1* and *JSF 2.0* in *Red Hat JBoss Enterprise Application Platform 6.1* or later.
+This example demonstrates the use of *CDI 1.0*, *JPA 2.0*, *JTA 1.1*, *EJB 3.1* and *JSF 2.0* in Red Hat JBoss Enterprise Application Platform.
 
 When you deploy this example, two users are automatically created for you:  `emuster` and `jdoe`. This data is located in the `src/main/resources/import.sql file`.
 
@@ -23,15 +24,14 @@ To test this example:
 5. Click on the `Greet a user!` link to return to the `Greet!` page.
 
 
-
 There is a tutorial for this quickstart in the [Getting Started Developing Applications Guide](http://www.jboss.org/jdf/stage/quickstarts/jboss-as-quickstart/guide/GreeterQuickstart/).
 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later.
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1.
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -40,7 +40,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/h2-console/README.md
+++ b/h2-console/README.md
@@ -5,6 +5,7 @@ Level: Beginner
 Technologies: H2
 Summary: Shows how to use the H2 console with JBoss AS
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -12,15 +13,15 @@ What is it?
 
 JBoss AS bundles H2 as an in-memory, in-process database. H2 is written in Java so can run on any platform JBoss AS runs.
 
-This is quickstart shows you how to use the H2 console with JBoss Enterprise Platform 6.1 or later. It uses the `greeter` quickstart as a GUI for entering data.
+This is quickstart shows you how to use the H2 console with Red Hat JBoss Enterprise Application Platform. It uses the `greeter` quickstart as a GUI for entering data.
 
 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
  
 
 Configure Maven
@@ -40,7 +41,7 @@ You can verify the deployment of the `greeter` quickstart by accessing the follo
 Deploy the H2 Console
 ------------------------
 
-This quickstart comes bundled with a version of the H2 Console built for JBoss EAP 6.1. The changes that have been made to the stock console are described below. 
+This quickstart comes bundled with a version of the H2 Console built for JBoss EAP. The changes that have been made to the stock console are described below. 
 
 Deploy the console by copying the `QUICKSTART_HOME/h2-console/h2console.war` to the `$JBOSS_HOME/standalone/deployments` directory. 
 
@@ -68,8 +69,8 @@ Take a look at the data added by the `greeter` application. Run the following SQ
 You should see the two users seeded by the `greeter` quickstart, plus any users you added when testing that application.
 
 
-Changes to the H2 Console for JBoss EAP 6.1
+Changes to the H2 Console for JBoss EAP
 ----------------------------------------
 
-To make the H2 console run on JBoss EAP 6.1, the H2 libraries were removed from the WAR and a dependency on the H2 module was added to the META-INF/MANIFEST.MF fle. The rebuilt console is provided with this quickstart.
+To make the H2 console run on JBoss EAP, the H2 libraries were removed from the WAR and a dependency on the H2 module was added to the META-INF/MANIFEST.MF fle. The rebuilt console is provided with this quickstart.
 

--- a/helloworld-jms/README.md
+++ b/helloworld-jms/README.md
@@ -5,26 +5,27 @@ Level: Intermediate
 Technologies: JMS
 Summary: Demonstrates the use of a standalone (Java SE) JMS client
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This quickstart demonstrates the use of external JMS clients with Red Hat JBoss Enterprise Application Platform 6.1 or later.
+This quickstart demonstrates the use of external JMS clients with Red Hat JBoss Enterprise Application Platform.
 
 It contains the following:
 
-1. A message producer that sends messages to a JMS destination deployed to a JBoss EAP 6.1 server.
+1. A message producer that sends messages to a JMS destination deployed to a JBoss server.
 
-2. A message consumer that receives message from a JMS destination deployed to a JBoss EAP 6.1 server. 
+2. A message consumer that receives message from a JMS destination deployed to a JBoss server. 
 
 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven
@@ -45,13 +46,13 @@ You must first add the JMS `test` queue to the application server configuration 
 
 _NOTE - Before you begin:_
 
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Backup the file: `JBOSS_HOME/standalone/configuration/standalone-full.xml`
 3. After you have completed testing this quickstart, you can replace this file to restore the server to its original configuration.
 
 #### Configure JMS by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml
@@ -67,7 +68,7 @@ This script adds the `test` queue to the `messaging` subsystem in the server con
 
 #### Configure JMS Using the JBoss CLI Tool Interactively
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml
@@ -81,7 +82,7 @@ This script adds the `test` queue to the `messaging` subsystem in the server con
 
 #### Configure JMS by Manually Editing the Server Configuration File
 
-1.  If it is running, stop the JBoss EAP 6.1 server.
+1.  If it is running, stop the JBoss server.
 2.  Backup the file: `JBOSS_HOME/standalone/configuration/standalone-full.xml`
 3.  Open the file: JBOSS_HOME/standalone/configuration/standalone-full.xml
 4.  Add the JMS `test` queue as follows:
@@ -99,7 +100,7 @@ This script adds the `test` queue to the `messaging` subsystem in the server con
     * Save the changes and close the file.
 
 
-Start JBoss EAP 6.1 with the Full Profile
+Start the JBoss Server with the Full Profile
 ---------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.
@@ -214,7 +215,7 @@ You can remove the JMS configuration by running the  `remove-jms.cli` script pro
 
 ### Remove the JMS Configuration by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml
@@ -229,7 +230,7 @@ This script removes the `test` queue from the `messaging` subsystem in the serve
 
 
 ### Remove the JMS Configuration Manually
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Replace the `JBOSS_HOME/standalone/configuration/standalone-full.xml` file with the back-up copy of the file.
 
 

--- a/helloworld-mbean/README.md
+++ b/helloworld-mbean/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: CDI, JMX and MBean
 Summary: Demonstrates the use of CDI 1.0 and MBean
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the use of *CDI 1.0* and *MBean* in  *Red Hat JBoss Enterprise Application Platform 6.1* or later. The project also includes a set of Aquillian tests for mbeans.
+This example demonstrates the use of *CDI 1.0* and *MBean* in  Red Hat JBoss Enterprise Application Platform. The project also includes a set of Aquillian tests for mbeans.
 
 The example is composed of mbeans. They are as follows :
 
@@ -25,9 +26,9 @@ The example is composed of mbeans. They are as follows :
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -36,7 +37,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#mavenconfiguration) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/helloworld-mbean/pom.xml
+++ b/helloworld-mbean/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.quickstarts.eap</groupId>
     <artifactId>jboss-helloworld-mbean</artifactId>

--- a/helloworld-mdb/README.md
+++ b/helloworld-mdb/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: JMS, EJB, MDB
 Summary: Demonstrates the use of JMS 1.1 and EJB 3.1 Message-Driven Bean
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the use of *JMS 1.1* and *EJB 3.1 Message-Driven Bean* in Red Hat JBoss Enterprise Application Platform 6.1 or later..
+This example demonstrates the use of *JMS 1.1* and *EJB 3.1 Message-Driven Bean* in Red Hat JBoss Enterprise Application Platform.
 
 This project creates two JMS resources:
 
@@ -21,9 +22,9 @@ This project creates two JMS resources:
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -32,7 +33,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1 with the Full Profile
+Start the JBoss Server with the Full Profile
 ---------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.
@@ -114,7 +115,7 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 ### Create the OpenShift Application
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss Enterprise Application Platform 6.1:
+Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss Enterprise Application Platform:
 
     rhc app create -a hellworldmdb -t APPLICATION_TYPE
 

--- a/helloworld-osgi/README.md
+++ b/helloworld-osgi/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: OSGi
 Summary: Shows how to create and deploy a simple OSGi Bundle
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the use of *OSGi* in  *Red Hat JBoss Enterprise Application Platform 6.1* or later.
+This example demonstrates the use of *OSGi* in Red Hat JBoss Enterprise Application Platform.
 
 There is a tutorial for this quickstart in the [Getting Started Developing Applications Guide](http://www.jboss.org/jdf/quickstarts/jboss-as-quickstart/guide/HelloworldOSGiQuickstart/).
 
@@ -18,9 +19,9 @@ There is a tutorial for this quickstart in the [Getting Started Developing Appli
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -29,13 +30,11 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1 with the OSGi Profile
+Start the JBoss Server with the OSGi Profile
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.
 2. The following shows the command line to start the server with the OSGi profile:
-
-        For JBoss Enterprise Application Platform 6.1: 
         
             For Linux:   JBOSS_HOME/bin/standalone.sh  -c standalone-osgi.xml
             For Windows: JBOSS_HOME\bin\standalone.bat -c standalone-osgi.xml

--- a/helloworld-osgi/pom.xml
+++ b/helloworld-osgi/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0    http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0    http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>
@@ -103,7 +102,7 @@
                         <Import-Package>*</Import-Package>
 
                         <!-- This bundle does not export any packages -->
-                        <Export-Package />
+                        <Export-Package/>
 
                         <!-- Packages that are not exported but need to be 
                             included need to be listed as Private-Package -->

--- a/helloworld-rs/README.md
+++ b/helloworld-rs/README.md
@@ -5,20 +5,21 @@ Level: Intermediate
 Technologies: CDI, JAX-RS
 Summary: Demonstrates the use of CDI 1.0 and JAX-RS
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the use of *CDI 1.0* and *JAX-RS* in *Red Hat JBoss Enterprise Application Platform 6.1* or later.
+This example demonstrates the use of *CDI 1.0* and *JAX-RS* in Red Hat JBoss Enterprise Application Platform.
 
 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later.
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1.
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -27,7 +28,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.
@@ -94,7 +95,7 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 ### Create the OpenShift Application
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss EAP 6.1:
+Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss EAP:
 
     rhc app create -a helloworldrs -t APPLICATION_TYPE
 

--- a/helloworld-singleton/README.md
+++ b/helloworld-singleton/README.md
@@ -5,19 +5,20 @@ Level: Beginner
 Technologies: EJB, Singleton
 Summary: Demonstrates the use of an EJB 3.1 Singleton Session Bean, instantiated once, maintaining state for the life of the session
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This quickstart demonstrates the use of an *EJB 3.1 Singleton Bean* in *Red Hat JBoss Enterprise Application Platform 6.1*.
+This quickstart demonstrates the use of an *EJB 3.1 Singleton Bean* in Red Hat JBoss Enterprise Application Platform.
 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1.
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -26,7 +27,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/helloworld-ws/README.md
+++ b/helloworld-ws/README.md
@@ -5,19 +5,20 @@ Level: Beginner
 Technologies: JAX-WS
 Summary: Deployment of a basic JAX-WS Web service bundled in a WAR archive
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the use of *JAX-WS* in *Red Hat JBoss Enterprise Application Platform 6.1* or later as a simple Hello World application.
+This example demonstrates the use of *JAX-WS* in Red Hat JBoss Enterprise Application Platform as a simple Hello World application.
 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later.
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -26,7 +27,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 ----------------------         
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/helloworld-ws/pom.xml
+++ b/helloworld-ws/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>
@@ -284,4 +283,3 @@
     </profiles>
 
 </project>
-

--- a/helloworld/README.md
+++ b/helloworld/README.md
@@ -5,22 +5,22 @@ Level: Beginner
 Technologies: CDI, Servlet
 Summary: Basic example that can be used to verify that the server is configured and running correctly
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the use of *CDI 1.0* and *Servlet 3* in *Red Hat JBoss Enterprise Application Platform 6.1* or later.
+This example demonstrates the use of *CDI 1.0* and *Servlet 3* in Red Hat JBoss Enterprise Application Platform.
 
 There is a tutorial for this quickstart in the [Getting Started Developing Applications Guide](http://www.jboss.org/jdf/quickstarts/jboss-as-quickstart/guide/HelloworldQuickstart).
 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
 
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
  
 Configure Maven
 ---------------
@@ -28,7 +28,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/hibernate3/README.md
+++ b/hibernate3/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: Hibernate 3
 Summary: Example that uses Hibernate 3 for database access. Compare the code in this quickstart to the _hibernate4_ quickstart to see the changes needed to upgrade to Hibernate 4.
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -27,9 +28,9 @@ This quickstart, like the `log4j` quickstart, demonstrates how to define a modul
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -38,7 +39,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/hibernate4/README.md
+++ b/hibernate4/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: Hibernate 4
 Summary: This quickstart performs the same functions as the _hibernate3_ quickstart, but uses Hibernate 4 for database access. Compare this quickstart to the _hibernate3_ quickstart to see the changes needed to run with Hibernate 4..
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This quickstart is based upon the kitchensink example, but demonstrates how to use Hibernate ORM 4 over JPA in Red Hat JBoss Enterprise Application Platform 6.1 or later.
+This quickstart is based upon the kitchensink example, but demonstrates how to use Hibernate ORM 4 over JPA in Red Hat JBoss Enterprise Application Platform.
 
 This project is setup to allow you to create a compliant Java EE 6 application using JSF 2.0, CDI 1.0, EJB 3.1, JPA 2.0 , Hibernate-Core and Hibernate Bean Validation.  It includes a persistence unit associated with Hibernate session and some sample persistence and transaction code to help you with database access in enterprise Java. 
 
@@ -20,9 +21,9 @@ You can compare this quickstart to the `hibernate3` quickstart to see the code d
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -34,9 +35,9 @@ If you have not yet done so, you must [Configure Maven](../README.md#configure-m
 Add the Correct Dependencies
 ---------------------------
 
-JBoss EAP 6.1 provides Hibernate 4 and JPA support. 
+JBoss EAP provides Hibernate 4 and JPA support. 
 
-If you use Hibernate 4 packaged within Red Hat JBoss EAP 6.1 or later, you will need to first import the JPA API.
+If you use Hibernate 4 packaged within Red Hat JBoss EAP, you will need to first import the JPA API.
 
 This quickstart demonstrates usage of Hibernate Session and Hibernate Validators.
 
@@ -59,7 +60,7 @@ For example:
 Please note that if you are working with Hibernate 3, the process is different. You will need to bundle the jars since JBoss EAP 6 does not ship with Hibernate 3. Refer to the `hibernate3` quickstart for details on how to bundle the JARs.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/hornetq-clustering/README.md
+++ b/hornetq-clustering/README.md
@@ -6,6 +6,7 @@ Technologies: JMS, MDB, HornetQ
 Summary: Demonstrates the use of HornetQ Clustering
 Prerequisites: helloworld-mdb
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 What is it?
 -----------
@@ -17,6 +18,7 @@ System requirements
 
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
 
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
  
 Configure Maven
 ---------------
@@ -35,7 +37,7 @@ Type this command to build the WAR archive:
 
 See the helloworld-mdb [README](../helloworld-mdb/README.md) for further information about this quickstart.
 
-Configure and Start the JBoss EAP 6.1 server
+Configure and Start the JBoss server
 ---------------
 
 You can choose to deploy and run this quickstart in a managed domain or on a standalone server. The sections below describe how to configure and start the server for both modes. 
@@ -58,7 +60,7 @@ After you have completed testing this quickstart, you can replace these files to
 
 You can configure the server by running the install-domain.cli script provided in the root directory of this quickstart, by using the JBoss CLI interactively, or by manually editing the configuration file.
 
-### Configure and Start JBoss EAP 6.1 in Domain Mode
+### Configure and Start the JBoss Server in Domain Mode
 
 #### Start the server in domain mode.
 1. Open a command line and navigate to the root of the JBoss server directory.
@@ -88,7 +90,7 @@ configures HornetQ Clustering for testing this quickstart. You will note it does
    You should see "outcome" => "success" for all of the commands.
 
 
-### Configure and Start JBoss EAP 6.1 in Standalone Mode
+### Configure and Start the JBoss Server in Standalone Mode
 
 If you choose to use standalone servers rather than domain mode, you will need two instances of the application server. Application
 server 2 must be started with a port offset parameter provided to the startup script as "-Djboss.socket.binding.port-offset=100". 
@@ -124,7 +126,7 @@ Since both application servers must be configured in the same way, you must conf
 
 After you have successfully configured the server, make a copy of this JBoss directory structure to use for the second server.
 
-#### Start the JBoss EAP 6.1 Standalone Servers
+#### Start the JBoss EAP Standalone Servers with the Full Profile
 
 If you are using Linux:
 

--- a/inter-app/README.md
+++ b/inter-app/README.md
@@ -5,12 +5,13 @@ Level: Advanced
 Technologies: EJB, CDI, JSF
 Summary: Shows how to communicate between two applications using EJB and CDI
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This quickstart shows you how to easily communicate between two modular deployments to Red Hat JBoss Enterprise Application Platform 6.1 or later. Two wars, with a shared API jar, are deployed to the app server. EJB is used to provide inter-application communication, with EJB beans alised to CDI beans, making the inter-application communication transparent to clients of the bean.
+This quickstart shows you how to easily communicate between two modular deployments to Red Hat JBoss Enterprise Application Platform. Two wars, with a shared API jar, are deployed to the app server. EJB is used to provide inter-application communication, with EJB beans alised to CDI beans, making the inter-application communication transparent to clients of the bean.
 
 CDI only provides intra-applicaion injection (i.e within a top level deployment, ear, war, jar etc). This improves performance of the application server, as to satisfy an injection point all possible candidates have to be scanned / analyzed. If inter-app injection was supported by CDI, performance would scale according to the number of deployments you have (the more deployments in the running system, the slower the deployment). Java EE injection uses unique JNDI names for the wiring, so each injection point is O(1). The approach shown here combines the two approaches such that you limit the name based wiring to one location in your code, and the main consumers of components can use CDI injection to reference these name wired components. For the name approach to work though, you still need to publish instances, and EJB singletons allow you to do that with just one extra annotation.
 
@@ -24,9 +25,9 @@ In all, the project has three modules:
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -34,7 +35,7 @@ Configure Maven
 
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/jax-rs-client/README.md
+++ b/jax-rs-client/README.md
@@ -6,13 +6,14 @@ Technologies: JAX-RS
 Summary: Demonstrates the use an external JAX-RS RestEasy client which interacts with a JAX-RS Web service that uses CDI 1.0 and JAX-RS
 Prerequisites: helloworld-rs
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
 This example demonstrates an external JAX-RS RestEasy client which interacts with a JAX-RS Web service that uses *CDI 1.0* and *JAX-RS* 
-in *Red Hat JBoss Enterprise Application Platform 6.1* or later.
+in Red Hat JBoss Enterprise Application Platform.
 
 This client "calls" the HelloWorld JAX-RS Web Service that was created in the `helloworld-rs` quickstart. See the **Prerequisite** section below for details on how to build and deploy the `helloworld-rs` quickstart.
 
@@ -20,9 +21,9 @@ This client "calls" the HelloWorld JAX-RS Web Service that was created in the `h
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven

--- a/jta-crash-rec/README.md
+++ b/jta-crash-rec/README.md
@@ -5,6 +5,7 @@ Level: Advanced
 Technologies: JTA, Crash Recovery
 Summary: Uses Java Transaction API and JBoss Transactions to demonstrate recovery of a crashed transaction
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -23,15 +24,15 @@ The relational database table in this example contains two columns that represen
 
 In this example, you halt the JBoss server in the middle of an XA transaction after the database modification has been committed, but before the JMS producer is committed. You can verify that the transaction was started, then restart the JBoss server to complete the transaction. You then verify that everything is in a consistent state.
 
-JBoss EAP 6.1 ships with H2, an in-memory database written in Java. In this example, we use H2 for the database. Although H2 XA support is not recommended for production systems, the example does illustrate the general steps you need to perform for any datasource vendor. This example provides its own H2 XA datasource configuration. It is defined in the `jta-crash-rec-ds.xml` file in the WEB-INF folder of the WAR archive. 
+JBoss EAP ships with H2, an in-memory database written in Java. In this example, we use H2 for the database. Although H2 XA support is not recommended for production systems, the example does illustrate the general steps you need to perform for any datasource vendor. This example provides its own H2 XA datasource configuration. It is defined in the `jta-crash-rec-ds.xml` file in the WEB-INF folder of the WAR archive. 
 
 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven
@@ -70,7 +71,7 @@ If you have run the `jts` or `jts-distributed-crash-recovery` quickstarts, make 
 Start the JBoss Server
 ---------------
 
-Start JBoss EAP 6.1 with the Full Profile
+Start the JBoss Server with the Full Profile
 
 1. Open a command line and navigate to the root of the JBoss server directory.
 2. The following shows the command line to start the server with the full profile:

--- a/jts-distributed-crash-rec/README.md
+++ b/jts-distributed-crash-rec/README.md
@@ -6,6 +6,7 @@ Technologies: JTS
 Summary: Demonstrates recovery of distributed crashed components
 Prerequisites: jts
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -32,9 +33,9 @@ As an overview, the sequence of events to expect:
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven

--- a/jts/README.md
+++ b/jts/README.md
@@ -6,6 +6,7 @@ Technologies: JTS
 Summary: Uses Java Transaction Service (JTS) to coordinate distributed transactions
 Prerequisites: cmt
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 
@@ -45,9 +46,9 @@ After users complete this quickstart, they are invited to run through the follow
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 Configure Maven
 ---------------
@@ -88,13 +89,13 @@ You can configure the server by running the  `configure-jts-transactions.cli` sc
 
 _NOTE - Before you begin:_
 
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Backup the file: `JBOSS_HOME/standalone/configuration/standalone-full.xml`
 3. After you have completed testing this quickstart, you can replace this file to restore the server to its original configuration.
 
 #### Modify the Server Configuration by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server with the full profile, passing a unique node ID by typing the following command. Be sure to replace `UNIQUE_NODE_ID` with a node identifier that is unique to both servers.
+1. Start the JBoss server with the full profile, passing a unique node ID by typing the following command. Be sure to replace `UNIQUE_NODE_ID` with a node identifier that is unique to both servers.
 
         For Linux:  JBOSS_HOME/bin/standalone.sh -c standalone-full.xml -Djboss.tx.node.id=UNIQUE_NODE_ID
         For Windows:  JBOSS_HOME\bin\standalone.bat -c standalone-full.xml  -Djboss.tx.node.id=UNIQUE_NODE_ID
@@ -113,7 +114,7 @@ This script configures the server to use jts transaction processing. You should 
 
 #### Modify the Server Configuration Using the JBoss CLI Tool Interactively
 
-1. Start the JBoss EAP 6.1 server with the full profile, passing a unique node ID by typing the following command. Be sure to replace `UNIQUE_NODE_ID` with a node identifier that is unique to both servers.
+1. Start the JBoss server with the full profile, passing a unique node ID by typing the following command. Be sure to replace `UNIQUE_NODE_ID` with a node identifier that is unique to both servers.
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml -Djboss.tx.node.id=UNIQUE_NODE_ID
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml -Djboss.tx.node.id=UNIQUE_NODE_ID
@@ -172,10 +173,10 @@ Make a copy of this JBoss directory structure to use for the second server.
     * [Add the PostgreSQL driver](../README.md#add-the-postgresql-driver-configuration-to-the-jboss-server) to the Application 1 server configuration file.
 
 
-Start the JBoss EAP 6.1 servers
+Start the JBoss servers
 -------------------------
 
-Start the the two JBoss EAP 6.1 or servers with the full profile, passing a unique node ID by typing the following command. You must pass a socket binding port offset on the command to start the second server. Be sure to replace `UNIQUE_NODE_ID` with a node identifier that is unique to both servers.
+Start the the two JBoss EAP servers with the full profile, passing a unique node ID by typing the following command. You must pass a socket binding port offset on the command to start the second server. Be sure to replace `UNIQUE_NODE_ID` with a node identifier that is unique to both servers.
 
 If you are using Linux:
 
@@ -241,7 +242,7 @@ You can modify the server configuration by running the `remove-jts-transactions.
 
 ### Remove the JTS Server Configuration by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server with the full profile.
+1. Start the JBoss server with the full profile.
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml
@@ -260,7 +261,7 @@ This script removes the `test` queue from the `messaging` subsystem in the serve
 
 ### Remove the JTS Server Configuration using the JBoss CLI Tool
 
-1. Start the JBoss EAP 6.1 server with the full profile.
+1. Start the JBoss server with the full profile.
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml

--- a/kitchensink-ear/README.md
+++ b/kitchensink-ear/README.md
@@ -5,21 +5,22 @@ Level: Intermediate
 Technologies: EAR
 Summary: Based on kitchensink, but deployed as an EAR
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This is your project! It is a sample, deployable Maven 3 project to help you get your foot in the door developing with Java EE 6 on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+This is your project! It is a sample, deployable Maven 3 project to help you get your foot in the door developing with Java EE 6 on Red Hat JBoss Enterprise Application Platform. 
 
 This project is setup to allow you to create a compliant Java EE 6 application using JSF 2.0, CDI 1.0, EJB 3.1, JPA 2.0 and Bean Validation 1.0. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java. 
 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -28,7 +29,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/kitchensink-ear/pom.xml
+++ b/kitchensink-ear/pom.xml
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <name>JBoss EAP Quickstart: kitchensink-ear</name>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/kitchensink-jsp/README.md
+++ b/kitchensink-jsp/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: JSP
 Summary: Based on kitchensink, but uses a JSP for the user interface
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This quickstart is a deployable Maven 3 project to help you get your foot in the door developing with Java EE 6 on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+This quickstart is a deployable Maven 3 project to help you get your foot in the door developing with Java EE 6 on Red Hat JBoss Enterprise Application Platform. 
 
 This project is setup to allow you to create a compliant Java EE 6 application using *JSP 2.0* *EL 2.0* *JSTL 1.2* *CDI 1.0*, *EJB 3.1*, *JPA 2.0* and Bean Validation 1.0. 
 
@@ -19,10 +20,9 @@ This project recreates the presentation tier of the `kitchensink` quickstart usi
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
 
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
  
 Configure Maven
 ---------------
@@ -30,7 +30,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/kitchensink-ml-ear/README.md
+++ b/kitchensink-ml-ear/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: EAR
 Summary: A localized version of kitchensink-ear
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This is your project! It is a sample, deployable Maven 3 project to help you get your foot in the door developing with Java EE 6 on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+This is your project! It is a sample, deployable Maven 3 project to help you get your foot in the door developing with Java EE 6 on Red Hat JBoss Enterprise Application Platform. 
 
 This project is setup to allow you to create a _localized_ Java EE 6 compliant application using JSF 2.0, CDI 1.0, EJB 3.1, JPA 2.0 and Bean Validation 1.0. A localized application is one that supports multiple languages. That is what the _-ml_ suffix denotes in the quickstart name `kitchensink-ml-ear`. This quickstart also includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java. 
 
@@ -94,10 +95,9 @@ How you set your browser preferred locale depends on the browser and version you
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
 
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
  
 Configure Maven
 ---------------
@@ -105,7 +105,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/kitchensink-ml-ear/pom.xml
+++ b/kitchensink-ml-ear/pom.xml
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <name>JBoss EAP Quickstart: kitchensink-ml-ear</name>
     <description>JBoss EAP Quickstart: Localized Kitchensink EAR</description>
     <modelVersion>4.0.0</modelVersion>

--- a/kitchensink-ml/README.md
+++ b/kitchensink-ml/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: CDI, JSF, JPA, EJB, JPA, JAX-RS, BV
 Summary: A localized version of kitchensink
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This is your project! It is a sample, deployable Maven 3 project to help you get your foot in the door developing with Java EE 6 on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+This is your project! It is a sample, deployable Maven 3 project to help you get your foot in the door developing with Java EE 6 on Red Hat JBoss Enterprise Application Platform. 
 
 This project is setup to allow you to create a _localized_ Java EE 6 compliant application using JSF 2.0, CDI 1.0, EJB 3.1, JPA 2.0 and Bean Validation 1.0. A localized application is one that supports multiple languages. That is what the _-ml_ suffix denotes in the quickstart name `kitchensink-ml`. This quickstart also includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java. 
 
@@ -95,9 +96,9 @@ How you set your browser preferred locale depends on the browser and version you
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -106,7 +107,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/kitchensink-ml/pom.xml
+++ b/kitchensink-ml/pom.xml
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/kitchensink/README.md
+++ b/kitchensink/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: CDI, JSF, JPA, EJB, JPA, JAX-RS, BV
 Summary: An example that incorporates multiple technologies
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This is your project! It is a sample, deployable Maven 3 project to help you get your foot in the door developing with Java EE 6 on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+This is your project! It is a sample, deployable Maven 3 project to help you get your foot in the door developing with Java EE 6 on Red Hat JBoss Enterprise Application Platform. 
 
 This project is setup to allow you to create a compliant Java EE 6 application using JSF 2.0, CDI 1.0, EJB 3.1, JPA 2.0 and Bean Validation 1.0. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java. 
 
@@ -19,9 +20,9 @@ There is a tutorial for this quickstart in the [Getting Started Developing Appli
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -30,7 +31,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/log4j/README.md
+++ b/log4j/README.md
@@ -5,6 +5,7 @@ Level: Beginner
 Technologies: JBoss Modules
 Summary: Demonstrates how to use modules to control class loading for 3rd party logging frameworks
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -21,9 +22,9 @@ This example is very simple. It declares dependency on the Apache Log4j module w
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -32,7 +33,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/logging-tools/README.md
+++ b/logging-tools/README.md
@@ -5,6 +5,7 @@ Level: Beginner
 Technologies: JBoss Logging Tools
 Summary: Demonstrates the use of JBoss Logging Tools to create internationalized loggers, exceptions, and generic messages
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -20,9 +21,9 @@ Instructions are included below for starting JBoss AS7/EAP6 with a different loc
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
 
-The application this project produces is designed to be run on *Red Hat JBoss Enterprise Application Platform 6.1*. 
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven
@@ -49,7 +50,7 @@ To start the JBoss server with a different locale than the system default:
    Refer to <http://java.sun.com/javase/technologies/core/basic/intl/faq.jsp#set-default-locale>
       
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/logging-tools/pom.xml
+++ b/logging-tools/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>
@@ -133,4 +132,3 @@
         </plugins>
     </build>
 </project>
-

--- a/logging/README.md
+++ b/logging/README.md
@@ -6,12 +6,13 @@ Technologies: Logging
 Summary: Demonstrates how to set various application logging levels
 Prerequisites: None
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates how to set up and log different levels of information in Red Hat JBoss Enterprise Application Platform 6.1 or later. An example of asynchronous logging is also included in the configuration examples.
+This example demonstrates how to set up and log different levels of information in Red Hat JBoss Enterprise Application Platform. An example of asynchronous logging is also included in the configuration examples.
 
 This quickstart contains just one class file and one JSP file. When you access the application, it fires off the logging information.
 
@@ -21,9 +22,9 @@ To better visualize how the logging configuration works, you first deploy and ac
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -34,7 +35,6 @@ If you have not yet done so, you must [Configure Maven](../README.md#configure-m
 
 Start the JBoss Server
 -------------------------
-Start JBoss EAP 6.1
 
 1. Open a command line and navigate to the root of the JBoss server directory.
 2. The following shows the command line to start the server:
@@ -148,14 +148,14 @@ You can configure logging by running the `configure-logging.cli` script provided
 
 _NOTE - Before you begin:_
 
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Backup the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
 3. After you have completed testing this quickstart, you can replace this file to restore the server to its original configuration.
 
 
 #### Configure Logging by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME/bin/standalone.sh 
         For Windows:  JBOSS_HOME\bin\standalone.bat
@@ -191,7 +191,7 @@ You should see the following result when you run the script:
 
 #### Configure Logging by Using the JBoss CLI Tool Interactively
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME/bin/standalone.sh 
         For Windows:  JBOSS_HOME\bin\standalone.bat 
@@ -227,7 +227,7 @@ You should see the following result when you run the script:
 
 ####  Configure Logging by Manually Editing the Server Configuration File
 
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Backup the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
 3. Open the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
 4. Locate the `logging` subsystem, identified by `<subsystem xmlns="urn:jboss:domain:logging:1.1">` in the file. Copy the following XML before the ending `</subsystem>` element.
@@ -380,7 +380,7 @@ Remove the Logging Configuration
 
 ### Restore the Logging Properties File
 
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Replace the `JBOSS_HOME/standalone/configuration/logging.properties` file with the back-up copy of the file.
 
 ### Remove the Server Logging Configuration
@@ -389,7 +389,7 @@ You can remove the logging configuration by running the  `remove-logging.cli` sc
 
 #### Remove the Logging Configuration by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat
@@ -416,7 +416,7 @@ This script removes the log and file handlers from the `logging` subsystem in th
 
 
 #### Remove the Logging Configuration Manually
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Replace the `JBOSS_HOME/standalone/configuration/standalone.xml` file with the back-up copy of the file.
 
 

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>
@@ -122,4 +121,3 @@
     </build>
 
 </project>
-

--- a/mail/README.md
+++ b/mail/README.md
@@ -5,14 +5,15 @@ Level: Beginner
 Technologies: JavaMail, JSF, CDI
 Summary: Demonstrates the use of JavaMail
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates sending email with the use of *CDI 1.0* and *JSF 2.0* in *Red Hat JBoss Enterprise Platform 6.1* or later.
+This example demonstrates sending email with the use of *CDI 1.0* and *JSF 2.0* in Red Hat JBoss Enterprise Application Platform.
 
-The example uses the default Mail provider that comes out of the box with JBoss EAP 6.1.  It uses your local mail relay and the default SMTP port of 25.
+The example uses the default Mail provider that comes out of the box with JBoss EAP. It uses your local mail relay and the default SMTP port of 25.
 
 The configuration of the mail provider is found in the `JBOSS_HOME/standalone/configuration/standalone.xml` if you are running a standalone server or in the `JBOSS_HOME/domain/configuration/domain.xml` file if you are running in a managed domain. An example of the mail subsystem XML configuration is provided below:
 
@@ -36,9 +37,9 @@ The example is a web application that takes `To`, `From`, `Subject`, and `Messag
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -47,7 +48,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/numberguess/README.md
+++ b/numberguess/README.md
@@ -5,21 +5,22 @@ Level: Beginner
 Technologies: CDI, JSF
 Summary: Demonstrates the use of CDI 1.0 and JSF 2.0
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the use of *CDI 1.0* and *JSF 2.0* in *JBoss Enterprise Application Platform 6.1* or later.
+This example demonstrates the use of *CDI 1.0* and *JSF 2.0* in Red Hat JBoss Enterprise Application Platform.
 
 There is a tutorial for this quickstart in the [Getting Started Developing Applications Guide](http://www.jboss.org/jdf/quickstarts/jboss-as-quickstart/guide/NumberguessQuickstart/).
 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -28,7 +29,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/payment-cdi-event/README.md
+++ b/payment-cdi-event/README.md
@@ -5,12 +5,13 @@ Level: Beginner
 Technologies: CDI
 Summary: Demonstrates how to use CDI 1.0 Events
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This quickstart demonstrates how to use *CDI 1.0 Events* in  *Red Hat JBoss Enterprise Application Platform 6.1* or later.
+This quickstart demonstrates how to use *CDI 1.0 Events* in  Red Hat JBoss Enterprise Application Platform.
 
 The JSF front-end client allows you to create both credit and debit operation events.
 
@@ -41,9 +42,9 @@ The payment-cdi-event quickstart defines the following classes:
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -52,7 +53,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/payment-cdi-event/pom.xml
+++ b/payment-cdi-event/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/servlet-async/README.md
+++ b/servlet-async/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: Servlet, CDI, EJB
 Summary: Demonstrates CDI, plus asynchronous Servlets and EJBs
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -25,9 +26,9 @@ not depend on this service.
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven
@@ -36,7 +37,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/servlet-filterlistener/README.md
+++ b/servlet-filterlistener/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: Servlet
 Summary: Demonstrates Servlet filters and listeners
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -15,9 +16,10 @@ This is a sample project showing the use of servlet filters and listeners.
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
+
 
 Configure Maven
 ---------------
@@ -25,7 +27,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/servlet-security-genericheader-auth/README.md
+++ b/servlet-security-genericheader-auth/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: Servlet, JAAS
 Summary: Demonstrates the use a custom authenticator to enable support for header-based authentication
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -27,10 +28,9 @@ on the `SecuredServlet` sample.
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better and Maven 3.0 or better.
+The application this project produces is designed to be run on JBoss Enterprise Application Platform 6.1 or later. 
 
-The application this project produces is designed to be run on JBoss Enterprise Application Platform 6.1. 
-
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later and Maven 3.0 or later.
 
 Configure Maven
 ---------------
@@ -38,26 +38,22 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Prerequisites
--------------
-
-_Note_: Unlike most of the quickstarts, this one must be run against JBoss Enterprise Application Platform 6.1.
 
 
-Configure the JBoss EAP Platform 6.1 Server
+Configure the JBoss EAP Server
 ---------------
 
 This quickstart requires a custom security `GenericHeaderAuth` domain be enabled in order to trust the remote proxy server's username header.
 
 _NOTE - Before you begin:_
 
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Backup the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
 3. After you have completed testing this quickstart, you can replace this file to restore the server to its original configuration.
 
 #### Configure the Security Domain by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat
@@ -75,7 +71,7 @@ This script adds the `GenericHeaderAuth` domain to the `security` subsystem in t
 
 ### Configure the Security Domain Using the JBoss CLI Interactively
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat
@@ -94,7 +90,7 @@ This script adds the `GenericHeaderAuth` domain to the `security` subsystem in t
 
 ### Configure the Security Domain by Manually Editing the Server Configuration File
 
-1.  If it is running, stop the JBoss EAP 6.1 server.
+1.  If it is running, stop the JBoss server.
 2.  Make sure you have backed up the `JBOSS_HOME/standalone/configuration/standalone.xml` file as noted in the beginning of this section.
 3.  Open the `JBOSS_HOME/standalone/configuration/standalone.xml` file in an editor and locate the subsystem `urn:jboss:domain:security`. 
 4.  Add the following XML just before the `</security-domains>` tag:
@@ -109,7 +105,7 @@ This script adds the `GenericHeaderAuth` domain to the `security` subsystem in t
         </security-domain>
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.
@@ -183,7 +179,7 @@ You can remove the security domain configuration by running the  `remove-securit
 
 ### Remove the Security Domain Configuration by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat
@@ -198,7 +194,7 @@ This script removes the `test` queue from the `messaging` subsystem in the serve
 
 
 ### Remove the Security Domain Configuration Manually
-1. If it is running, stop the JBoss EAP 6.1 Server.
+1. If it is running, stop the JBoss server.
 2. Replace the `JBOSS_HOME/standalone/configuration/standalone.xml` file with the back-up copy of the file.
 
 

--- a/servlet-security-genericheader-auth/pom.xml
+++ b/servlet-security-genericheader-auth/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    JBoss, Home of Professional Open Source
    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,8 +15,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
    -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>
@@ -218,4 +217,3 @@
         </profile>
     </profiles>
 </project>
-

--- a/servlet-security/README.md
+++ b/servlet-security/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: Servlet, Security
 Summary: Demonstrates how to use Java EE declarative security to control access to Servlet 3
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the use of Java EE declarative security to control access to Servlets and Security in JBoss Enterprise Application Platform 6.1 or later.
+This example demonstrates the use of Java EE declarative security to control access to Servlets and Security in JBoss Enterprise Application Platform.
 
 When you deploy this example, two users are automatically created for you: user `quickstartUser` with password `quickstartPwd1!` and user `guest` with password `guest`. This data is located in the `src/main/resources/import.sql` file. 
 
@@ -37,9 +38,9 @@ Please note the allowed user role `quickstarts` in the annotation -`@RolesAllowe
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven
@@ -70,13 +71,13 @@ This quickstart authenticates users using a simple database setup. The datasourc
 
 _NOTE - Before you begin:_
 
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Backup the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
 3. After you have completed testing this quickstart, you can replace this file to restore the server to its original configuration.
 
 #### Configure the Security Domain by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME/bin/standalone.sh 
         For Windows:  JBOSS_HOME\bin\standalone.bat
@@ -92,7 +93,7 @@ This script adds the `servlet-security-quickstart` domain to the `security` subs
 
 ### Configure the Security Domain Using the JBoss CLI Interactively
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME/bin/standalone.sh 
         For Windows:  JBOSS_HOME\bin\standalone.bat 
@@ -111,7 +112,7 @@ This script adds the `servlet-security-quickstart` domain to the `security` subs
 
 ### Configure the Security Domain by Manually Editing the Server Configuration File
 
-1.  If it is running, stop the JBoss EAP 6.1 server.
+1.  If it is running, stop the JBoss server.
 2.  Backup the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
 3.  Open the `JBOSS_HOME/standalone/configuration/standalone.xml` file in an editor and locate the subsystem `urn:jboss:domain:security`. 
 4.  Add the following XML to the :
@@ -129,7 +130,7 @@ This script adds the `servlet-security-quickstart` domain to the `security` subs
 Please note that the security domain name `servlet-security-quickstart` must match the one defined in the `/src/main/webapp/WEB-INF/jboss-web.xml` file.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.
@@ -193,7 +194,7 @@ You can remove the security domain configuration by running the  `remove-securit
 
 ### Remove the Security Domain Configuration by Running the JBoss CLI Script
 
-1. Start the JBoss EAP 6.1 server by typing the following: 
+1. Start the JBoss server by typing the following: 
 
         For Linux:  JBOSS_HOME_SERVER_1/bin/standalone.sh
         For Windows:  JBOSS_HOME_SERVER_1\bin\standalone.bat
@@ -208,7 +209,7 @@ This script removes the `test` queue from the `messaging` subsystem in the serve
 
 
 ### Remove the Security Domain Configuration Manually
-1. If it is running, stop the JBoss EAP 6.1 server.
+1. If it is running, stop the JBoss server.
 2. Replace the `JBOSS_HOME/standalone/configuration/standalone.xml` file with the back-up copy of the file.
 
 

--- a/shopping-cart/README.md
+++ b/shopping-cart/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: EJB
 Summary: Demonstrates a stateful session bean
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -25,9 +26,9 @@ The shopping-cart application consists of the following:
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -36,7 +37,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/tasks-jsf/README.md
+++ b/tasks-jsf/README.md
@@ -6,6 +6,7 @@ Technologies: JSF, JPA
 Summary: Provides a JSF 2.0 as view layer for the `tasks` quickstart
 Prerequisites: tasks
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -26,9 +27,9 @@ The task view is contains a task list, a task detail and a task addition form. T
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven 
@@ -37,7 +38,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/tasks-jsf/pom.xml
+++ b/tasks-jsf/pom.xml
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/tasks-rs/README.md
+++ b/tasks-rs/README.md
@@ -6,6 +6,7 @@ Technologies: JPA, JAX-RS
 Summary: Demonstrates how to use JAX-RS and JPA together
 Prerequisites: tasks
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -23,9 +24,9 @@ The application manages User and Task JPA entities. A user represents an authent
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later.
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
 
 Configure Maven
@@ -41,7 +42,7 @@ Add an Application User
 This quickstart uses a secured management interface and requires that you create an application user to access the running application. Instructions to set up an Application user can be found here:  [Add an Application User](../README.md#add-an-application-user).  After following these instructions. you should have created a user called `quickstartUser` with password `quickstartPwd1!`, belonging to the `guest` role.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/tasks-rs/pom.xml
+++ b/tasks-rs/pom.xml
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -5,13 +5,14 @@ Level: Intermediate
 Technologies: JPA, Arquillian
 Summary: Demonstrates testing JPA using Arquillian
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 
 What is it?
 -----------
 
-This project demonstrates how to use JPA 2.0 in Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+This project demonstrates how to use JPA 2.0 in Red Hat JBoss Enterprise Application Platform. 
 
 It includes a persistence unit and some sample persistence code to introduce you database access in enterprise Java. 
 
@@ -20,9 +21,9 @@ It does not contain an user interface layer. The purpose of the project is to sh
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -31,7 +32,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/tasks/pom.xml
+++ b/tasks/pom.xml
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/temperature-converter/README.md
+++ b/temperature-converter/README.md
@@ -5,13 +5,14 @@ Level: Beginner
 Technologies: EJB
 Summary: Demonstrates a stateless session bean 
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
 This example demonstrates the use of an *EJB 3.1 Stateless Session Bean* and *CDI* to access it via a *JSF*.
-Deployment occurs via a war archive for deployment to *Red Hat JBoss Enterprise Application Platform 6.1* or later.
+Deployment occurs via a war archive for deployment to Red Hat JBoss Enterprise Application Platform.
 
 These are the steps that occur:
 
@@ -25,9 +26,9 @@ These are the steps that occur:
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -36,7 +37,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/template/README.md
+++ b/template/README.md
@@ -6,6 +6,7 @@ Technologies: (list technologies used here)
 Summary: (a brief description of the quickstart to appear in the table )
 Prerequisites: (list any quickstarts that must be deployed prior to running this one)
 Target Product: (EAP, WFK, JDG, etc)
+Product Versions: (EAP 6.1, EAP 6.2, etc)
 Source: (The URL for the repository that is the source of record for this quickstart)
 
 
@@ -31,9 +32,9 @@ System requirements
 
 Contributor: For example: 
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -60,16 +61,16 @@ Contributor: If your quickstart requires any additional components, decribe how 
  * This quickstart uses Byteman to help demonstrate crash recovery. Instructions to install and configure Byteman can be found here: [Install and Configure Byteman](../README.md#install-and-configure-byteman)
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 Contributor: Does this quickstart require one or more running servers? If so, you must show how to start the server. If you start the server in one of the following 3 ways, you can simply copy the instructions in the README file located in the root folder of the quickstart directory:
 
- * Start JBoss EAP 6.1
+ * Start the JBoss Server
 
- * Start JBoss EAP 6.1 with the Full Profile
+ * Start the JBoss Server with the Full Profile
 
- * Start JBoss EAP 6.1 with Custom Options. You will need to provide the argument string to pass on the command line, for example: 
+ * Start the JBoss Server with Custom Options. You will need to provide the argument string to pass on the command line, for example: 
 
       `--server-config=../../docs/examples/configs/standalone-xts.xml`
 

--- a/wicket-ear/README.md
+++ b/wicket-ear/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: Apache Wicket, JPA
 Summary: Demonstrates how to use the Wicket Framework 1.5 with the JBoss server using the Wicket-Stuff Java EE integration, packaged as an EAR
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -29,9 +30,9 @@ This is an EAR version, with the following structure:
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -40,7 +41,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/wicket-war/README.md
+++ b/wicket-war/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: Apache Wicket, JPA
 Summary: Demonstrates how to use the Wicket Framework 1.5 with the JBoss server using the Wicket-Stuff Java EE integration packaged as a WAR
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -24,9 +25,9 @@ This is a WAR version.
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -35,7 +36,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/wsat-simple/README.md
+++ b/wsat-simple/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: WS-AT, JAX-WS
 Summary: Deployment of a WS-AT (WS-AtomicTransaction) enabled JAX-WS Web service bundled in a WAR archive
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the deployment of a WS-AT (WS-AtomicTransaction) enabled JAX-WS Web service bundled in a WAR archive for deployment to  *Red Hat JBoss Enterprise Application Platform 6.1* or later.
+This example demonstrates the deployment of a WS-AT (WS-AtomicTransaction) enabled JAX-WS Web service bundled in a WAR archive for deployment to Red Hat JBoss Enterprise Application Platform.
 
 The Web service is offered by a Restaurant for making bookings. The Service allows bookings to be made within an Atomic Transaction.
 
@@ -44,9 +45,9 @@ There is another test that shows what happens if the client decides to rollback 
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -55,7 +56,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1 with the Custom Options
+Start the JBoss Server with the Custom Options
 ----------------------
 
 First, edit the log level to reduce the amount of log output. This should make it easier to read the logs produced by this example. To do this add the
@@ -65,7 +66,7 @@ following logger block to the ./docs/examples/configs/standalone-xts.xml of your
             <level name="WARN"/>
         </logger>         
 
-Next you need to start JBoss EAP 6.1 with the XTS sub system enabled. This is enabled through the optional server configuration *standalone-xts.xml*. To do this, run the following commands from the top-level directory of JBossAS:
+Next you need to start JBoss EAP with the XTS sub system enabled. This is enabled through the optional server configuration *standalone-xts.xml*. To do this, run the following commands from the top-level directory of JBossAS:
 
         For Linux:     ./bin/standalone.sh --server-config=../../docs/examples/configs/standalone-xts.xml
         For Windows:   \bin\standalone.bat --server-config=..\..\docs\examples\configs\standalone-xts.xml
@@ -146,7 +147,7 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 Note that we use the `jboss-as-quickstart@jboss.org` user for these examples. You need to substitute it with your own user name.
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss EAP 6.1:
+Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss EAP:
 
     rhc app create -a wsatsimple -t APPLICATION_TYPE
 
@@ -222,7 +223,7 @@ You can now deploy the changes to your OpenShift application using git as follow
         git commit -m "wsat-simple quickstart on OpenShift"
         git push
 
-OpenShift will build the application using Maven, and deploy it to JBoss EAP 6.1. If successful, you should see output similar to:
+OpenShift will build the application using Maven, and deploy it to JBoss EAP. If successful, you should see output similar to:
 
     remote: [INFO] ------------------------------------------------------------------------
     remote: [INFO] BUILD SUCCESS

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>
@@ -253,4 +252,3 @@
     </profiles>
 
 </project>
-

--- a/wsba-coordinator-completion-simple/README.md
+++ b/wsba-coordinator-completion-simple/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: WS-BA, JAX-WS
 Summary:  Deployment of a WS-BA (WS-BusinessActivity) enabled JAX-WS Web service bundled in a WAR archive (Participant Completion protocol)
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the deployment of a WS-BA (WS Business Activity) enabled JAX-WS Web service bundled in a WAR archive for deployment to *Red Hat JBoss Enterprise Application Platform 6.1* or later.
+This example demonstrates the deployment of a WS-BA (WS Business Activity) enabled JAX-WS Web service bundled in a WAR archive for deployment to Red Hat JBoss Enterprise Application Platform.
 
 The Web service exposes a simple 'set' collection as a service. The Service allows items to be added to the set within a Business Activity.
 
@@ -37,7 +38,7 @@ When running the org.jboss.as.quickstarts.wsba.coordinatorcompletion.simple.Clie
 7. The service invokes the business logic. In this case, a String value is added to the set.
 9. The client can then make additional calls to the `SetService`. As the `SetService` participates as a `CoordinatorCompletion` protocol, it will continue to accept calls to `addValueToSet` until it is told to complete by the coordinator.
 10. The client can then decide to complete or cancel the BA. 
-    * If the client decides to complete, all participants will be told to complete. Providing all participants successfully complete, the coordinator will then tell all participants to close, otherwise the completed participants will be told to compensate.  
+    * If the client decides to complete, all participants will be told to complete. Providing all participants successfully complete, the coordinator will then tell all participants to close, otherwise the completed participants will be told to compensate.
     * If the participant decides to cancel, all participants will be told to compensate.
 
 There is another test that shows how the client can cancel a BA.
@@ -46,9 +47,9 @@ There is another test that shows how the client can cancel a BA.
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -57,10 +58,10 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1 with the Custom Options
+Start the JBoss Server with the Custom Options
 ----------------------
 
-Next you need to start JBoss EAP 6.1 with the XTS sub system enabled. This is enabled through the optional server configuration *standalone-xts.xml*. To do this, run the following commands from the top-level directory of JBossAS:
+Next you need to start JBoss EAP with the XTS sub system enabled. This is enabled through the optional server configuration *standalone-xts.xml*. To do this, run the following commands from the top-level directory of JBossAS:
 
         For Linux:     ./bin/standalone.sh --server-config=../../docs/examples/configs/standalone-xts.xml | egrep "started|stdout"
         For Windows:   \bin\standalone.bat --server-config=..\..\docs\examples\configs\standalone-xts.xml | egrep "started|stdout"

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>

--- a/wsba-participant-completion-simple/README.md
+++ b/wsba-participant-completion-simple/README.md
@@ -5,12 +5,13 @@ Level: Intermediate
 Technologies: WS-BA, JAX-WS
 Summary: Deployment of a WS-BA (WS-BusinessActivity) enabled JAX-WS Web service bundled in a war archive (Coordinator Completion protocol)
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
 -----------
 
-This example demonstrates the deployment of a WS-BA (WS Business Activity) enabled JAX-WS Web service bundled in a war archive for deployment to *Red Hat JBoss Enterprise Application Platform 6.1* or later.
+This example demonstrates the deployment of a WS-BA (WS Business Activity) enabled JAX-WS Web service bundled in a war archive for deployment to Red Hat JBoss Enterprise Application Platform.
 
 The Web service exposes a simple 'set' collection as a service. The Service allows items to be added to the set within a Business Activity.
 
@@ -51,9 +52,9 @@ There are other tests that show:
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -62,10 +63,10 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 ----------------------
 
-Next you need to start JBoss EAP 6.1 with the XTS sub system enabled. This is enabled through the optional server configuration *standalone-xts.xml*. To do this, run the following commands from the top-level directory of JBossAS:
+Next you need to start JBoss EAP with the XTS sub system enabled. This is enabled through the optional server configuration *standalone-xts.xml*. To do this, run the following commands from the top-level directory of JBossAS:
 
         For Linux:     ./bin/standalone.sh --server-config=../../docs/examples/configs/standalone-xts.xml | egrep "started|stdout"
         For Windows:   \bin\standalone.bat --server-config=..\..\docs\examples\configs\standalone-xts.xml | egrep "started|stdout"

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,8 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.quickstarts.eap</groupId>
@@ -212,4 +211,3 @@
     </profiles>
 
 </project>
-

--- a/xml-dom4j/README.md
+++ b/xml-dom4j/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: DOM4J, Servlet, JSF
 Summary: Demonstrates how to upload an XML file and parse it using 3rd party XML parsing libraries
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -17,9 +18,9 @@ It shows how to include 3rd part library in deployment.
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -28,7 +29,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.

--- a/xml-jaxp/README.md
+++ b/xml-jaxp/README.md
@@ -5,6 +5,7 @@ Level: Intermediate
 Technologies: JAXP, SAX, DOM, Servlet
 Summary: Upload, validation and parsing of XML using SAX or DOM
 Target Product: EAP
+Product Versions: EAP 6.1, EAP 6.2
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 
 What is it?
@@ -17,9 +18,9 @@ It also shows how to use modules available in JBoss AS.
 System requirements
 -------------------
 
-All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
-
 The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 6.1 or later. 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 
  
 Configure Maven
@@ -28,7 +29,7 @@ Configure Maven
 If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
 
 
-Start JBoss EAP 6.1
+Start the JBoss Server
 -------------------------
 
 1. Open a command line and navigate to the root of the JBoss server directory.


### PR DESCRIPTION
@pgier: I think this is good to go. If you append '&w=1" to the URL when you compare, you can ignore whitespace differences that were fixed to comply with formatting requirements.

These are mostly README file changes to remove references to AS 7. We also removed most EAP version numbers throughout the text and refer only to 'EAP 6.1 or greater' near the beginning of the files.

Let me know if you see any problems.
