### PR TITLE
use maven property project.groupId instead of having hardcoded in dependencies

### DIFF
--- a/ejb-multi-server/app-main/ear/pom.xml
+++ b/ejb-multi-server/app-main/ear/pom.xml
@@ -41,13 +41,13 @@
     <dependencies>
   <!-- add the EJB and WEB project as dependency to include it in the EAR -->
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jboss-ejb-multi-server-app-main-ejb</artifactId>
             <type>ejb</type>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jboss-ejb-multi-server-app-main-web</artifactId>
             <type>war</type>
             <version>${project.version}</version>
@@ -77,23 +77,23 @@
                     <initializeInOrder>true</initializeInOrder>
                     <modules>
                         <ejbModule>
-                            <groupId>org.jboss.quickstarts.eap</groupId>
+                            <groupId>${project.groupId}</groupId>
                             <artifactId>jboss-ejb-multi-server-app-main-ejb</artifactId>
                             <bundleFileName>ejb.jar</bundleFileName>
                         </ejbModule>
                         <webModule>
-                            <groupId>org.jboss.quickstarts.eap</groupId>
+                            <groupId>${project.groupId}</groupId>
                             <artifactId>jboss-ejb-multi-server-app-main-web</artifactId>
                             <bundleFileName>jsf.war</bundleFileName>
                         </webModule>
             <!-- add the necessary EJB client interfaces of AppOne and AppTwo to the lib directory of the EAR -->
                         <ejbClientModule>
-                            <groupId>org.jboss.quickstarts.eap</groupId>
+                            <groupId>${project.groupId}</groupId>
                             <artifactId>jboss-ejb-multi-server-app-one-ejb</artifactId>
                             <bundleDir>lib</bundleDir>
                         </ejbClientModule>
                         <ejbClientModule>
-                            <groupId>org.jboss.quickstarts.eap</groupId>
+                            <groupId>${project.groupId}</groupId>
                             <artifactId>jboss-ejb-multi-server-app-two-ejb</artifactId>
                             <bundleDir>lib</bundleDir>
                         </ejbClientModule>

--- a/ejb-multi-server/app-main/ejb/pom.xml
+++ b/ejb-multi-server/app-main/ejb/pom.xml
@@ -45,18 +45,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
-            <artifactId>
-        jboss-ejb-multi-server-app-one-ejb
-      </artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-one-ejb</artifactId>
             <version>${project.version}</version>
             <type>ejb-client</type>
         </dependency>
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
-            <artifactId>
-        jboss-ejb-multi-server-app-two-ejb
-      </artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-two-ejb</artifactId>
             <version>${project.version}</version>
             <type>ejb-client</type>
         </dependency>

--- a/ejb-multi-server/app-main/web/pom.xml
+++ b/ejb-multi-server/app-main/web/pom.xml
@@ -45,28 +45,22 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
-            <artifactId>
-        jboss-ejb-multi-server-app-main-ejb
-      </artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-main-ejb</artifactId>
             <version>${project.version}</version>
             <type>ejb-client</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
-            <artifactId>
-        jboss-ejb-multi-server-app-one-ejb
-      </artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-one-ejb</artifactId>
             <version>${project.version}</version>
             <type>ejb-client</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
-            <artifactId>
-        jboss-ejb-multi-server-app-two-ejb
-      </artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-two-ejb</artifactId>
             <version>${project.version}</version>
             <type>ejb-client</type>
             <scope>provided</scope>

--- a/ejb-multi-server/app-one/ear/pom.xml
+++ b/ejb-multi-server/app-one/ear/pom.xml
@@ -36,7 +36,7 @@
     </licenses>
     <dependencies>
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jboss-ejb-multi-server-app-one-ejb</artifactId>
             <type>ejb</type>
             <version>${project.version}</version>
@@ -65,7 +65,7 @@
                     <generateApplicationXml>true</generateApplicationXml>
                     <modules>
                         <ejbModule>
-                            <groupId>org.jboss.quickstarts.eap</groupId>
+                            <groupId>${project.groupId}</groupId>
                             <artifactId>jboss-ejb-multi-server-app-one-ejb</artifactId>
                             <bundleFileName>ejb.jar</bundleFileName>
                         </ejbModule>

--- a/ejb-multi-server/app-two/ear/pom.xml
+++ b/ejb-multi-server/app-two/ear/pom.xml
@@ -37,7 +37,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jboss-ejb-multi-server-app-two-ejb</artifactId>
             <type>ejb</type>
             <version>${project.version}</version>
@@ -66,7 +66,7 @@
                     <generateApplicationXml>true</generateApplicationXml>
                     <modules>
                         <ejbModule>
-                            <groupId>org.jboss.quickstarts.eap</groupId>
+                            <groupId>${project.groupId}</groupId>
                             <artifactId>jboss-ejb-multi-server-app-two-ejb</artifactId>
                             <bundleFileName>ejb.jar</bundleFileName>
                         </ejbModule>

--- a/ejb-multi-server/app-web/pom.xml
+++ b/ejb-multi-server/app-web/pom.xml
@@ -53,26 +53,20 @@
          The API jar files will be packed into the lib directory of the WAR archive. 
      -->
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
-            <artifactId>
-        jboss-ejb-multi-server-app-main-ejb
-      </artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-main-ejb</artifactId>
             <version>${project.version}</version>
             <type>ejb-client</type>
         </dependency>
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
-            <artifactId>
-        jboss-ejb-multi-server-app-one-ejb
-      </artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-one-ejb</artifactId>
             <version>${project.version}</version>
             <type>ejb-client</type>
         </dependency>
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
-            <artifactId>
-        jboss-ejb-multi-server-app-two-ejb
-      </artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-two-ejb</artifactId>
             <version>${project.version}</version>
             <type>ejb-client</type>
         </dependency>

--- a/ejb-multi-server/client/pom.xml
+++ b/ejb-multi-server/client/pom.xml
@@ -40,7 +40,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jboss-ejb-multi-server-app-main-ejb</artifactId>
             <version>${project.version}</version>
             <type>ejb-client</type>


### PR DESCRIPTION
avoid problems if the projects groupId is changed
