### PR TITLE
Bz1029445: Update OpenShift instructions to be more current with latest version

### DIFF
--- a/helloworld-mdb/README.md
+++ b/helloworld-mdb/README.md
@@ -115,24 +115,40 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 ### Create the OpenShift Application
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss Enterprise Application Platform:
+Note that we use `USER_DOMAIN_NAME` for these examples. You need to substitute it with your own OpenShift account user name.
 
-    rhc app create -a hellworldmdb -t APPLICATION_TYPE
+Open a shell command prompt and change to a directory of your choice. Enter the following command to create a JBoss EAP 6 application:
 
-The domain name for this application will be `helloworldmdb-YOUR_DOMAIN_NAME.rhcloud.com`. Here we use the _quickstart_ domain. You will need to replace it with your own OpenShift domain name.
+    rhc app create -a hellworldmdb -t jbosseap-6
+
+The domain name for this application will be `helloworldmdb-YOUR_DOMAIN_NAME.rhcloud.com`. Be sure to replace `YOUR_DOMAIN_NAME` with your own OpenShift account user name.
 
 This command creates an OpenShift application called `helloworldmdb` and will run the application inside the `jbosseap-6`. You should see some output similar to the following:
 
-    Creating application: helloworldmdb
-    Now your new domain name is being propagated worldwide (this might take a minute)...
-    Warning: Permanently added 'helloworldmdb-quickstart.rhcloud.com,107.22.36.32' (RSA) to the list of known hosts.
-    Confirming application 'helloworldmdb' is available:  Success!
-    
-    helloworldmdb published:  http://helloworldmdb-quickstart.rhcloud.com/
-    git url:  ssh://b92047bdc05e46c980cc3501c3577c1e@helloworldmdb-quickstart.rhcloud.com/~/git/helloworldmdb.git/
-    Successfully created application: helloworldmdb
+    Application Options
+    -------------------
+      Namespace:  YOUR_DOMAIN_NAME
+      Cartridges: jbosseap-6 (addtl. costs may apply)
+      Gear Size:  default
+      Scaling:    no
 
-The create command creates a git repository in the current directory with the same name as the application. Notice that the output also reports the URL at which the application can be accessed. Make sure it is available by typing the published url <http://helloworldmdb-quickstart.rhcloud.com/> into a browser or use command line tools such as curl or wget. Be sure to replace the `quickstart` in the URL with your domain name.
+    Creating application 'helloworldmdb' ... done
+
+    Waiting for your DNS name to be available ... done
+
+    Cloning into 'helloworldmdb'...
+    Warning: Permanently added the RSA host key for IP address '54.237.58.0' to the list of known hosts.
+
+    Your application 'helloworldmdb' is now available.
+
+      URL:        http://helloworldmdb-YOUR_DOMAIN_NAME.rhcloud.com/
+      SSH to:     52864af85973ca430200006f@helloworldmdb-YOUR_DOMAIN_NAME.rhcloud.com
+      Git remote: ssh://52864af85973ca430200006f@helloworldmdb-YOUR_DOMAIN_NAME.rhcloud.com/~/git/helloworldmdb.git/
+      Cloned to:  CURRENT_DIRECTORY/helloworldmdb
+
+    Run 'rhc show-app helloworldmdb' for more details about your app.
+
+The create command creates a git repository in the current directory with the same name as the application, in this case, `helloworldmdb`. Notice that the output also reports the URL at which the application can be accessed. Make sure it is available by typing the published url <http://helloworldmdb-YOUR_DOMAIN_NAME.rhcloud.com/> into a browser or use command line tools such as curl or wget. Be sure to replace `YOUR_DOMAIN_NAME` with your OpenShift account domain name.
         
 
 ### Migrate the Quickstart Source
@@ -161,14 +177,14 @@ You can now deploy the changes to your OpenShift application using git as follow
 
 The final push command triggers the OpenShift infrastructure to build and deploy the changes. 
 
-Note that the `openshift` profile in the `pom.xml` file is activated by OpenShift. This causes the WAR built by OpenShift to be copied to the `deployments` directory and deployed without a context path.
+Note that the `openshift` profile in the `pom.xml` file is activated by OpenShift. This causes the WAR built by OpenShift to be copied to the `deployments/` directory and deployed without a context path.
 
 ### Test the OpenShift Application
 
-When the push command returns you can test the application by getting the following URL either via a browser or using tools such as curl or wget. Be sure to replace the `quickstart` in the URL with your domain name.
+When the push command returns you can test the application by getting the following URL either via a browser or using tools such as curl or wget. Be sure to replace the `YOUR_DOMAIN_NAME` in the URL with your OpenShift account domain name.
 
-* <http://helloworldmdb-quickstart.rhcloud.com/> to send messages to the queue
-* <http://helloworldmdb-quickstart.rhcloud.com/HelloWorldMDBServletClient?topic> to send messages to the topic
+* <http://helloworldmdb-YOUR_DOMAIN_NAME.rhcloud.com/> to send messages to the queue
+* <http://helloworldmdb-YOUR_DOMAIN_NAME.rhcloud.com/HelloWorldMDBServletClient?topic> to send messages to the topic
 
 If the application has run succesfully you should see some output in the browser.
 
@@ -187,13 +203,14 @@ This will show the tail of the servers log which should show something like the 
 
 You can use the OpenShift command line tools or the OpenShift web console to discover and control the application.
 
-### Destroy the OpenShift Application
+### Delete the OpenShift Application
 
-When you are finished with the application you can destroy it as follows:
+When you are finished with the application you can delete it from OpenShift it as follows:
 
-        rhc app destroy -a helloworldmdb
+        rhc app-delete -a helloworldmdb
         
-_Note_: There is a limit to the number of applications you can deploy concurrently to OpenShift. If the `rhc app create` command returns an error indicating you have reached that limit, you must destroy an existing application before you continue. 
+_Note_: There is a limit to the number of applications you can deploy concurrently to OpenShift. If the `rhc app create` command returns an error indicating you have reached that limit, you must delete an existing application before you continue. 
 
 * To view the list of your OpenShift applications, type: `rhc domain show`
-* To destroy an application, type the following, substituting the application name you want to destroy: `rhc app destroy -a APPLICATION_NAME_TO_DESTROY`
+* To delete an application from OpenShift, type the following, substituting the application name you want to delete: `rhc app-delete -a APPLICATION_NAME_TO_DELETE`
+

--- a/helloworld-rs/README.md
+++ b/helloworld-rs/README.md
@@ -95,24 +95,40 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 ### Create the OpenShift Application
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss EAP:
+Note that we use `USER_DOMAIN_NAME` for these examples. You need to substitute it with your own OpenShift account user name.
 
-    rhc app create -a helloworldrs -t APPLICATION_TYPE
+Open a shell command prompt and change to a directory of your choice. Enter the following command to create a JBoss EAP 6 application:
 
-_NOTE_: The domain name for this application will be `helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com`. Here we use the _quickstart_ domain. You will need to replace it with your own OpenShift domain name.
+        rhc app create -a helloworldrs -t jbosseap-6
+
+_NOTE_: The domain name for this application will be `helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com`. Be sure to replace `YOUR_DOMAIN_NAME` with your own OpenShift account user name.
 
 This command creates an OpenShift application named `helloworldrs` and will run the application inside the `jbosseap-6` container. You should see some output similar to the following:
 
-    Creating application: helloworldrs
-    Now your new domain name is being propagated worldwide (this might take a minute)...
-    Warning: Permanently added 'helloworldrs-quickstart.rhcloud.com,107.22.36.32' (RSA) to the list of known hosts.
-    Confirming application 'helloworldrs' is available:  Success!
-    
-    helloworldrs published:  http://helloworldrs-quickstart.rhcloud.com/
-    git url:  ssh://b92047bdc05e46c980cc3501c3577c1e@helloworldrs-quickstart.rhcloud.com/~/git/helloworldrs.git/
-    Successfully created application: helloworldrs
+    Application Options
+    -------------------
+      Namespace:  YOUR_DOMAIN_NAME
+      Cartridges: jbosseap-6 (addtl. costs may apply)
+      Gear Size:  default
+      Scaling:    no
 
-The create command creates a git repository in the current directory with the same name as the application. Notice that the output also reports the URL at which the application can be accessed. Make sure it is available by typing the published url <http://helloworldrs-quickstart.rhcloud.com/> into a browser or use command line tools such as curl or wget. Be sure to replace the `quickstart` in the URL with your domain name.
+    Creating application 'helloworldrs' ... done
+
+    Waiting for your DNS name to be available ... done
+
+    Cloning into 'helloworldrs'...
+    Warning: Permanently added the RSA host key for IP address '54.237.58.0' to the list of known hosts.
+
+    Your application 'helloworldrs' is now available.
+
+      URL:        http://helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com/
+      SSH to:     52864af85973ca430200006f@helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com
+      Git remote: ssh://52864af85973ca430200006f@helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com/~/git/helloworldrs.git/
+      Cloned to:  CURRENT_DIRECTORY/helloworldrs
+
+    Run 'rhc show-app helloworldrs' for more details about your app.
+
+The create command creates a git repository in the current directory with the same name as the application. Notice that the output also reports the URL at which the application can be accessed. Make sure it is available by typing the published url <http://helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com/> into a browser or use command line tools such as curl or wget. Be sure to replace `YOUR_DOMAIN_NAME` with your OpenShift account domain name.
 
 ### Migrate the Quickstart Source
 
@@ -123,8 +139,8 @@ Now that you have confirmed it is working you can migrate the quickstart source.
 
 Copy the source for the `helloworld-rs` quickstart into this new git repository:
 
-        cp -r <quickstarts>/helloworld-rs/src .
-        cp <quickstarts>/helloworld-rs/pom.xml .
+        cp -r QUICKSTART_HOME/helloworld-rs/src .
+        cp QUICKSTART_HOME/helloworld-rs/pom.xml .
 
 ### Deploy the OpenShift Application
 
@@ -136,24 +152,25 @@ You can now deploy the changes to your OpenShift application using git as follow
 
 The final push command triggers the OpenShift infrastructure to build and deploy the changes. 
 
-Note that the `openshift` profile in the `pom.xml` file is activated by OpenShift. This causes the WAR built by OpenShift to be copied to the `deployments` directory and deployed without a context path.
+Note that the `openshift` profile in the `pom.xml` file is activated by OpenShift. This causes the WAR built by OpenShift to be copied to the `deployments/` directory and deployed without a context path.
 
 ### Test the OpenShift Application
 
-When the push command returns you can test the application by getting the following URLs either via a browser or using tools such as curl or wget. Be sure to replace the `quickstart` in the URL with your domain name.
+When the push command returns you can test the application by getting the following URLs either via a browser or using tools such as curl or wget. Be sure to replace the `YOUR_DOMAIN_NAME` in the URL with your OpenShift account domain name.
 
-* <http://helloworldrs-quickstart.rhcloud.com/rest/xml> if you want *xml* or
-* <http://helloworldrs-quickstart.rhcloud.com/rest/json> if you want *json*
+* <http://helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com/rest/xml> if you want *xml* or
+* <http://helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com/rest/json> if you want *json*
 
 You can use the OpenShift command line tools or the OpenShift web console to discover and control the application.
 
-### Destroy the OpenShift Application
+### Delete the OpenShift Application
 
-If you plan to test the `jax-rs-client` quickstart on OpenShift, you may want to wait to destroy this application because it is also used by that quickstart for testing. When you are finished with the application you can destroy it as follows:
+If you plan to test the `jax-rs-client` quickstart on OpenShift, you may want to wait to delete this application because it is also used by that quickstart for testing. When you are finished with the application you can delete if from OpenShift as follows:
 
-        rhc app destroy -a helloworldrs
+        rhc app-delete -a helloworldrs
 
-_Note_: There is a limit to the number of applications you can deploy concurrently to OpenShift. If the `rhc app create` command returns an error indicating you have reached that limit, you must destroy an existing application before you continue. 
+_Note_: There is a limit to the number of applications you can deploy concurrently to OpenShift. If the `rhc app create` command returns an error indicating you have reached that limit, you must delete an existing application before you continue. 
 
 * To view the list of your OpenShift applications, type: `rhc domain show`
-* To destroy an existing application, type the following, substituting the application name you want to destroy: `rhc app destroy -a APPLICATION_NAME_TO_DESTROY`
+* To delete an application from OpenShift, type the following, substituting the application name you want to delete: `rhc app-delete -a APPLICATION_NAME_TO_DELETE`
+

--- a/helloworld-ws/README.md
+++ b/helloworld-ws/README.md
@@ -118,44 +118,59 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 ### Create the OpenShift Application
 
-Note that we use the `jboss-as-quickstart@jboss.org` user for these examples. You need to substitute it with your own user name.
+Note that we use `USER_DOMAIN_NAME` for these examples. You need to substitute it with your own OpenShift account user name.
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss EAP 6:
+Open a shell command prompt and change to a directory of your choice. Enter the following command to create a JBoss EAP 6 application:
 
-        rhc app create -a helloworldws -t APPLICATION_TYPE
+    rhc app create -a helloworldws -t jbosseap-6
 
-_NOTE_: The domain name for this application will be `helloworldws-YOUR_DOMAIN_NAME.rhcloud.com`. Here we use the _quickstart_ domain. You will need to replace it with your own OpenShift domain name.
+_NOTE_: The domain name for this application will be `helloworldws-YOUR_DOMAIN_NAME.rhcloud.com`. Be sure to replace `YOUR_DOMAIN_NAME` with your own OpenShift account user name.
 
-This command creates an OpenShift application called `helloworldws` and will run the application inside a `jbossas-7` or a `jbosseap-6` container. You should see some output similar to the following:
+This command creates an OpenShift application called `helloworldws` and will run the application inside the `jbosseap-6` container. You should see some output similar to the following:
 
-    Creating application: helloworldws
-    Now your new domain name is being propagated worldwide (this might take a minute)...
-    Warning: Permanently added 'helloworldws-quickstart.rhcloud.com,107.22.36.32' (RSA) to the list of known hosts.
-    Confirming application 'helloworldws' is available:  Success!
-    
-    helloworldws published:  http://helloworldws-quickstart.rhcloud.com/
-    git url:  ssh://b92047bdc05e46c980cc3501c3577c1e@helloworldws-quickstart.rhcloud.com/~/git/helloworldws.git/
-    Successfully created application: helloworldws
+    Application Options
+    -------------------
+      Namespace:  YOUR_DOMAIN_NAME
+      Cartridges: jbosseap-6 (addtl. costs may apply)
+      Gear Size:  default
+      Scaling:    no
 
-The create command creates a git repository in the current directory with the same name as the application. Notice that the output also reports the URL at which the application can be accessed. Make sure it is available by typing the published url <http://helloworldws-quickstart.rhcloud.com/> into a browser or use command line tools such as curl or wget.
+    Creating application 'helloworldws' ... done
+
+    Waiting for your DNS name to be available ... done
+
+    Cloning into 'helloworldws'...
+    Warning: Permanently added the RSA host key for IP address '54.237.58.0' to the list of known hosts.
+
+    Your application 'helloworldws' is now available.
+
+      URL:        http://helloworldws-YOUR_DOMAIN_NAME.rhcloud.com/
+      SSH to:     52864af85973ca430200006f@helloworldws-YOUR_DOMAIN_NAME.rhcloud.com
+      Git remote: ssh://52864af85973ca430200006f@helloworldws-YOUR_DOMAIN_NAME.rhcloud.com/~/git/helloworldws.git/
+      Cloned to:  CURRENT_DIRECTORY/helloworldws
+
+    Run 'rhc show-app helloworldws' for more details about your app.
+
+The create command creates a git repository in the current directory with the same name as the application, in this case, `helloworldws`. Notice that the output also reports the URL at which the application can be accessed. Make sure it is available by typing the published url <http://helloworldws-YOUR_DOMAIN_NAME.rhcloud.com/> into a browser or use command line tools such as curl or wget. Be sure to replace `YOUR_DOMAIN_NAME` with your OpenShift account domain name.
 
 ### Migrate the Quickstart Source
 
-Now that you have confirmed it is working you can now migrate the quickstart source. You no longer need the default application so change directory into the new git repository and tell git to remove the source files and pom:
+Now that you have confirmed it is working you can now migrate the quickstart source and POM file. You no longer need the default application, so change directory into the new git repository and tell git to remove the source and pom files:
 
-        cd helloworldws
-        git rm -r src pom.xml
+    cd helloworldws
+    git rm -r src pom.xml
 
-Copy the source for the `helloworld-ws` quickstart into this new git repository:
+Copy the source and POM file for the `helloworld-ws` quickstart into this new git repository:
 
-        cp -r <quickstarts>/helloworld-ws/src .
-        cp <quickstarts>/helloworld-ws/pom.xml .
+    cp -r QUICKSTART_HOME/helloworld-ws/src .
+    cp QUICKSTART_HOME/helloworld-ws/pom.xml .
         
 ### Configure the OpenShift Server
 
-Openshift does not have Web services setup by default, so we need to modify the server configuration. To do this open `.openshift/config/standalone.xml` (this file may be hidden) in an editor and make the following additions:
+Verify that Openshift has Web services configured by default. To do this: 
 
-1. If the webservices subsystem is not configured as below under the `<profile>` element, copy the following and replace the webservices subsystem to enable and configure Web Services:
+1. Open the hidden `.openshift/config/standalone.xml` file in an editor. 
+2. If the `webservices` subsystem is not configured as below under the `<profile>` element, copy the following and replace the `webservices` subsystem to enable and configure Web Services:
         
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
@@ -173,25 +188,25 @@ Openshift does not have Web services setup by default, so we need to modify the 
 
 You can now deploy the changes to your OpenShift application using git as follows:
 
-        git add src pom.xml
-        git commit -m "helloworld-ws quickstart on OpenShift"
-        git push
+    git add src pom.xml
+    git commit -m "helloworld-ws quickstart on OpenShift"
+    git push
 
 The final push command triggers the OpenShift infrastructure to build and deploy the changes. 
 
-Note that the `openshift` profile in `pom.xml` is activated by OpenShift, and causes the war build by openshift to be copied to the `deployments` directory, and deployed to the "jboss-helloworld-ws" context path.
+Note that the `openshift` profile in `pom.xml` file is activated by OpenShift and causes the WAR built by openshift to be copied to the `deployments/` directory and deployed to the "jboss-helloworld-ws" context path.
 
 ### Access the OpenShift Application
 
 Now you will start to tail the log files of the server. To do this run the following command, remembering to replace the application name and login id.
 
-        rhc app tail -a helloworldws
+    rhc app tail -a helloworldws
 
-Once the app is deployed, you can test the application by accessing the following URL either via a browser or using tools such as curl or wget. Be sure to replace the `quickstart` in the URL with your domain name.
+Once the application is deployed, you can test the application by accessing the following URL either via a browser or using tools such as curl or wget. Be sure to replace the `YOUR_DOMAIN_NAME` in the URL with your OpenShift account domain name.
 
-    http://helloworldws-quickstart.rhcloud.com/jboss-helloworld-ws/HelloWorldService?wsdl
+    http://helloworldws-YOUR_DOMAIN_NAME.rhcloud.com/jboss-helloworld-ws/HelloWorldService?wsdl
 
-If the application has run successfully you should see some output in the browser.
+If the application has run successfully you should see the WSDL output in the browser.
 
 You can use the OpenShift command line tools or the OpenShift web console to discover and control the application.
 
@@ -202,13 +217,18 @@ This quickstart provides tests that can be run remotely. By default, these tests
 _NOTE: The following commands assume you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line.._
 
 1. Make sure you have deployed the Application to Openshift as described above.
-2. Type the following command to run the test goal with the following profile activated and the URL of the deployed Application:
+2. Type the following command to run the test goal with the following profile activated and the URL of the deployed Application. Be sure to replaces `YOUR_DOMAIN_NAME` in the URL with your OpenShift account domain name:
 
-		mvn clean test -Pjbossas-remote -Dremote.server.url=http://helloworldws-quickstart.rhcloud.com/
+		mvn clean test -Pjbossas-remote -Dremote.server.url=http://helloworldws-YOUR_DOMAIN_NAME.rhcloud.com/
 
-### Destroy the OpenShift Application
+### Delete the OpenShift Application
 
-When you are finished with the application you can destroy it as follows:
+When you are finished with the application you can delete it from OpenShift as follows:
 
-        rhc app destroy -a helloworldws
+    rhc app-delete -a helloworldws
+
+_Note_: There is a limit to the number of applications you can deploy concurrently to OpenShift. If the `rhc app create` command returns an error indicating you have reached that limit, you must delete an existing application before you continue. 
+
+* To view the list of your OpenShift applications, type: `rhc domain show`
+* To delete an application from OpenShift, type the following, substituting the application name you want to delete: `rhc app-delete -a APPLICATION_NAME_TO_DELETE`
 

--- a/jax-rs-client/README.md
+++ b/jax-rs-client/README.md
@@ -93,12 +93,12 @@ To make this quickstart more interesting, deploy the RESTful service to OpenShif
 Build and Deploy the Quickstart - to OpenShift
 -------------------------
 
-_IMPORTANT_: This quickstart depends on the deployment of the `helloworld-rs` quickstart to OpenShift for its test. Follow the instructions [Build and Deploy the Quickstart - to OpenShift](../helloworld-rs/README.md#build-and-deploy-the-quickstart-to-openshift) in the helloworld-rs README to deploy that application to OpenShift. Do NOT yet follow the step "Destroy the OpenShift Application".
+_IMPORTANT_: This quickstart depends on the deployment of the `helloworld-rs` quickstart to OpenShift for its test. Follow the instructions [Build and Deploy the Quickstart - to OpenShift](../helloworld-rs/README.md#build-and-deploy-the-quickstart-to-openshift) in the helloworld-rs README to deploy that application to OpenShift. Do NOT yet follow the step "Delete the OpenShift Application".
 
-As it says in the helloworld-rs instructions, you can verify the deployment of the `helloworld-rs` quickstart by accessing the following content. Be sure to replace the `quickstart` in the URL with your domain name.
+As it says in the `helloworld-rs` instructions, you can verify the deployment of the `helloworld-rs` quickstart by accessing the following content. Be sure to replace the `YOUR_DOMAIN_NAME` in the URL with your domain name.
 
-* <http://helloworldrs-quickstart.rhcloud.com/rest/xml> if you want *xml* or
-* <http://helloworldrs-quickstart.rhcloud.com/rest/json> if you want *json*
+* <http://helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com/rest/xml> if you want *xml* or
+* <http://helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com/rest/json> if you want *json*
 
 
 ### Modify the jax-rs-client quickstart pom.xml
@@ -107,15 +107,15 @@ Now that you have deployed the application, it is time to make changes to the ja
 
 1. Open a shell command prompt and navigate to the `QUICKSTART_HOME/jax-rs-client/` directory.
 2. Make a backup copy of the `pom.xml` file.
-3. Open the `pom.xml` file in an editor and modify the `xmlUrl` and `jsonUrl` property values as follows. Be sure to replace the `quickstart` in the URL with your domain name.
+3. Open the `pom.xml` file in an editor and modify the `xmlUrl` and `jsonUrl` property values as follows. Be sure to replace the `YOUR_DOMAIN_NAME` in the URL with your OpenShift domain name.
 
         <property>
             <name>xmlUrl</name>
-            <value>http://helloworldrs-quickstart.rhcloud.com/rest/xml</value>
+            <value>http://helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com/rest/xml</value>
         </property>
         <property>
             <name>jsonUrl</name>
-            <value>http://helloworldrs-quickstart.rhcloud.com/rest/json</value>
+            <value>http://helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com/rest/json</value>
         </property>
 
 
@@ -128,7 +128,7 @@ Type the following command to run the jax-rs-client:
 This command will compile the example and execute a test to make two separate requests to the Web Service.  Towards the end of the Maven build output, you should see the following if the execution is successful:
 
         ===============================================
-        URL: http://helloworldrs-quickstart.rhcloud.com/rest/xml
+        URL: http://helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com/rest/xml
         MediaType: application/xml
 
         *** Response from Server ***
@@ -137,7 +137,7 @@ This command will compile the example and execute a test to make two separate re
 
         ===============================================
         ===============================================
-        URL: http://helloworldrs-quickstart.rhcloud.com/rest/json
+        URL: http://helloworldrs-YOUR_DOMAIN_NAME.rhcloud.com/rest/json
         MediaType: application/json
 
         *** Response from Server ***
@@ -148,13 +148,14 @@ This command will compile the example and execute a test to make two separate re
 
 When you are finished testing, restore the `pom.xml` file to the previous version if you want to test locally.
 
-### Destroy the OpenShift Application
+### Delete the OpenShift Application
 
-When you are finished with the application you can destroy it as follows:
+When you are finished with the application you can delete it from OpenShift as follows:
 
-        rhc app destroy -a helloworldrs
+        rhc app-delete -a helloworldrs
 
-_Note_: There is a limit to the number of applications you can deploy concurrently to OpenShift. If the `rhc app create` command returns an error indicating you have reached that limit, you must destroy an existing application before you continue. 
+_Note_: There is a limit to the number of applications you can deploy concurrently to OpenShift. If the `rhc app create` command returns an error indicating you have reached that limit, you must delete an existing application before you continue. 
 
 * To view the list of your OpenShift applications, type: `rhc domain show`
-* To destroy an existing application, type the following, substituting the application name you want to destroy: `rhc app destroy -a APPLICATION_NAME_TO_DESTROY`
+* To delete an application from OpenShift, type the following, substituting the application name you want to delete: `rhc app-delete -a APPLICATION_NAME_TO_DELETE`
+

--- a/template/README.md
+++ b/template/README.md
@@ -187,24 +187,40 @@ If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](h
 
 ### Create the OpenShift Application
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss EAP 6.1:
+Note that we use `USER_DOMAIN_NAME` for these examples. You need to substitute it with your own OpenShift account user name.
 
-    rhc app create -a APPLICATION_NAME -t APPLICATION_TYPE
+Open a shell command prompt and change to a directory of your choice. Enter the following command to create a JBoss EAP 6 application:
 
-_NOTE_: The domain name for this application will be APPLICATION_NAME-YOUR_DOMAIN_NAME.rhcloud.com`. Here we use the _quickstart_ domain. You will need to replace it with your own OpenShift domain name.
+    rhc app create -a APPLICATION_NAME -t jbosseap-6
 
-This command creates an OpenShift application named  and will run the application inside the `jbosseap-6`  container. You should see some output similar to the following:
+_NOTE_: The domain name for this application will be APPLICATION_NAME-YOUR_DOMAIN_NAME.rhcloud.com`. Be sure to replace `YOUR_DOMAIN_NAME` with your own OpenShift account user name.
 
-    Creating application: APPLICATION_NAME
-    Now your new domain name is being propagated worldwide (this might take a minute)...
-    Warning: Permanently added 'APPLICATION_NAME-quickstart.rhcloud.com,107.22.36.32' (RSA) to the list of known hosts.
-    Confirming application 'APPLICATION_NAME' is available:  Success!
-    
-    APPLICATION_NAME published:  http://APPLICATION_NAME-quickstart.rhcloud.com/
-    git url:  ssh://b92047bdc05e46c980cc3501c3577c1e@APPLICATION_NAME-quickstart.rhcloud.com/~/git/APPLICATION_NAME.git/
-    Successfully created application: APPLICATION_NAME
+This command creates an OpenShift application named APPLICATION_NAME and will run the application inside the `jbosseap-6`  container. You should see some output similar to the following:
 
-The create command creates a git repository in the current directory with the same name as the application. Notice that the output also reports the URL at which the application can be accessed. Make sure it is available by typing the published url <http://APPLICATION_NAME-quickstart.rhcloud.com/> into a browser or use command line tools such as curl or wget.
+    Application Options
+    -------------------
+      Namespace:  YOUR_DOMAIN_NAME
+      Cartridges: jbosseap-6 (addtl. costs may apply)
+      Gear Size:  default
+      Scaling:    no
+
+    Creating application 'APPLICATION_NAME' ... done
+
+    Waiting for your DNS name to be available ... done
+
+    Cloning into 'APPLICATION_NAME'...
+    Warning: Permanently added the RSA host key for IP address '54.237.58.0' to the list of known hosts.
+
+    Your application 'APPLICATION_NAME' is now available.
+
+      URL:        http://APPLICATION_NAME-YOUR_DOMAIN_NAME.rhcloud.com/
+      SSH to:     52864af85973ca430200006f@APPLICATION_NAME-YOUR_DOMAIN_NAME.rhcloud.com
+      Git remote: ssh://52864af85973ca430200006f@APPLICATION_NAME-YOUR_DOMAIN_NAME.rhcloud.com/~/git/APPLICATION_NAME.git/
+      Cloned to:  CURRENT_DIRECTORY/APPLICATION_NAME
+
+    Run 'rhc show-app APPLICATION_NAME' for more details about your app.
+
+The create command creates a git repository in the current directory with the same name as the application. Notice that the output also reports the URL at which the application can be accessed. Make sure it is available by typing the published url <http://APPLICATION_NAME-quickstart.rhcloud.com/> into a browser or use command line tools such as curl or wget. Be sure to replace `YOUR_DOMAIN_NAME` with your OpenShift account domain name.
 
 ### Migrate the Quickstart Source
 
@@ -232,23 +248,24 @@ You can now deploy the changes to your OpenShift application using git as follow
 
 The final push command triggers the OpenShift infrastructure to build and deploy the changes. 
 
-Note that the `openshift` profile in `pom.xml` is activated by OpenShift, and causes the war build by openshift to be copied to the `deployments` directory, and deployed without a context path.
+Note that the `openshift` profile in `pom.xml` is activated by OpenShift, and causes the war build by openshift to be copied to the `deployments/` directory, and deployed without a context path.
 
 ### Test the OpenShift Application
 
 When the push command returns you can test the application by getting the following URL either via a browser or using tools such as curl or wget:
 
-* <http://APPLICATION_NAME-quickstart.rhcloud.com/> 
+* <http://APPLICATION_NAME-YOUR_DOMAIN_NAME.rhcloud.com/> 
 
 You can use the OpenShift command line tools or the OpenShift web console to discover and control the application.
 
-### Destroy the OpenShift Application
+### Delete the OpenShift Application
 
-When you are finished with the application you can destroy it as follows:
+When you are finished with the application you can delete it as follows:
 
-        rhc app destroy -a APPLICATION_NAME
+        rhc app-delete -a APPLICATION_NAME
 
-_Note_: There is a limit to the number of applications you can deploy concurrently to OpenShift. If the `rhc app create` command returns an error indicating you have reached that limit, you must destroy an existing application before you continue. 
+_Note_: There is a limit to the number of applications you can deploy concurrently to OpenShift. If the `rhc app create` command returns an error indicating you have reached that limit, you must delete an existing application before you continue. 
 
 * To view the list of your OpenShift applications, type: `rhc domain show`
-* To destroy an existing application, type the following, substituting the application name you want to destroy: `rhc app destroy -a APPLICATION_NAME_TO_DESTROY`
+* To delete an application from OpenShift, type the following, substituting the application name you want to delete: `rhc app-delete -a APPLICATION_NAME_TO_DELETE`
+

--- a/wsat-simple/README.md
+++ b/wsat-simple/README.md
@@ -143,26 +143,43 @@ Build and Deploy the Quickstart - to OpenShift
 ### Create an OpenShift Express Account and Domain
 
 If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](https://openshift.redhat.com/app/login) to create the account and domain. [Get Started with OpenShift](https://www.openshift.com/get-started) will show you how to install the OpenShift Express command line interface.
+
 ### Create the OpenShift Application
 
-Note that we use the `jboss-as-quickstart@jboss.org` user for these examples. You need to substitute it with your own user name.
+Note that we use `USER_DOMAIN_NAME` for these examples. You need to substitute it with your own OpenShift account user name.
 
-Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6` for quickstarts running on JBoss EAP:
+Open a shell command prompt and change to a directory of your choice. Enter the following command to create a JBoss EAP 6 application:
 
-    rhc app create -a wsatsimple -t APPLICATION_TYPE
+    rhc app create -a wsatsimple -t jbosseap-6
 
-_NOTE_: The domain name for this application will be `wsatsimple-YOUR_DOMAIN_NAME.rhcloud.com`. Here we use the _quickstart_ domain. You will need to replace it with your own OpenShift domain name.
+_NOTE_: The domain name for this application will be `wsatsimple-YOUR_DOMAIN_NAME.rhcloud.com`. Be sure to replace `YOUR_DOMAIN_NAME` with your own OpenShift account user name.
 
 This command creates an OpenShift application called `wsatsimple` and will run the application inside the `jbosseap-6` container. You should see some output similar to the following:
 
-    Creating application: wsatsimple
-    Now your new domain name is being propagated worldwide (this might take a minute)...
-    Warning: Permanently added the RSA host key for IP address '23.20.102.147' to the list of known hosts.
-    Confirming application 'wsatsimple' is available:  Success!
-    
-    wsatsimple published:  http://wsatsimple-quickstart.rhcloud.com/
-    git url:  ssh://76f095330e3f49af97a52e513a9c966b@wsatsimple-quickstart.rhcloud.com/~/git/wsatsimple.git/
-    Successfully created application: wsatsimple
+    Application Options
+    -------------------
+      Namespace:  YOUR_DOMAIN_NAME
+      Cartridges: jbosseap-6 (addtl. costs may apply)
+      Gear Size:  default
+      Scaling:    no
+
+    Creating application 'wsatsimple' ... done
+
+    Waiting for your DNS name to be available ... done
+
+    Cloning into 'wsatsimple'...
+    Warning: Permanently added the RSA host key for IP address '54.237.58.0' to the list of known hosts.
+
+    Your application 'wsatsimple' is now available.
+
+      URL:        http://wsatsimple-YOUR_DOMAIN_NAME.rhcloud.com/
+      SSH to:     52864af85973ca430200006f@wsatsimple-YOUR_DOMAIN_NAME.rhcloud.com
+      Git remote: ssh://52864af85973ca430200006f@wsatsimple-YOUR_DOMAIN_NAME.rhcloud.com/~/git/wsatsimple.git/
+      Cloned to:  CURRENT_DIRECTORY/wsatsimple
+
+    Run 'rhc show-app wsatsimple' for more details about your app.
+
+The create command creates a git repository in the current directory with the same name as the application, in this case, `wsatsimple`. Notice that the output also reports the URL at which the application can be accessed. Make sure it is available by typing the published url <http://wsatsimple-YOUR_DOMAIN_NAME.rhcloud.com/> into a browser or use command line tools such as curl or wget. Be sure to replace `YOUR_DOMAIN_NAME` with your OpenShift account domain name.
 
 ### Migrate the Quickstart Source
 
@@ -171,27 +188,27 @@ Now that you have confirmed it is working you can migrate the quickstart source.
         cd wsatsimple
         git rm -r src pom.xml
 
-Copy the source for the wsat-simple quickstart into this new git repo:
+Copy the source for the `wsat-simple` quickstart into this new git repo:
 
         cp -r <quickstarts>/wsat-simple/src .
         cp <quickstarts>/wsat-simple/pom.xml .
 
 ### Configure the OpenShift Server
 
-Openshift does not have Web services or WS-AT enabled by default, so we need to modify the server configuration. To do this open `.openshift/config/standalone.xml` (this file may be hidden) in an editor and make the following additions:
+Openshift does not have Web services or WS-AT enabled by default, so we need to modify the server configuration. To do this:
 
-1. If the following extensions do not exist, add them under the `<extensions>` element: 
+1. Open the hidden `.openshift/config/standalone.xml` file in an editor. 
+2. If the following extensions do not exist, add them under the `<extensions>` element: 
 
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.xts"/>
-
-2. If the jmx subsystem is not configured under the `<profile>` element, copy the following under the `<profile>` element to enable and configure JMX:
+3. If the `jmx` subsystem is not configured under the `<profile>` element, copy the following under the `<profile>` element to enable and configure JMX:
 
         <subsystem xmlns="urn:jboss:domain:jmx:1.1">
             <show-model value="true"/>
             <remoting-connector/>
         </subsystem>
-3. If the webservices subsystem is not configured under the `<profile>` element, copy the following under the `<profile>` element to enable and configure Web Services:
+4. If the `webservices` subsystem is not configured under the `<profile>` element, copy the following under the `<profile>` element to enable and configure Web Services:
         
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
@@ -207,7 +224,7 @@ Openshift does not have Web services or WS-AT enabled by default, so we need to 
         <subsystem xmlns="urn:jboss:domain:xts:1.0">
             <xts-environment url="http://${OPENSHIFT_INTERNAL_IP}:8080/ws-c11/ActivationService"/>
         </subsystem>
-4. To reduce the amount of logging and make it easier to read the logs produced by this quickstart, edit the log level by adding the following block just below the other blocks:
+5. To reduce the amount of logging and make it easier to read the logs produced by this quickstart, edit the log level by adding the following block just below the other blocks:
 
         <logger category="org.apache.cxf.service.factory.ReflectionServiceFactoryBean">
             <level name="WARN"/>
@@ -239,10 +256,10 @@ OpenShift will build the application using Maven, and deploy it to JBoss EAP. If
     remote: Starting application...
     remote: Done
     remote: Running .openshift/action_hooks/post_deploy
-    To ssh://1e63c17c2dd94a329f21555a33dc617d@wsatsimple-quickstart.rhcloud.com/~/git/wsatsimple.git/
+    To ssh://1e63c17c2dd94a329f21555a33dc617d@wsatsimple-YOUR_DOMAIN_NAME.rhcloud.com/~/git/wsatsimple.git/
        e6f80bd..63504b9  master -> master
 
-Note that the `openshift` profile in the `pom.xml` file is activated by OpenShift. This causes the WAR built by OpenShift to be copied to the `deployments` directory and deployed without a context path.
+Note that the `openshift` profile in the `pom.xml` file is activated by OpenShift. This causes the WAR built by OpenShift to be copied to the `deployments/` directory and deployed without a context path.
 
 ### Test the OpenShift Application
 
@@ -250,25 +267,22 @@ Now you will start to tail the log files of the server. To do this run the follo
 
         rhc app tail -a wsatsimple
 
-Once the app is deployed, you can test the application by accessing the following URL either via a browser or using tools such as curl or wget. Be sure to replace the `quickstart` in the URL with your domain name.
+Once the app is deployed, you can test the application by accessing the following URL either via a browser or using tools such as curl or wget. Be sure to replace the `YOUR_DOMAIN_NAME` in the URL with your OpenShift account domain name.
 
-    http://wsatsimple-quickstart.rhcloud.com/WSATSimpleServletClient
+    http://wsatsimple-YOUR_DOMAIN_NAME.rhcloud.com/WSATSimpleServletClient
 
 If the application has run successfully you should see some output in the browser. You should also see some output on the server log, similar to the output from the "Test commit" test above.
 
 You can use the OpenShift command line tools or the OpenShift web console to discover and control the application.
 
-### Destroy the OpenShift Application
+### Delete the OpenShift Application
 
-When you are finished with the application you can destroy it as follows:
+When you are finished with the application you can delete it from OpenShift as follows:
 
-        rhc app destroy -a wsatsimple
+        rhc app-delete -a wsatsimple
 
-To view the list of your current OpenShift applications, type:
-
-        rhc domain
-
-_Note_: There is a limit to the number of applications you can deploy concurrently to OpenShift. If the `rhc app create` command returns an error indicating you have reached that limit, you must destroy an existing application before you continue. 
+_Note_: There is a limit to the number of applications you can deploy concurrently to OpenShift. If the `rhc app create` command returns an error indicating you have reached that limit, you must delete an existing application before you continue. 
 
 * To view the list of your OpenShift applications, type: `rhc domain show`
-* To destroy an existing application, type the following, substituting the application name you want to destroy: `rhc app destroy -a APPLICATION_NAME_TO_DESTROY`
+* To delete an application from OpenShift, type the following, substituting the application name you want to delete: `rhc app-delete -a APPLICATION_NAME_TO_DELETE`
+


### PR DESCRIPTION
OpenShift output has changed and the destroy command is deprecated in favor of app-delete. Modifed the instructions to reflect this.
