### PR TITLE
Removed colons from document title for guides.

### DIFF
--- a/guide/GreeterQuickstart.asciidoc
+++ b/guide/GreeterQuickstart.asciidoc
@@ -1,4 +1,4 @@
-CDI + JPA + EJB + JTA + JSF: Greeter quickstart
+CDI + JPA + EJB + JTA + JSF -- Greeter quickstart
 ===============================================
 :Author: Pete Muir
 

--- a/guide/HelloworldOSGiQuickstart.asciidoc
+++ b/guide/HelloworldOSGiQuickstart.asciidoc
@@ -1,4 +1,4 @@
-OSGi: Helloworld OSGi quickstart
+OSGi -- Helloworld OSGi quickstart
 ================================
 :Author: Pete Muir
 

--- a/guide/HelloworldQuickstart.asciidoc
+++ b/guide/HelloworldQuickstart.asciidoc
@@ -1,4 +1,4 @@
-CDI + Servlet: Helloworld quickstart
+CDI + Servlet -- Helloworld quickstart
 ====================================
 :Author: Pete Muir
 

--- a/guide/KitchensinkQuickstart.asciidoc
+++ b/guide/KitchensinkQuickstart.asciidoc
@@ -1,4 +1,4 @@
-CDI + JSF + EJB + JTA + Bean Validation + JAX-RS + Arquillian: Kitchensink quickstart
+CDI + JSF + EJB + JTA + Bean Validation + JAX-RS + Arquillian -- Kitchensink quickstart
 =====================================================================================
 :Author: Pete Muir
 

--- a/guide/NumberguessQuickstart.asciidoc
+++ b/guide/NumberguessQuickstart.asciidoc
@@ -1,4 +1,4 @@
-CDI + JSF: Numberguess quickstart
+CDI + JSF -- Numberguess quickstart
 =================================
 :Author: Pete Muir
 


### PR DESCRIPTION
Colons were parsed resulted in some additional unwanted characters
being generated for the titles of these guides in the JDF site.
