### PR TITLE
BZ1029076 Improve commands used for server lifecycle

### DIFF
--- a/hornetq-clustering/install-domain.cli
+++ b/hornetq-clustering/install-domain.cli
@@ -1,6 +1,6 @@
 ## Batch file to configure the domain for the hornetq-clustering quickstart.
 
-# - Stop the servers
+# -- Stop the currently running servers
 :stop-servers
 
 batch
@@ -25,5 +25,6 @@ deploy --server-groups=jdf-hornetq-clustering-group ../helloworld-mdb/target/jbo
 # -- Run this batch file
 run-batch
 
-# -- Restart the servers to use these changes
-:restart-servers
+# -- Start the newly defined servers
+/host=master/server-config=jdf-hornetqcluster-node1:start(blocking=true)
+/host=master/server-config=jdf-hornetqcluster-node2:start(blocking=true)

--- a/hornetq-clustering/remove-domain.cli
+++ b/hornetq-clustering/remove-domain.cli
@@ -1,7 +1,8 @@
 ## Batch file to remove the domain configuration for the hornetq-clustering quickstart.
 
 # - Stop the servers
-:stop-servers
+/host=master/server-config=jdf-hornetqcluster-node1:stop(blocking=true)
+/host=master/server-config=jdf-hornetqcluster-node2:stop(blocking=true)
 
 batch
 
@@ -15,5 +16,5 @@ batch
 # -- Run this batch file
 run-batch
 
-# -- Restart the servers to use these changes
-:restart-servers
+# -- Restart the original servers
+:start-servers


### PR DESCRIPTION
1) :restart-servers only restarts currently running servers, and since install-domain.cli stops all servers, it has no effect.

2) I have the scripts now individually start and stop the newly added servers

3) I add the "blocking=true" param to start/stop which causes the client to wait for server start/stop to fully complete. That's mildly more robust.
