### PR TITLE
[BZ-1018311] Remove ejb-security-* quickstarts from modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,6 @@
                 <module>ejb-remote</module>
                 <module>ejb-security</module>
                 <module>ejb-security-interceptors</module>
-                <module>ejb-security-plus</module>
                 <module>ejb-throws-exception</module>
                 <module>ejb-timer</module>
                 <module>ejb-multi-server</module>
@@ -238,8 +237,6 @@
             </activation>
             <modules>
                 <module>cluster-ha-singleton</module>
-                <module>ejb-security-plus</module>
-                <module>ejb-security-propagation</module>
                 <module>inter-app</module>                
                 <module>jax-rs-client</module>
                 <module>jts</module>


### PR DESCRIPTION
Removing both quickstarts ejb-security-plus and ejb-security-propagation from maven modules declaration in Quickstarts Parent pom.xml. Fixes the issue from commit eda2795 which brokes compilation.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1018311
