### PR TITLE
Remove JBoss AS 7 references from quickstarts

### DIFF
--- a/bean-validation/src/test/java/org/jboss/as/quickstarts/bean_validation/test/MemberValidationTest.java
+++ b/bean-validation/src/test/java/org/jboss/as/quickstarts/bean_validation/test/MemberValidationTest.java
@@ -65,7 +65,7 @@ public class MemberValidationTest {
                 .addAsWebInfResource("test-ds.xml", "test-ds.xml");
     }
 
-    // Get configured validator directly from JBoss AS 7 environment
+    // Get configured validator directly from JBoss EAP 6 environment
     @Inject
     Validator validator;
 

--- a/ejb-multi-server/app-one/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/AppOneBean.java
+++ b/ejb-multi-server/app-one/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/AppOneBean.java
@@ -32,7 +32,7 @@ import org.jboss.logging.Logger;
  * </p>
  * <p>
  * If the security-domain is removed the secured method can be invoked from every user. The shown principal user is 'anonymous'
- * instead of the original logged in user (AS 7.1, 7.2 and EAP6.0)
+ * instead of the original logged in user.
  * </p>
  * 
  * <p>

--- a/guide/GettingStarted.asciidoc
+++ b/guide/GettingStarted.asciidoc
@@ -1,5 +1,5 @@
-Getting started with JBoss Enterprise Application Platform or JBoss AS 7
-========================================================================
+Getting started with JBoss Enterprise Application Platform 6
+=============================================================
 :Author: Pete Muir
 
 [[GettingStarted-]]
@@ -12,7 +12,7 @@ If you already have any of these pieces of software, there is no need to
 install them again!
 ========================================================================
 
-Java 1.6, to run JBoss AS and Maven::
+Java 1.6, to run JBoss EAP and Maven::
   Choose your Java runtime, and follow their installation instructions. For example, you could choose one of:
 
   * link:http://openjdk.java.net/install/[OpenJDK]
@@ -21,20 +21,13 @@ Java 1.6, to run JBoss AS and Maven::
 Maven 3, to build and deploy the quickstarts::
   Follow the official Maven installation guide if you don't already have Maven 3 installed. You can check which version of Maven you have installed (if any) by running `mvn --version` . If you see a version newer than 3.0.0, you are ready to go. 
 
-Now, you need to choose either JBoss Enterprise Application Platform 6 or JBoss AS 7. If you choose JBoss Enterprise Application Platform 6, make sure you have:
+Make sure you have:
 
 The JBoss Enterprise Application Platform 6 runtime::
   TODO
 
 The JBoss Enterprise Application Platform 6 quickstarts::
   TODO
-
-If you choose JBoss AS 7, make sure you have:
-
-The JBoss AS 7 runtime::
-  Download JBoss AS 7 from the link:http://jboss.org/jbossas/downloads[JBoss AS download page]
-The JBoss AS quickstarts::
-  Available from link:http://jboss.org/jdf/quickstarts/get-started[JBoss Developer Framework]
 
 If you wish to use the examples from an IDE, we recommend using JBoss Developer Studio, or Eclipse with JBoss Tools.
 
@@ -45,17 +38,17 @@ Eclipse, with JBoss Tools::
 
 [TIP]
 ========================================================================
-JBoss Enterprise Application Platform 6 and JBoss AS 7 offer the 
-ability to manage multiple AS instances from a single control point. 
+JBoss Enterprise Application Platform 6 offers the 
+ability to manage multiple EAP instances from a single control point. 
 A collection of such servers are referred to as members of a "domain",
 with a single Domain Controller process acting as the management control
 point. Domains can span multiple physical (or virtual) machines, with 
-all AS instances on a given host under the control of a Host Controller 
+all EAP instances on a given host under the control of a Host Controller 
 process. The Host Controllers interact with the Domain Controller to 
-control the lifecycle of the AS instances running on that host and to 
+control the lifecycle of the EAP instances running on that host and to 
 assist the Domain Controller in managing them.
 
-JBoss AS 7 also offers a standalone mode, which is perfect for a single 
+JBoss EAP 6 also offers a standalone mode, which is perfect for a single 
 server. We use this throughout the quickstarts.
 ========================================================================
 
@@ -75,31 +68,29 @@ You should see a version string (at least `1.6.0`) printed. If not, contact your
 
 You should see a version string (at lest `3.0.0`) printed. If not, contact the Maven community for assistance. 
 
-Next, we need to choose a location for JBoss AS to live. By default, JBoss AS 7 will be extracted into `jboss-as-7.x.x.x` (where `7.x.x.x` matches the version you downloaded): 
+Next, we need to choose a location for JBoss EAP to live. By default, JBoss EAP will be extracted into `jboss-eap.6.x.x` (where `6.x.x` matches the version you downloaded): 
 
-    unzip jboss-as-7.x.x.x.zip
+    unzip jboss-eap-6.2.x.zip
 
-Now, let's start JBoss AS in standalone mode:
+Now, let's start JBoss EAP in standalone mode:
 
-    jboss-as-7.x.x.x/bin/standalone.sh
+    jboss-eap-6.2.x/bin/standalone.sh
 
 
 [TIP]
 ========================================================================
-If you want to stop JBoss AS, simply press Crtl-C whilst the terminal 
+If you want to stop JBoss EAP, simply press Crtl-C whilst the terminal 
 has focus. 
 ========================================================================
 
-That's it, JBoss AS is installed and running! Visit http://localhost:8080/ to check the server has started properly. 
+That's it, JBoss EAP is installed and running! Visit http://localhost:8080/ to check the server has started properly. 
 
 
 [TIP]
 ========================================================================
 You can find the server log for standalone instances in 
-`jboss-as-7.x.x.x/standalone/log/server.log`. The 
-link:http://docs.redhat.com/docs/en-US/JBoss_Enterprise_Application_Platform/6/html/Administration_and_Configuration_Guide/index.html[Administration and Configuration Guide for JBoss Enterprise Application Platform 6] or the
-link:https://docs.jboss.org/author/display/AS71/Getting+Started+Guide[Getting Started Guide for JBoss AS 7] 
-covers more on configuring logging. 
+`jboss-eap-6.x.x/standalone/log/server.log`. The 
+link:https://access.redhat.com/site/documentation/JBoss_Enterprise_Application_Platform/[Administration and Configuration Guide for JBoss Enterprise Application Platform 6] covers more on configuring logging. 
 ========================================================================
 
 
@@ -118,9 +109,9 @@ You should see a version string (at least `1.6.0`) printed. If not, contact your
 
 You should see a version string (at lest `3.0.0`) printed. If not, contact the Maven community for assistance. 
 
-Next, we need to choose a location for JBoss Enterprise Application Platform 6 or JBoss AS to live. By default, JBoss AS 7 will be extracted into `jboss-as-7.x.x.x` (where `7.x.x.x` matches the version you downloaded). Unzip JBoss Enterprise Application Platform or JBoss AS 7 using your tool of choice. 
+Next, we need to choose a location for JBoss Enterprise Application Platform 6 to live. By default, JBoss EAP 6 will be extracted into `jboss-eap-6.x.x` (where `6.x.x` matches the version you downloaded). Unzip JBoss Enterprise Application Platform using your tool of choice. 
 
-Finally, let's start JBoss Enterprise Application Platform or JBoss AS 7 in standalone mode. Locate your installation and run `standalone.bat` located in `bin`.
+Finally, let's start JBoss Enterprise Application Platform in standalone mode. Locate your installation and run `standalone.bat` located in `bin`.
 
 
 [TIP]
@@ -129,16 +120,14 @@ If you want to stop the server, simply press Crtl-C whilst the terminal
 has focus. 
 ========================================================================
 
-That's it, JBoss Enterprise Application Platform 6 or JBoss AS 7 is installed and running! Visit http://localhost:8080/ to check the server has started properly. 
+That's it, JBoss Enterprise Application Platform 6 is installed and running! Visit http://localhost:8080/ to check the server has started properly. 
 
 
 [TIP]
 ========================================================================
 You can find the server log for standalone instances in 
-`jboss-as-7.x.x.x/standalone/log/server.log`. The 
-link:http://docs.redhat.com/docs/en-US/JBoss_Enterprise_Application_Platform/6/html/Administration_and_Configuration_Guide/index.html[Administration and Configuration Guide for JBoss Enterprise Application Platform 6] or the
-link:https://docs.jboss.org/author/display/AS71/Getting+Started+Guide[Getting Started Guide for JBoss AS 7] 
-covers more on configuring logging.
+`jboss-as-6.x.x/standalone/log/server.log`. The 
+link:https://access.redhat.com/site/documentation/JBoss_Enterprise_Application_Platform/[Administration and Configuration Guide for JBoss Enterprise Application Platform 6] covers more on configuring logging.
 ========================================================================
 
 
@@ -146,9 +135,9 @@ Starting the JBoss server from JBDS or Eclipse with JBoss Tools
 ---------------------------------------------------------------
 [[GettingStarted-with_jboss_tools]]
 
-You may choose to use JBoss Developer Studio, or Eclipse with JBoss Tools, rather than the command line to run JBoss Enterprise Application Platform 6 or JBoss AS 7, and to deploy the quickstarts. If you don't wish to use Eclipse, you should skip this section.
+You may choose to use JBoss Developer Studio, or Eclipse with JBoss Tools, rather than the command line to run JBoss Enterprise Application Platform 6 and to deploy the quickstarts. If you don't wish to use Eclipse, you should skip this section.
 
-Make sure you have installed and started JBoss Developer Studio or Eclipse. First, we need to add our JBoss AS instance to it. First, navigate to _Preferences_:
+Make sure you have installed and started JBoss Developer Studio or Eclipse. First, we need to add our JBoss EAP instance to it. First, navigate to _Preferences_:
 
 image:gfx/Eclipse_Detect_Servers_1.png[]
 
@@ -225,20 +214,20 @@ image:gfx/Import_Quickstarts_5.jpg[]
 It will take a short time to import the projects, as Maven needs to download the project's dependencies from remote repositories.
 
 
-Managing JBoss Enterprise Application Platform 6 or JBoss AS 7
---------------------------------------------------------------
+Managing JBoss Enterprise Application Platform 6
+------------------------------------------------
 
-Here we will quickly outline how you can access both the command line interface and the web management interface for managing JBoss Enterprise Application Platform 6 or JBoss AS 7. Detailed information for both can be found in the link:http://docs.redhat.com/docs/en-US/JBoss_Enterprise_Application_Platform/6/html/Administration_and_Configuration_Guide/index.html[Administration and Configuration Guide for JBoss Enterprise Application Platform 6] or the link:https://docs.jboss.org/author/display/AS71/Admin+Guide[Admin Guide for JBoss AS 7].
+Here we will quickly outline how you can access both the command line interface and the web management interface for managing JBoss Enterprise Application Platform 6. Detailed information can be found in the link:https://access.redhat.com/site/documentation/JBoss_Enterprise_Application_Platform/[Administration and Configuration Guide for JBoss Enterprise Application Platform 6].
 
 When the server is running, the web management interface can be accessed at http://localhost:9990/console. You can use the web management interface to create datasources, manage deployments and configure the server. 
 
-JBoss Enterprise Application Platform 6 and JBoss AS 7 also comes with a command line interface. To run it on Linux, Unix or Mac, execute:
+JBoss Enterprise Application Platform 6 comes with a command line interface. To run it on Linux, Unix or Mac, execute:
 
-    jboss-as-7.x.x.x/bin/jboss-admin.sh --connect
+    jboss-eap-6.x.x/bin/jboss-admin.sh --connect
 
 Or, on Windows:
 
-    jboss-as-7.x.x.x/bin/jboss-admin.bat --connect
+    jboss-eap-6.x.x/bin/jboss-admin.bat --connect
 
 Once started, type help to discover the commands available to you. 
 

--- a/guide/GreeterQuickstart.asciidoc
+++ b/guide/GreeterQuickstart.asciidoc
@@ -4,16 +4,16 @@ CDI + JPA + EJB + JTA + JSF: Greeter quickstart
 
 [[GreeterQuickstart-]]
 
-This quickstart shows you how to create and deploy an application which persists information to a database to JBoss Enterprise Application Platform 6 or JBoss AS 7. Information is displayed using JSF views, business logic is encapsulated in CDI beans, information is persisted using JPA, and transactions can be controlled manually or using EJB.
+This quickstart shows you how to create and deploy an application which persists information to a database to JBoss Enterprise Application Platform 6. Information is displayed using JSF views, business logic is encapsulated in CDI beans, information is persisted using JPA, and transactions can be controlled manually or using EJB.
 
 Switch to the `quickstarts/greeter` directory and instruct Maven to build and deploy the application: 
 
     mvn package jboss-as:deploy
 
 
-The quickstart uses a Maven plugin to deploy the application. The plugin requires JBoss Enterprise Application Platform 6 or JBoss AS 7 to be running (you can find out how to start the server in <<GettingStarted-on_linux, Installing and starting the JBoss server on Linux, Unix or Mac OS X>> or <<GettingStarted-on_windows, Installing and starting the JBoss server on Windows>>).
+The quickstart uses a Maven plugin to deploy the application. The plugin requires JBoss Enterprise Application Platform 6 to be running (you can find out how to start the server in <<GettingStarted-on_linux, Installing and starting the JBoss server on Linux, Unix or Mac OS X>> or <<GettingStarted-on_windows, Installing and starting the JBoss server on Windows>>).
 
-Or you can start the server using an IDE, like JBoss Developer Studio. If you are using JBoss Developer Studio, you can deploy the quickstart by right clicking on the `jboss-as-greeter` project, and choosing _Run As -> Run On Server_: 
+Or you can start the server using an IDE, like JBoss Developer Studio. If you are using JBoss Developer Studio, you can deploy the quickstart by right clicking on the `jboss-greeter` project, and choosing _Run As -> Run On Server_: 
 
 image:gfx/Eclipse_Greeter_Deploy_1.png[]
 
@@ -25,15 +25,15 @@ You should see the server start up (unless you already started it in <<GettingSt
 
 image:gfx/Eclipse_Greeter_Deploy_3.png[]
 
-To use the application, visit http://localhost:8080/jboss-as-greeter/.
+To use the application, visit http://localhost:8080/jboss-greeter/.
 
 [[greeter_in_depth]]
 The greeter quickstart in depth
 -------------------------------
 
-In the quickstart, all users are stored in an H2 database (an in-memory, embedded database provided out of the box in JBoss Enterprise Application Platform 6 and JBoss AS 7). Each user is stored as an entity, and entities are mapped to the database using JPA. By default, transactions are managed manually, using the JTA API. Optionally, you can use EJB to manage transactions (we'll look at how to enable that later). We need a transaction in progress in order to read and write any entities.
+In the quickstart, all users are stored in an H2 database (an in-memory, embedded database provided out of the box in JBoss Enterprise Application Platform 6). Each user is stored as an entity, and entities are mapped to the database using JPA. By default, transactions are managed manually, using the JTA API. Optionally, you can use EJB to manage transactions (we'll look at how to enable that later). We need a transaction in progress in order to read and write any entities.
 
-The quickstart is comprised of two JSF views, an entity, and a number of CDI beans. Additionally, there are the usual configuration files in `WEB-INF/` (which can be found in the `src/main/webapp` directory). Here we find `beans.xml` and `faces-config.xml` which tell JBoss Enterprise Application Platform 6 and JBoss AS 7 to enable CDI and JSF for the application. Notice that we don't need a `web.xml`. There are two new configuration files in `WEB-INF/classes/META-INF` (which can be found in the `src/main/resources` directory of the quickstart) — `persistence.xml`, which sets up JPA, and `import.sql` which Hibernate, the JPA provider in  JBoss Enterprise Application Platform 6 and JBoss AS 7, will use to load the initial users into the application when the application starts. 
+The quickstart is comprised of two JSF views, an entity, and a number of CDI beans. Additionally, there are the usual configuration files in `WEB-INF/` (which can be found in the `src/main/webapp` directory). Here we find `beans.xml` and `faces-config.xml` which tell JBoss Enterprise Application Platform 6 to enable CDI and JSF for the application. Notice that we don't need a `web.xml`. There are two new configuration files in `WEB-INF/classes/META-INF` (which can be found in the `src/main/resources` directory of the quickstart) — `persistence.xml`, which sets up JPA, and `import.sql` which Hibernate, the JPA provider in  JBoss Enterprise Application Platform 6, will use to load the initial users into the application when the application starts. 
 
 `persistence.xml` is pretty straight forward, and links JPA to a datasource: 
 
@@ -74,12 +74,11 @@ The quickstart is comprised of two JSF views, an entity, and a number of CDI bea
 
 [TIP]
 ========================================================================
-JBoss Enterprise Application Platform 6 and JBoss AS 7 ships with a 
-sample datasource `java:jboss/datasources/ExampleDS`. This data source 
-is backed by H2, an in-memory database. Whilst this datasource is great
-for quickstarts, you will probably want to use a different datasource in
-your application. The link:http://docs.redhat.com/docs/en-US/JBoss_Enterprise_Application_Platform/6/html/Administration_and_Configuration_Guide/index.html[Administration and Configuration Guide for JBoss Enterprise Application Platform 6] or the
-link:https://docs.jboss.org/author/display/AS71/Getting+Started+Guide[Getting Started Guide for JBoss AS 7] 
+JBoss Enterprise Application Platform 6 ships with a sample datasource 
+`java:jboss/datasources/ExampleDS`. This data source is backed by h2, 
+an in-memory database. Whilst this datasource is great for quickstarts, 
+you will want to use a different datasource in your application. 
+The link:https://access.redhat.com/site/documentation/en-US/JBoss_Enterprise_Application_Platform/[Administration and Configuration Guide for JBoss Enterprise Application Platform 6] 
 tells you how to create a new datasource. 
 ========================================================================
 

--- a/guide/HelloworldOSGiQuickstart.asciidoc
+++ b/guide/HelloworldOSGiQuickstart.asciidoc
@@ -10,8 +10,8 @@ This quickstart shows you how to create and deploy a simple OSGi Bundle.
 [TIP]
 .What is OSGi?
 ========================================================================
-OSGi is a new feature to JBoss Enterprise Application Platform (Tech 
-Preview) and JBoss AS 7. It provides standards-based modularity and 
+OSGi is a new feature to JBoss Enterprise Application Platform 6. 
+It provides standards-based modularity and 
 micro-services as defined in the OSGi 4.2 Core Specifications. You can 
 deploy OSGi bundles directly into the server.
 
@@ -74,12 +74,12 @@ Now, let's look at the pom.xml , where we create the bundle:
              http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.as.quickstarts</groupId>
-    <artifactId>jboss-as-helloworld-osgi</artifactId>
+    <groupId>org.jboss.eap.quickstarts</groupId>
+    <artifactId>jboss-helloworld-osgi</artifactId>
     <version>7.1.1.Final</version>
     <packaging>bundle</packaging>                                    <1>
-    <name>JBoss AS Quickstarts: Helloworld OSGi</name>
-    <description>JBoss AS Quickstarts: Helloworld OSGi</description>
+    <name>JBoss EAP Quickstarts: Helloworld OSGi</name>
+    <description>JBoss EAP Quickstarts: Helloworld OSGi</description>
 
     <url>http://jboss.org/jbossas/osgi</url>
     <licenses>
@@ -185,11 +185,11 @@ Now, let's look at the pom.xml , where we create the bundle:
 ------------------------------------------------------------------------
 <1> The packaging of the maven module is set to bundle . This instructs maven and the maven-bundle-plugin to create an OSGi bundle. 
 <2> Since the activator uses an OSGi interface, these are provided through the OSGi interfaces artifact.
-<3> Use the provided scope for dependencies that are either provided by the OSGi framework (i.e. JBoss Enterprise Application Platform 6 or JBoss AS 7) itself or for dependencies that are provided through separate bundles. 
+<3> Use the provided scope for dependencies that are either provided by the OSGi framework (i.e. JBoss Enterprise Application Platform 6) itself or for dependencies that are provided through separate bundles. 
 <4> The maven-bundle-plugin is used to create a bundle.  You can configure it create import and export statements, and to specify the activator in use. You can read more about the link:http://felix.apache.org/site/apache-felix-maven-bundle-plugin-bnd.html[OSGi Bundle Maven Plugin] on the Apache Felix site.
 <5> We can use the jboss-as Maven plugin to deploy the bundle to the server as usual.
 
-As you can see, using OSGi with JBoss Enterprise Application Platform 6 and JBoss AS 7 is pretty easy!
+As you can see, using OSGi with JBoss Enterprise Application Platform 6 is pretty easy!
 
 
 Creating a new OSGi bundle using Eclipse
@@ -223,5 +223,5 @@ When you are finished making changes you can export your OSGi bundle so that it 
 
 image:gfx/Export.png[]
 
-You have now created an OSGi Bundle, and the JAR can be found in the plugins directory of the location specified in the screen above. You can deploy it to the server using any of the standard deployment mechanisms described in the link:http://docs.redhat.com/docs/en-US/JBoss_Enterprise_Application_Platform/6/html/Administration_and_Configuration_Guide/index.html[Administration and Configuration Guide for JBoss Enterprise Application Platform 6] or the link:http://docs.jboss.org/author/display/AS71/Getting+Started+Guide[JBoss AS 7 Getting Started Guide].
+You have now created an OSGi Bundle, and the JAR can be found in the plugins directory of the location specified in the screen above. You can deploy it to the server using any of the standard deployment mechanisms described in the link:https://access.redhat.com/site/documentation/JBoss_Enterprise_Application_Platform/[Administration and Configuration Guide for JBoss Enterprise Application Platform 6].
 

--- a/guide/HelloworldQuickstart.asciidoc
+++ b/guide/HelloworldQuickstart.asciidoc
@@ -4,7 +4,7 @@ CDI + Servlet: Helloworld quickstart
 
 [[HelloworldQuickstart-]]
 
-This quickstart shows you how to deploy a simple servlet to JBoss Enterprise Application Platform 6 or JBoss AS 7. The business logic is encapsulated in a service, which is provided as a CDI bean, and injected into the Servlet.
+This quickstart shows you how to deploy a simple servlet to JBoss Enterprise Application Platform 6. The business logic is encapsulated in a service, which is provided as a CDI bean, and injected into the Servlet.
 
 [TIP]
 .Contexts and Dependency Injection for Java EE
@@ -21,9 +21,9 @@ Switch to the `quickstarts/helloworld` directory and instruct Maven to build and
 
     mvn package jboss-as:deploy
 
-The quickstart uses a Maven plugin to deploy the application. The plugin requires JBoss Enterprise Application Platform 6 or JBoss AS 7 to be running (you can find out how to start the server in <<GettingStarted-on_linux, Installing and starting the JBoss server on Linux, Unix or Mac OS X>> or <<GettingStarted-on_windows, Installing and starting the JBoss server on Windows>>).
+The quickstart uses a Maven plugin to deploy the application. The plugin requires JBoss Enterprise Application Platform 6 to be running (you can find out how to start the server in <<GettingStarted-on_linux, Installing and starting the JBoss server on Linux, Unix or Mac OS X>> or <<GettingStarted-on_windows, Installing and starting the JBoss server on Windows>>).
 
-Now, check if the application has deployed properly by clicking http://localhost:8080/jboss-as-helloworld/HelloWorld. If you see a "Hello World" message it's all working! 
+Now, check if the application has deployed properly by clicking http://localhost:8080/jboss-helloworld/HelloWorld. If you see a "Hello World" message it's all working! 
 
 [TIP]
 ========================================================================
@@ -41,9 +41,9 @@ It's time to pull the covers back and dive into the internals of the quickstart.
 Deploying the Helloworld quickstart using JBoss Developer Studio, or Eclipse with JBoss Tools
 ---------------------------------------------------------------------------------------------
 
-You may choose to deploy the quickstart using JBoss Developer Studio, or Eclipse with JBoss Tools. You'll need to have JBoss Enterprise Application Platform 6 or JBoss AS 7 started in the IDE (as described  in <<GettingStarted-with_jboss_tools, Starting the JBoss server from JBDS or Eclipse with JBoss Tools>>) and to have imported the quickstarts into Eclipse (as described in <<GettingStarted-importing_quickstarts_into_eclipse,Importing the quickstarts into Eclipse>>).
+You may choose to deploy the quickstart using JBoss Developer Studio, or Eclipse with JBoss Tools. You'll need to have JBoss Enterprise Application Platform 6 started in the IDE (as described  in <<GettingStarted-with_jboss_tools, Starting the JBoss server from JBDS or Eclipse with JBoss Tools>>) and to have imported the quickstarts into Eclipse (as described in <<GettingStarted-importing_quickstarts_into_eclipse,Importing the quickstarts into Eclipse>>).
 
-With the quickstarts imported, you can deploy the quickstart by right clicking on the `jboss-as-helloworld` project, and choosing _Run As -> Run On Server_: 
+With the quickstarts imported, you can deploy the quickstart by right clicking on the `jboss-helloworld` project, and choosing _Run As -> Run On Server_: 
 
 image:gfx/Eclipse_Helloworld_Deploy_1.jpg[]
 
@@ -61,7 +61,7 @@ The helloworld quickstart in depth
 
 The quickstart is very simple - all it does is print "Hello World" onto a web page.
 
-The helloworld quickstart is comprised of a servlet and a CDI bean. We also include an empty `beans.xml` file, which tells JBoss Enterprise Application Platform 6 or JBoss AS 7 to look for beans in this application and to activate the CDI. `beans.xml` is located in `WEB-INF/`, which can be found in the `src/main/webapp` directory. Also in this directory we include `index.html` which uses a simple meta refresh to send the users browser to the Servlet, which is located at http://localhost:8080/jboss-as-helloworld/HelloWorld.
+The helloworld quickstart is comprised of a servlet and a CDI bean. We also include an empty `beans.xml` file, which tells JBoss Enterprise Application Platform 6 to look for beans in this application and to activate the CDI. `beans.xml` is located in `WEB-INF/`, which can be found in the `src/main/webapp` directory. Also in this directory we include `index.html` which uses a simple meta refresh to send the users browser to the Servlet, which is located at http://localhost:8080/jboss-helloworld/HelloWorld.
 
 All the configuration files for this quickstart are located in `WEB-INF/`, which can be found in the `src/main/webapp` directory.
 

--- a/guide/Introduction.asciidoc
+++ b/guide/Introduction.asciidoc
@@ -2,7 +2,7 @@ Introduction
 ============
 :Author: Pete Muir
 
-This guide will walk you through installing and starting up JBoss Enterprise Application Platform 6 or JBoss AS 7. It will then introduce key features of the Java EE 6 (Web Profile) programming model, of which JBoss AS 7 is a certified implementation.
+This guide will walk you through installing and starting up JBoss Enterprise Application Platform 6. It will then introduce key features of the Java EE 6 (Web Profile) programming model, of which JBoss EAP 6 is a certified implementation.
 
 
 [TIP]
@@ -25,9 +25,9 @@ produce a complete, modern development environment.
 ========================================================================
 
 
-JBoss Enterprise Application Platform 6 and JBoss AS 7 depart from the familiar structure of previous JBoss AS versions, so we recommend all developers follow the steps in <<GettingStarted-, Getting Started with JBoss Enterprise Application Platform 6 or JBoss AS 7>> to install and start up the application server for the first time. 
+JBoss Enterprise Application Platform 6 departs from the familiar structure of previous JBoss EAP versions, so we recommend all developers follow the steps in <<GettingStarted-, Getting Started with JBoss Enterprise Application Platform 6>> to install and start up the application server for the first time. 
 
-JBoss Enterprise Application Platform 6 and JBoss AS 7 come with a series of quickstarts aimed to get you up to writing applications with minimal fuss. We recommend that start by working through the quickstarts in this guide, in the order they are presented. If you have previous experience with Java EE 6, you may wish to skip some or all of the quickstarts.
+JBoss Enterprise Application Platform 6 comes with a series of quickstarts aimed to get you up to writing applications with minimal fuss. We recommend that start by working through the quickstarts in this guide, in the order they are presented. If you have previous experience with Java EE 6, you may wish to skip some or all of the quickstarts.
 
 *Core*
 

--- a/guide/KitchensinkQuickstart.asciidoc
+++ b/guide/KitchensinkQuickstart.asciidoc
@@ -27,11 +27,11 @@ Switch to the `quickstarts/kitchensink` directory and instruct Maven to build an
 
     mvn package jboss-as:deploy
 
-The quickstart uses a Maven plugin to deploy the application. The plugin requires JBoss Enterprise Application Platform 6 or JBoss AS 7 to be running (you can find out how to start the server in <<GettingStarted-on_linux, Installing and starting the JBoss server on Linux, Unix or Mac OS X>> or <<GettingStarted-on_windows, Installing and starting the JBoss server on Windows>>).
+The quickstart uses a Maven plugin to deploy the application. The plugin requires JBoss Enterprise Application Platform 6 to be running (you can find out how to start the server in <<GettingStarted-on_linux, Installing and starting the JBoss server on Linux, Unix or Mac OS X>> or <<GettingStarted-on_windows, Installing and starting the JBoss server on Windows>>).
 
 Or you can start the server using an IDE, like Eclipse.
 
-Now, check if the application has deployed properly by clicking http://localhost:8080/jboss-as-kitchensink. If you see a splash page it's all working!
+Now, check if the application has deployed properly by clicking http://localhost:8080/jboss-kitchensink. If you see a splash page it's all working!
 
 
 [TIP]
@@ -49,9 +49,9 @@ It's time to pull the covers back and dive into the internals of the application
 Deploying the Kitchensink quickstart using JBoss Developer Studio, or Eclipse with JBoss Tools
 ----------------------------------------------------------------------------------------------
 
-You may choose to deploy the quickstart using JBoss Developer Studio, or Eclipse with JBoss Tools. You'll need to have JBoss Enterprise Application Platform 6 or JBoss AS 7 started in the IDE (as described  in <<GettingStarted-with_jboss_tools, Starting the JBoss server from JBDS or Eclipse with JBoss Tools>>) and to have imported the quickstarts into Eclipse (as described in <<GettingStarted-importing_quickstarts_into_eclipse,Importing the quickstarts into Eclipse>>).
+You may choose to deploy the quickstart using JBoss Developer Studio, or Eclipse with JBoss Tools. You'll need to have JBoss Enterprise Application Platform 6 started in the IDE (as described  in <<GettingStarted-with_jboss_tools, Starting the JBoss server from JBDS or Eclipse with JBoss Tools>>) and to have imported the quickstarts into Eclipse (as described in <<GettingStarted-importing_quickstarts_into_eclipse,Importing the quickstarts into Eclipse>>).
 
-With the quickstarts imported, you can deploy the quickstart by right clicking on the `jboss-as-kitchensink` project, and choosing _Run As -> Run On Server_:
+With the quickstarts imported, you can deploy the quickstart by right clicking on the `jboss-kitchensink` project, and choosing _Run As -> Run On Server_:
 
 image:gfx/Eclipse_KitchenSink_Deploy_1.jpg[]
 
@@ -69,7 +69,7 @@ The kitchensink quickstart in depth
 
 The kitchensink application shows off a number of Java EE technologies such as CDI, JSF, EJB, JTA, JAX-RS and Arquillian. It does this by providing a member registration database, available via JSF and JAX-RS.
 
-As usual, let's start by looking at the necessary deployment descriptors. By now, we're very used to seeing `beans.xml` and `faces-config.xml` in `WEB-INF/` (which can be found in the `src/main/webapp` directory). Notice that, once again, we don't need a `web.xml`. There are two configuration files in `WEB-INF/classes/META-INF` (which can be found in the `src/main/resources` directory) — `persistence.xml`, which sets up JPA, and `import.sql` which Hibernate, the JPA provider in JBoss Enterprise Application Platform 6 or JBoss AS 7, will use to load the initial users into the application when the application starts. We discussed both of these files in detail in <<GreeterQuickstart-,the Greeter Quickstart>>, and these are largely the same.
+As usual, let's start by looking at the necessary deployment descriptors. By now, we're very used to seeing `beans.xml` and `faces-config.xml` in `WEB-INF/` (which can be found in the `src/main/webapp` directory). Notice that, once again, we don't need a `web.xml`. There are two configuration files in `WEB-INF/classes/META-INF` (which can be found in the `src/main/resources` directory) — `persistence.xml`, which sets up JPA, and `import.sql` which Hibernate, the JPA provider in JBoss Enterprise Application Platform 6, will use to load the initial users into the application when the application starts. We discussed both of these files in detail in <<GreeterQuickstart-,the Greeter Quickstart>>, and these are largely the same.
 
 Next, let's take a look at the JSF view the user sees. As usual, we use a template to provide the sidebar and footer. This one lives in `src/main/webapp/WEB-INF/templates/default.xhtml`:
 
@@ -102,7 +102,7 @@ Next, let's take a look at the JSF view the user sees. As usual, we use a templa
                 Platform 6.</p>
             <ul>
                 <li>
-                    <a href="http://red.ht/jbeap-6-docs">
+                    <a href="https://access.redhat.com/site/documentation/JBoss_Enterprise_Application_Platform/">
                         Documentation
                     </a>
                 </li>
@@ -111,19 +111,6 @@ Next, let's take a look at the JSF view the user sees. As usual, we use a templa
                         Product Information
                     </a>
                </li>
-            </ul>
-            <p>Learn more about JBoss AS 7.</p>
-            <ul>
-                <li>
-                    <a href="http://jboss.org/jdf/quickstarts/jboss-as-quickstart/guide">
-                        Getting Started Developing Applications Guide
-                    </a>
-                </li>
-                <li>
-                    <a href="http://jboss.org/jbossas">
-                        Community Project Information
-                    </a>
-                </li>
             </ul>
         </div>
         <div id="footer">
@@ -693,7 +680,7 @@ public class MemberResourceRESTService {
 <4> CDI allows us to inject a Bean Validation `Validator` instance, which is used to validate the POSTed member before it is persisted
 <5> `MemberRegistration` is injected to allow us to alter the member database
 <6> `MemberRepository` is injected to allow us to query the member database
-<7> The `listAllMembers()` method is called when the raw endpoint is accessed and offers up a list of endpoints. Notice that the object is automatically marshalled to JSON by RESTEasy (the JAX-RS implementation included in JBoss Enterprise Application Platform 6 and JBoss AS 7). 
+<7> The `listAllMembers()` method is called when the raw endpoint is accessed and offers up a list of endpoints. Notice that the object is automatically marshalled to JSON by RESTEasy (the JAX-RS implementation included in JBoss Enterprise Application Platform 6). 
 <8> The `lookupMemberById()` method is called when the endpoint is accessed with a member id parameter appended (for example `rest/members/1)`. Again, the object is automatically marshalled to JSON by RESTEasy.
 <9> `createMember()` is called when a POST is performed on the URL. Once again, the object is automatically unmarshalled from JSON.
 <10> In order to ensure that the member is valid, we call the `validateMember` method, which validates the object, and adds any constraint violations to the response. These can then be handled on the client side, and displayed to the user
@@ -706,7 +693,7 @@ Arquillian
 
 If you've been following along with the Test Driven Development craze of the past few years, you're probably getting a bit nervous by now, wondering how on earth you are going to test your application. Lucky for you, the Arquillian project is here to help!
 
-Arquillian provides all the boiler plate for running your test inside JBoss Enterprise Application Platform 6 or JBoss AS 7, allowing you to concentrate on testing your application. In order to do that, it utilizes Shrinkwrap, a fluent API for defining packaging, to create an archive to deploy. We'll go through the testcase, and how you configure Arquillian in just a moment, but first let's run the test.
+Arquillian provides all the boiler plate for running your test inside JBoss Enterprise Application Platform 6, allowing you to concentrate on testing your application. In order to do that, it utilizes Shrinkwrap, a fluent API for defining packaging, to create an archive to deploy. We'll go through the testcase, and how you configure Arquillian in just a moment, but first let's run the test.
 
 Before we start, we need to let Arquillian know the path to our server. Open up `src/test/resources/arquillian.xml`, uncomment the `<configuration>` elements, and set the `jbossHome` property to the path to the server:
 
@@ -725,27 +712,27 @@ $ > mvn clean test -Parq-jbossas-managed
 [INFO] Scanning for projects...
 [INFO]
 [INFO] ------------------------------------------------------------------------
-[INFO] Building JBoss AS Quickstarts: Kitchensink 7.0.0-SNAPSHOT
+[INFO] Building JBoss EAP Quickstarts: Kitchensink 7.0.0-SNAPSHOT
 [INFO] ------------------------------------------------------------------------
 [INFO]
-[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ jboss-as-kitchensink ---
+[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ jboss-kitchensink ---
 [INFO] Deleting /Users/pmuir/workspace/jboss-as-docs/quickstarts/kitchensink/target
 [INFO]
-[INFO] --- maven-resources-plugin:2.4.3:resources (default-resources) @ jboss-as-kitchensink ---
+[INFO] --- maven-resources-plugin:2.4.3:resources (default-resources) @ jboss-kitchensink ---
 [INFO] Using 'UTF-8' encoding to copy filtered resources.
 [INFO] Copying 2 resources
 [INFO]
-[INFO] --- maven-compiler-plugin:2.3.1:compile (default-compile) @ jboss-as-kitchensink ---
+[INFO] --- maven-compiler-plugin:2.3.1:compile (default-compile) @ jboss-kitchensink ---
 [INFO] Compiling 6 source files to /Users/pmuir/workspace/jboss-as-docs/quickstarts/kitchensink/target/classes
 [INFO]
-[INFO] --- maven-resources-plugin:2.4.3:testResources (default-testResources) @ jboss-as-kitchensink ---
+[INFO] --- maven-resources-plugin:2.4.3:testResources (default-testResources) @ jboss-kitchensink ---
 [INFO] Using 'UTF-8' encoding to copy filtered resources.
 [INFO] Copying 1 resource
 [INFO]
-[INFO] --- maven-compiler-plugin:2.3.1:testCompile (default-testCompile) @ jboss-as-kitchensink ---
+[INFO] --- maven-compiler-plugin:2.3.1:testCompile (default-testCompile) @ jboss-kitchensink ---
 [INFO] Compiling 1 source file to /Users/pmuir/workspace/jboss-as-docs/quickstarts/kitchensink/target/test-classes
 [INFO]
-[INFO] --- maven-surefire-plugin:2.7.2:test (default-test) @ jboss-as-kitchensink ---
+[INFO] --- maven-surefire-plugin:2.7.2:test (default-test) @ jboss-kitchensink ---
 [INFO] Surefire report directory: /Users/pmuir/workspace/jboss-as-docs/quickstarts/kitchensink/target/surefire-reports
 
 -------------------------------------------------------
@@ -760,7 +747,7 @@ Jun 25, 2011 7:17:54 PM org.jboss.as.arquillian.container.managed.ManagedDeploya
 INFO: Starting container with: [java, -Djboss.home.dir=/Users/pmuir/development/jboss, -Dorg.jboss.boot.log.file=/Users/pmuir/development/jboss/standalone/log/boot.log, -Dlogging.configuration=file:/Users/pmuir/development/jboss/standalone/configuration/logging.properties, -jar, /Users/pmuir/development/jboss/jboss-modules.jar, -mp, /Users/pmuir/development/jboss/modules, -logmodule, org.jboss.logmanager, -jaxpmodule, javax.xml.jaxp-provider, org.jboss.as.standalone, -server-config, standalone.xml]
 19:17:55,107 INFO  [org.jboss.modules] JBoss Modules version 1.0.0.CR4
 19:17:55,329 INFO  [org.jboss.msc] JBoss MSC version 1.0.0.CR2
-19:17:55,386 INFO  [org.jboss.as] JBoss AS 7.0.0.Beta4-SNAPSHOT "(TBD)" starting
+19:17:55,386 INFO  [org.jboss.as]  JBoss EAP 6.2.0.GA (AS 7.3.0.Final-redhat-10) starting
 19:17:56,159 INFO  [org.jboss.as] creating http management service using network interface (management) port (9990) securePort (-1)
 19:17:56,181 INFO  [org.jboss.as.logging] Removing bootstrap log handlers
 19:17:56,189 INFO  [org.jboss.as.naming] (Controller Boot Thread) Activating Naming Subsystem
@@ -779,7 +766,7 @@ INFO: Starting container with: [java, -Djboss.home.dir=/Users/pmuir/development/
 19:17:56,837 INFO  [org.jboss.as.connector.subsystems.datasources] (MSC service thread 1-2) Bound data source [java:jboss/datasources/ExampleDS]
 19:17:57,335 INFO  [org.jboss.as.server.deployment] (MSC service thread 1-1) Starting deployment of "arquillian-service"
 19:17:57,348 INFO  [org.jboss.as.deployment] (MSC service thread 1-7) Started FileSystemDeploymentService for directory /Users/pmuir/development/jboss/standalone/deployments
-19:17:57,693 INFO  [org.jboss.as] (Controller Boot Thread) JBoss AS 7.0.0.Beta4-SNAPSHOT "(TBD)" started in 2806ms - Started 111 of 138 services (27 services are passive or on-demand)
+19:17:57,693 INFO  [org.jboss.as] (Controller Boot Thread)  JBoss EAP 6.2.0.GA (AS 7.3.0.Final-redhat-10) started in 2806ms - Started 111 of 138 services (27 services are passive or on-demand)
 19:18:00,596 INFO  [org.jboss.as.server.deployment] (MSC service thread 1-6) Stopped deployment arquillian-service in 8ms
 19:18:01,394 INFO  [org.jboss.as.server.deployment] (pool-2-thread-7) Content added at location /Users/pmuir/development/jboss/standalone/data/content/0a/9e20b7bc978fd2778b89c7c06e4d3e1f308dfe/content
 19:18:01,403 INFO  [org.jboss.as.server.deployment] (MSC service thread 1-7) Starting deployment of "arquillian-service"
@@ -849,7 +836,7 @@ Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
 
 ------------------------------------------------------------------------
 
-As you can see, that didn't take too long (approximately 15s), and is great for running in your QA environment, but if you running locally, you might prefer to connect to a running server. To do that, start up JBoss Enterprise Application Platform 6 or JBoss AS 7 (as described in <<GettingStarted-, Getting Started with JBoss Enterprise Application Platform of JBoss AS>>. Now, run your test, but use the `arq-jbossas-remote` profile:
+As you can see, that didn't take too long (approximately 15s), and is great for running in your QA environment, but if you running locally, you might prefer to connect to a running server. To do that, start up JBoss Enterprise Application Platform 6 (as described in <<GettingStarted-, Getting Started with JBoss Enterprise Application Platform of JBoss EAP>>. Now, run your test, but use the `arq-jbossas-remote` profile:
 
     mvn clean test -Parq-jbossas-remote
 
@@ -860,27 +847,27 @@ $ > mvn clean test -Parq-jbossas-remote
 [INFO] Scanning for projects...
 [INFO]
 [INFO] ------------------------------------------------------------------------
-[INFO] Building JBoss AS Quickstarts: Kitchensink 7.0.0-SNAPSHOT
+[INFO] Building JBoss EAP Quickstarts: Kitchensink 7.0.0-SNAPSHOT
 [INFO] ------------------------------------------------------------------------
 [INFO]
-[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ jboss-as-kitchensink ---
+[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ jboss-kitchensink ---
 [INFO] Deleting /Users/pmuir/workspace/jboss-as-docs/quickstarts/kitchensink/target
 [INFO]
-[INFO] --- maven-resources-plugin:2.4.3:resources (default-resources) @ jboss-as-kitchensink ---
+[INFO] --- maven-resources-plugin:2.4.3:resources (default-resources) @ jboss-kitchensink ---
 [INFO] Using 'UTF-8' encoding to copy filtered resources.
 [INFO] Copying 2 resources
 [INFO]
-[INFO] --- maven-compiler-plugin:2.3.1:compile (default-compile) @ jboss-as-kitchensink ---
+[INFO] --- maven-compiler-plugin:2.3.1:compile (default-compile) @ jboss-kitchensink ---
 [INFO] Compiling 6 source files to /Users/pmuir/workspace/jboss-as-docs/quickstarts/kitchensink/target/classes
 [INFO]
-[INFO] --- maven-resources-plugin:2.4.3:testResources (default-testResources) @ jboss-as-kitchensink ---
+[INFO] --- maven-resources-plugin:2.4.3:testResources (default-testResources) @ jboss-kitchensink ---
 [INFO] Using 'UTF-8' encoding to copy filtered resources.
 [INFO] Copying 1 resource
 [INFO]
-[INFO] --- maven-compiler-plugin:2.3.1:testCompile (default-testCompile) @ jboss-as-kitchensink ---
+[INFO] --- maven-compiler-plugin:2.3.1:testCompile (default-testCompile) @ jboss-kitchensink ---
 [INFO] Compiling 1 source file to /Users/pmuir/workspace/jboss-as-docs/quickstarts/kitchensink/target/test-classes
 [INFO]
-[INFO] --- maven-surefire-plugin:2.7.2:test (default-test) @ jboss-as-kitchensink ---
+[INFO] --- maven-surefire-plugin:2.7.2:test (default-test) @ jboss-kitchensink ---
 [INFO] Surefire report directory: /Users/pmuir/workspace/jboss-as-docs/quickstarts/kitchensink/target/surefire-reports
 
 ------------------------------------------------------
@@ -1025,7 +1012,7 @@ Now, let's look at how we configure Arquillian. First of all, let's take a look 
         containers, as it is the most mature -->
    <defaultProtocol type="Servlet 3.0" />                            <2>
 
-   <!-- Example configuration for a remote JBoss AS 7 instance -->
+   <!-- Example configuration for a remote JBoss EAP 6 instance -->
    <container qualifier="jboss" default="true">
       <!-- If you want to use the JBOSS_HOME environment variable,
            just delete the jbossHome property -->
@@ -1046,8 +1033,8 @@ Now, we need to look at how we select between containers in the `pom.xml`:
 ------------------------------------------------------------------------
 <profile>
     <!-- An optional Arquillian testing profile that executes tests 
-        in your JBoss AS instance -->
-    <!-- This profile will start a new JBoss AS instance, and 
+        in your JBoss EAP instance -->
+    <!-- This profile will start a new JBoss EAP instance, and 
         execute the test, shutting it down when done -->
     <!-- Run with: mvn clean test -Parq-jbossas-managed -->
     <id>arq-jbossas-managed</id>                                     <1>
@@ -1064,7 +1051,7 @@ Now, we need to look at how we select between containers in the `pom.xml`:
 
 <profile>
     <!-- An optional Arquillian testing profile that executes 
-        tests in a remote JBoss AS instance -->
+        tests in a remote JBoss EAP instance -->
     <!-- Run with: mvn clean test -Parq-jbossas-remote -->
     <id>arq-jbossas-remote</id>
     <dependencies>

--- a/guide/NumberguessQuickstart.asciidoc
+++ b/guide/NumberguessQuickstart.asciidoc
@@ -4,17 +4,17 @@ CDI + JSF: Numberguess quickstart
 
 [[NumberguessQuickstart-]]
 
-This quickstart shows you how to create and deploy a simple application to JBoss Enterprise Application Platform 6 or JBoss AS 7; the application does not persist any information. Information is displayed using a JSF view, and business logic is encapsulated in two CDI beans.
+This quickstart shows you how to create and deploy a simple application to JBoss Enterprise Application Platform 6; the application does not persist any information. Information is displayed using a JSF view, and business logic is encapsulated in two CDI beans.
 
 Switch to the `quickstarts/numberguess` directory and instruct Maven to build and deploy the application:
 
     mvn package jboss-as:deploy
 
-The quickstart uses a Maven plugin to deploy the application. The plugin requires JBoss Enterprise Application Platform 6 or JBoss AS 7 to be running (you can find out how to start the server in <<GettingStarted-on_linux, Installing and starting the JBoss server on Linux, Unix or Mac OS X>> or <<GettingStarted-on_windows, Installing and starting the JBoss server on Windows>>).
+The quickstart uses a Maven plugin to deploy the application. The plugin requires JBoss Enterprise Application Platform 6 to be running (you can find out how to start the server in <<GettingStarted-on_linux, Installing and starting the JBoss server on Linux, Unix or Mac OS X>> or <<GettingStarted-on_windows, Installing and starting the JBoss server on Windows>>).
 
 Or you can start the server using an IDE, like JBoss Developer Studio.
 
-Now, see if you can determine the most efficient approach to pinpoint the random number at the URL http://localhost:8080/jboss-as-numberguess.
+Now, see if you can determine the most efficient approach to pinpoint the random number at the URL http://localhost:8080/jboss-numberguess.
 
 [TIP]
 ========================================================================
@@ -32,9 +32,9 @@ It's time to pull the covers back and dive into the internals of the quickstart.
 Deploying the Numberguess quickstart using Eclipse
 --------------------------------------------------
 
-You may choose to deploy the quickstart using Eclipse. You'll need to have JBoss Enterprise Application Platform 6 or JBoss AS 7 started in Eclipse as described  in <<GettingStarted-with_jboss_tools, Starting the JBoss server from JBDS or Eclipse with JBoss Tools>>) and to have imported the quickstarts into Eclipse (as described in <<GettingStarted-importing_quickstarts_into_eclipse, Importing the quickstarts into Eclipse>>).
+You may choose to deploy the quickstart using Eclipse. You'll need to have JBoss Enterprise Application Platform 6 started in Eclipse as described  in <<GettingStarted-with_jboss_tools, Starting the JBoss server from JBDS or Eclipse with JBoss Tools>>) and to have imported the quickstarts into Eclipse (as described in <<GettingStarted-importing_quickstarts_into_eclipse, Importing the quickstarts into Eclipse>>).
 
-With the quickstarts imported, you can deploy the quickstart by right clicking on the `jboss-as-numberguess` project, and choosing _Run As -> Run On Server_: 
+With the quickstarts imported, you can deploy the quickstart by right clicking on the `jboss-numberguess` project, and choosing _Run As -> Run On Server_: 
 
 image:gfx/Eclipse_Numberguess_Deploy_1.jpg[]
 
@@ -54,7 +54,7 @@ In the numberguess application you get 10 attempts to guess a number between 1 a
 
 The quickstart is comprised of a number of beans, configuration files and Facelets (JSF) views, packaged as a war module. Let's start by examining the configuration files.
 
-All the configuration files for this quickstart are located in `WEB-INF/`, which can be found in the `src/main/webapp` directory. First, we have the JSF 2.0 version of `faces-config.xml`. A standardized version of Facelets is the default view handler in JSF 2.0, so there's really nothing that we have to configure. JBoss AS goes above and beyond Java EE here, and will automatically configure JSF for you if you include this file. Thus, the configuration consists of only the root element. 
+All the configuration files for this quickstart are located in `WEB-INF/`, which can be found in the `src/main/webapp` directory. First, we have the JSF 2.0 version of `faces-config.xml`. A standardized version of Facelets is the default view handler in JSF 2.0, so there's really nothing that we have to configure. JBoss EAP goes above and beyond Java EE here, and will automatically configure JSF for you if you include this file. Thus, the configuration consists of only the root element. 
 
 .src/main/webapp/WEB-INF/faces-config.xml
 [source,xml]
@@ -69,7 +69,7 @@ All the configuration files for this quickstart are located in `WEB-INF/`, which
 </faces-config>
 ------------------------------------------------------------------------
 
-There's also an empty `beans.xml` file, which tells JBoss AS to look for beans in this  application and to activate the CDI. 
+There's also an empty `beans.xml` file, which tells JBoss EAP to look for beans in this  application and to activate the CDI. 
 
 Notice that we don't even need a `web.xml`! 
 

--- a/helloworld-mdb/src/main/java/org/jboss/as/quickstarts/servlet/HelloWorldMDBServletClient.java
+++ b/helloworld-mdb/src/main/java/org/jboss/as/quickstarts/servlet/HelloWorldMDBServletClient.java
@@ -69,7 +69,7 @@ public class HelloWorldMDBServletClient extends HttpServlet {
         resp.setContentType("text/html");
         PrintWriter out = resp.getWriter();
         Connection connection = null;
-        out.write("<h1>Quickstart: Example demonstrates the use of <strong>JMS 1.1</strong> and <strong>EJB 3.1 Message-Driven Bean</strong> in JBoss Enterprise Application 6 or JBoss AS 7.1.0.</h1>");
+        out.write("<h1>Quickstart: This example demonstrates the use of <strong>JMS 1.1</strong> and <strong>EJB 3.1 Message-Driven Bean</strong> in JBoss Enterprise Application 6.</h1>");
         try {
             Destination destination;
             if (req.getParameterMap().keySet().contains("topic")) {

--- a/jax-rs-client/src/test/java/org/jboss/as/quickstarts/jaxrsclient/JaxRsClientTest.java
+++ b/jax-rs-client/src/test/java/org/jboss/as/quickstarts/jaxrsclient/JaxRsClientTest.java
@@ -19,9 +19,10 @@ package org.jboss.as.quickstarts.jaxrsclient;
 /**
  * This example demonstrates the use an external JAX-RS RestEasy client
  * which interacts with a JAX-RS Web service that uses CDI 1.0 and JAX-RS 
- * in JBoss AS 7.  Specifically, this client "calls" the HelloWorld JAX-RS
- * Web Service created in quickstart helloworld-rs.  Please refer to the helloworld-rs
- * README.md for instructions on how to build and deploy helloworld-rs.
+ * in JBoss Enterprise Application Platform 6.  Specifically, this client 
+ * "calls" the HelloWorld JAX-RS Web Service created in quickstart 
+ * helloworld-rs.  Please refer to the helloworld-rs README.md 
+ * for instructions on how to build and deploy helloworld-rs.
  */
 import static org.junit.Assert.*;
 

--- a/wsat-simple/src/main/java/org/jboss/as/quickstarts/wsat/simple/servlet/WSATSimpleServletClient.java
+++ b/wsat-simple/src/main/java/org/jboss/as/quickstarts/wsat/simple/servlet/WSATSimpleServletClient.java
@@ -81,7 +81,7 @@ public class WSATSimpleServletClient extends HttpServlet {
         resp.setContentType("text/html");
         PrintWriter out = resp.getWriter();
 
-        out.write("<h1>Quickstart: This example demonstrates the deployment of a WS-AT (WS-AtomicTransaction) enabled JAX-WS Web service bundled in a war archive for deployment to *JBoss AS 7*.</h1>");
+        out.write("<h1>Quickstart: This example demonstrates the deployment of a WS-AT (WS-AtomicTransaction) enabled JAX-WS Web service bundled in a war archive for deployment to *JBoss Enterprise Application Platform 6*.</h1>");
 
         System.out.println("[CLIENT] Creating a new WS-AT User Transaction");
         UserTransaction ut = UserTransactionFactory.userTransaction();


### PR DESCRIPTION
Apply changes to remove JBoss AS 7 revereences to the 6.2.x branch.
