### PR TITLE
Missing ID tag in profile to work with the activeProfiles tag.

### DIFF
--- a/contributor-settings.xml
+++ b/contributor-settings.xml
@@ -50,6 +50,7 @@
         </pluginRepository>
       </pluginRepositories>
     </profile>
+    
     <!-- Configure the JBoss Early Access Maven repository -->
     <profile>
       <id>jboss-earlyaccess-repository</id>
@@ -78,32 +79,34 @@
         </pluginRepository>
       </pluginRepositories>
     </profile>
+    
     <!-- Configure the JBoss Developer Temporary Maven repository -->
     <profile>
-        <repositories>
-            <repository>
-                <id>jboss-developer-repository</id>
-                <url>http://jboss-developer.github.io/temp-maven-repo/</url>
-                <releases>
-                   <enabled>true</enabled>
-                </releases>
-                <snapshots>
-                  <enabled>false</enabled>
-                </snapshots>
-            </repository>
-        </repositories>
-        <pluginRepositories>
-            <pluginRepository>
-                <id>jboss-developer-plugin-repository</id>
-                <url>http://jboss-developer.github.io/temp-maven-repo/</url>
-                <releases>
-                  <enabled>true</enabled>
-                </releases>
-                <snapshots>
-                  <enabled>false</enabled>
-                </snapshots>
-            </pluginRepository>
-        </pluginRepositories>
+      <id>jboss-developer-repository</id>
+      <repositories>
+        <repository>
+          <id>jboss-developer-repository</id>
+          <url>http://jboss-developer.github.io/temp-maven-repo/</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>jboss-developer-plugin-repository</id>
+          <url>http://jboss-developer.github.io/temp-maven-repo/</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
     </profile>
 
   </profiles>


### PR DESCRIPTION
Build was failing if the temporary repo isn't active. It's in the <activeProfiles> tag, so I'm assuming the <id> tag in the profile was mistakenly left out. Also matched that profile's indentation with the others. 
