### PR TITLE
add example of TransactionAttributeType.REQUIRES_NEW

### DIFF
--- a/cmt/src/main/java/org/jboss/as/quickstarts/cmt/controller/LogMessageManager.java
+++ b/cmt/src/main/java/org/jboss/as/quickstarts/cmt/controller/LogMessageManager.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cmt.controller;
+
+import java.util.List;
+
+import javax.faces.bean.RequestScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.naming.NamingException;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+
+import org.jboss.as.quickstarts.cmt.ejb.LogMessageManagerEJB;
+import org.jboss.as.quickstarts.cmt.model.LogMessage;
+
+@Named("logMessageManager")
+@RequestScoped
+public class LogMessageManager {
+	@Inject
+	private LogMessageManagerEJB logMessageManager;
+
+	public List<LogMessage> getLogMessages() throws SecurityException, IllegalStateException,
+			NamingException, NotSupportedException, SystemException, RollbackException,
+			HeuristicMixedException, HeuristicRollbackException {
+		return logMessageManager.listLogMessages();
+	}
+}

--- a/cmt/src/main/java/org/jboss/as/quickstarts/cmt/ejb/LogMessageManagerEJB.java
+++ b/cmt/src/main/java/org/jboss/as/quickstarts/cmt/ejb/LogMessageManagerEJB.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cmt.ejb;
+
+import java.rmi.RemoteException;
+import java.util.List;
+
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.jms.JMSException;
+import javax.naming.NamingException;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+
+import org.jboss.as.quickstarts.cmt.model.LogMessage;
+
+@Stateless
+public class LogMessageManagerEJB {
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+	public void logCreateCustomer(String name) throws RemoteException, JMSException {
+		LogMessage lm = new LogMessage();
+		lm.setMessage("Attempt to create record for customer: '" + name + "'");
+		entityManager.persist(lm);
+	}
+
+	@TransactionAttribute(TransactionAttributeType.REQUIRED)
+	public void blaMethod() throws RemoteException, JMSException {
+		logCreateCustomer("Niks");
+	}
+
+	/**
+	 * List all the log-messages.
+	 * 
+	 * @return
+	 * @throws NamingException
+	 * @throws NotSupportedException
+	 * @throws SystemException
+	 * @throws SecurityException
+	 * @throws IllegalStateException
+	 * @throws RollbackException
+	 * @throws HeuristicMixedException
+	 * @throws HeuristicRollbackException
+	 */
+	@TransactionAttribute(TransactionAttributeType.NEVER)
+	@SuppressWarnings("unchecked")
+	public List<LogMessage> listLogMessages() {
+		return entityManager.createQuery("select lm from LogMessage lm").getResultList();
+	}
+}

--- a/cmt/src/main/java/org/jboss/as/quickstarts/cmt/model/LogMessage.java
+++ b/cmt/src/main/java/org/jboss/as/quickstarts/cmt/model/LogMessage.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cmt.model;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "LogMessage")
+public class LogMessage implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue
+	private int id;
+
+	@Column(unique = true, nullable = false)
+	private String message;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String name) {
+		this.message = name;
+	}
+}

--- a/cmt/src/main/webapp/logMessages.xhtml
+++ b/cmt/src/main/webapp/logMessages.xhtml
@@ -23,19 +23,22 @@
 <ui:composition template="template.xhtml">
 	<ui:define name="content">
 		<h:messages />
-		<h:form id="addCustomerForm">
-			<h:panelGrid columns="3">
-				<h:outputLabel for="name">Name:</h:outputLabel>
-				<h:inputText value="#{name}" />
-				<h:commandButton id="add" value="Add"
-					action="#{customerManager.addCustomer(name)}">
-				</h:commandButton>
-			</h:panelGrid>
-		</h:form>
-		<ul>
-			<li><h:link outcome="/customers.xhtml">List customers</h:link></li>
-			<li><h:link outcome="/logMessages.xhtml">List log messages</h:link></li>
-		</ul>
+		<h1>List of log-messages</h1>
+		<h:dataTable value="#{logMessageManager.logMessages}" var="lm">
+			<h:column>
+				<f:facet name="header">
+               Message
+            </f:facet>
+				<h:outputText value="#{lm.message}" />
+			</h:column>
+			<h:column>
+				<f:facet name="header">
+               Id
+            </f:facet>
+				<h:outputText value="#{lm.id}" />
+			</h:column>
+		</h:dataTable>
+		<a href="javascript:history.back(-1)">Go Back</a>
 	</ui:define>
 </ui:composition>
 </html>


### PR DESCRIPTION
An example to show how a method marked with TransactionAttributeType.REQUIRES_NEW does commit a record while the former transaction can still fail.
One can see this by running the application and adding a 'customer' whose name starts with a 'p'. This will result in a LogMessage-record in the database but not a customer-record neither will a JMS-message be delivered.

Signed-off-by: Gerke - Ephorus gerke.ephorus@gmail.com
