### PR TITLE
BZ#1015948 Fixed test failures.

### DIFF
--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/Resources.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/Resources.java
@@ -40,6 +40,7 @@ import javax.persistence.PersistenceContextType;
  * 
  */
 @Stateful
+@RequestScoped
 public class Resources {
 
     @PersistenceContext(type = PersistenceContextType.EXTENDED)
@@ -57,7 +58,6 @@ public class Resources {
     }
 
     @Produces
-    @RequestScoped
     public FacesContext getFacesContext() {
         return FacesContext.getCurrentInstance();
     }

--- a/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskDaoTest.java
+++ b/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskDaoTest.java
@@ -27,6 +27,7 @@ import javax.persistence.EntityManager;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.as.quickstarts.tasksJsf.Resources;
 import org.jboss.as.quickstarts.tasksJsf.Task;
 import org.jboss.as.quickstarts.tasksJsf.TaskDao;
@@ -66,6 +67,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(1)
     public void user_should_be_created_with_one_task_attached() throws Exception {
         // given
         User user = new User("New user");
@@ -83,6 +85,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(2)
     public void all_tasks_should_be_obtained_from_detachedUser() {
         // when
         List<Task> userTasks = taskDao.getAll(detachedUser);
@@ -92,6 +95,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(3)
     public void range_of_tasks_should_be_provided_by_taskDao() {
         // when
         List<Task> headOfTasks = taskDao.getRange(detachedUser, 0, 1);
@@ -105,6 +109,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(4)
     public void taskDao_should_provide_basic_case_insensitive_full_text_search() {
         // given
         String taskTitlePart = "FIRST";
@@ -118,6 +123,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(5)
     public void taskDao_should_remove_task_from_detachedUser() {
         // given
         Task task = new Task();

--- a/tasks-rs/src/test/java/org/jboss/as/quickstarts/tasksrs/TaskDaoTest.java
+++ b/tasks-rs/src/test/java/org/jboss/as/quickstarts/tasksrs/TaskDaoTest.java
@@ -27,6 +27,7 @@ import javax.persistence.EntityManager;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.as.quickstarts.tasksrs.model.*;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
@@ -61,6 +62,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(1)
     public void user_should_be_created_with_one_task_attached() throws Exception {
         // given
         User user = new User("New user");
@@ -78,6 +80,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(2)
     public void all_tasks_should_be_obtained_from_detachedUser() {
         // when
         List<Task> userTasks = taskDao.getAll(detachedUser);
@@ -87,6 +90,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(3)
     public void range_of_tasks_should_be_provided_by_taskDao() {
         // when
         List<Task> headOfTasks = taskDao.getRange(detachedUser, 0, 1);
@@ -100,6 +104,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(4)
     public void taskDao_should_provide_basic_case_insensitive_full_text_search() {
         // given
         String taskTitlePart = "FIRST";
@@ -113,6 +118,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(5)
     public void taskDao_should_remove_task_from_detachedUser() {
         // given
         Task task = new Task();

--- a/tasks/src/test/java/org/jboss/as/quickstarts/tasks/TaskDaoTest.java
+++ b/tasks/src/test/java/org/jboss/as/quickstarts/tasks/TaskDaoTest.java
@@ -27,6 +27,7 @@ import javax.persistence.EntityManager;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,6 +60,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(1)
     public void user_should_be_created_with_one_task_attached() throws Exception {
         // given
         User user = new User("New user");
@@ -76,6 +78,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(2)
     public void all_tasks_should_be_obtained_from_detachedUser() {
         // when
         List<Task> userTasks = taskDao.getAll(detachedUser);
@@ -85,6 +88,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(3)
     public void range_of_tasks_should_be_provided_by_taskDao() {
         // when
         List<Task> headOfTasks = taskDao.getRange(detachedUser, 0, 1);
@@ -98,6 +102,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(4)
     public void taskDao_should_provide_basic_case_insensitive_full_text_search() {
         // given
         String taskTitlePart = "FIRST";
@@ -111,6 +116,7 @@ public class TaskDaoTest {
     }
 
     @Test
+    @InSequence(5)
     public void taskDao_should_remove_task_from_detachedUser() {
         // given
         Task task = new Task();


### PR DESCRIPTION
Adopted use of @InSequence annotation to order tests for TaskDao.

Converted the Resources bean in tasks-jsf to a @RequestScoped one
to ensure that Arquillian injects a valid EntityManager instance
in the test instances.
