### PR TITLE
add example of TransactionAttributeType.REQUIRES_NEW (attempt 2)

### DIFF
--- a/cmt/README.md
+++ b/cmt/README.md
@@ -104,6 +104,11 @@ After a user is successfully added to the database, a message is produced contai
 
     Received Message: Created invoice for customer named:  Tom
 
+When the same customer name is given, a duplicate warning is given and no JMS-message is send to cause the above message.
+
+The customer name should match: letter & '-', else an error is given. This is to show that a 'LogMessage' entity is still stored in the database thanks to the ```@TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)```
+that the method logCreateCustomer in the EJB LogMessageManagerEJB is decorated with. 
+ 
 
 Server Log: Expected warnings and errors
 -----------------------------------

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 
@@ -16,14 +16,14 @@
     limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.quickstarts.eap</groupId>
     <artifactId>jboss-cmt</artifactId>
     <version>6.2.0-redhat-SNAPSHOT</version>
+    <packaging>war</packaging>
     <name>JBoss EAP Quickstart: cmt</name>
     <description>CMT: Using transactions managed by the container</description>
-    <packaging>war</packaging>
-
     <url>http://jboss.org/jbossas</url>
     <licenses>
         <license>
@@ -32,7 +32,6 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
     </licenses>
-
     <properties>
         <!-- Explicitly declaring the source encoding eliminates the following 
             message: -->
@@ -54,7 +53,6 @@
         <maven.compiler.target>1.6</maven.compiler.target>
         <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
-
     <dependencyManagement>
         <dependencies>
             <!-- JBoss distributes a complete set of Java EE 6 APIs including 
@@ -72,7 +70,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <!-- Import the JPA API, we use provided scope as the API is included in JBoss EAP 6 -->
         <dependency>
@@ -119,7 +116,6 @@
         </dependency>
 
     </dependencies>
-
     <build>
         <!-- Maven will append the version to the finalName (which is the 
             name given to the generated war, and hence the context root) -->

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -110,6 +110,14 @@
             <artifactId>javax.inject</artifactId>
             <scope>provided</scope>
         </dependency>
+        
+        <!-- Needed for running tests (you may also use TestNG) -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/cmt/src/main/java/org/jboss/as/quickstarts/cmt/controller/CustomerManager.java
+++ b/cmt/src/main/java/org/jboss/as/quickstarts/cmt/controller/CustomerManager.java
@@ -50,6 +50,10 @@ public class CustomerManager {
             customerManager.createCustomer(name);
             return "customerAdded";
         } catch (Exception e) {
+            if (e.getMessage().contains("Invalid name")) {
+                logger.warning("Invalid name: " + e.getMessage());
+                return "customerInvalidName";
+            }
             logger.warning("Caught a duplicate: " + e.getMessage());
             // Transaction will be marked rollback only anyway utx.rollback();
             return "customerDuplicate";

--- a/cmt/src/main/java/org/jboss/as/quickstarts/cmt/controller/CustomerManager.java
+++ b/cmt/src/main/java/org/jboss/as/quickstarts/cmt/controller/CustomerManager.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
  * contributors by the @authors tag. See the copyright.txt in the
  * distribution for a full listing of individual contributors.
  *
@@ -41,7 +41,7 @@ public class CustomerManager {
     private CustomerManagerEJB customerManager;
 
     public List<Customer> getCustomers() throws SecurityException, IllegalStateException, NamingException,
-            NotSupportedException, SystemException, RollbackException, HeuristicMixedException, HeuristicRollbackException {
+        NotSupportedException, SystemException, RollbackException, HeuristicMixedException, HeuristicRollbackException {
         return customerManager.listCustomers();
     }
 

--- a/cmt/src/main/java/org/jboss/as/quickstarts/cmt/controller/LogMessageManager.java
+++ b/cmt/src/main/java/org/jboss/as/quickstarts/cmt/controller/LogMessageManager.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cmt.controller;
+
+import java.util.List;
+
+import javax.faces.bean.RequestScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.naming.NamingException;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+
+import org.jboss.as.quickstarts.cmt.ejb.LogMessageManagerEJB;
+import org.jboss.as.quickstarts.cmt.model.LogMessage;
+
+@Named("logMessageManager")
+@RequestScoped
+public class LogMessageManager {
+    @Inject
+    private LogMessageManagerEJB logMessageManager;
+
+    public List<LogMessage> getLogMessages() throws SecurityException, IllegalStateException,
+        NamingException, NotSupportedException, SystemException, RollbackException,
+        HeuristicMixedException, HeuristicRollbackException {
+        return logMessageManager.listLogMessages();
+    }
+}

--- a/cmt/src/main/java/org/jboss/as/quickstarts/cmt/ejb/CustomerManagerEJB.java
+++ b/cmt/src/main/java/org/jboss/as/quickstarts/cmt/ejb/CustomerManagerEJB.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
  * contributors by the @authors tag. See the copyright.txt in the
  * distribution for a full listing of individual contributors.
  *

--- a/cmt/src/main/java/org/jboss/as/quickstarts/cmt/ejb/InvoiceManagerEJB.java
+++ b/cmt/src/main/java/org/jboss/as/quickstarts/cmt/ejb/InvoiceManagerEJB.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
  * contributors by the @authors tag. See the copyright.txt in the
  * distribution for a full listing of individual contributors.
  *

--- a/cmt/src/main/java/org/jboss/as/quickstarts/cmt/ejb/LogMessageManagerEJB.java
+++ b/cmt/src/main/java/org/jboss/as/quickstarts/cmt/ejb/LogMessageManagerEJB.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
  * contributors by the @authors tag. See the copyright.txt in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,11 +19,9 @@ package org.jboss.as.quickstarts.cmt.ejb;
 import java.rmi.RemoteException;
 import java.util.List;
 
-import javax.ejb.EJBException;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
-import javax.inject.Inject;
 import javax.jms.JMSException;
 import javax.naming.NamingException;
 import javax.persistence.EntityManager;
@@ -34,44 +32,27 @@ import javax.transaction.NotSupportedException;
 import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
 
-import org.jboss.as.quickstarts.cmt.model.Customer;
+import org.jboss.as.quickstarts.cmt.model.LogMessage;
 
 @Stateless
-public class CustomerManagerEJB {
-
+public class LogMessageManagerEJB {
     @PersistenceContext
     private EntityManager entityManager;
 
-    @Inject
-    private LogMessageManagerEJB logMessageManager;
-
-    @Inject
-    private InvoiceManagerEJB invoiceManager;
-
-    @TransactionAttribute(TransactionAttributeType.REQUIRED)
-    public void createCustomer(String name) throws RemoteException, JMSException {
-        logMessageManager.logCreateCustomer(name);
-
-        Customer c1 = new Customer();
-        c1.setName(name);
-        entityManager.persist(c1);
-
-        invoiceManager.createInvoice(name);
-
-        // It could be done before all the 'storing' but this is just to show that
-        // the invoice is not delivered when we cause an EJBException
-        // after the fact but before the transaction is committed.
-        if (!nameIsValid(name)) {
-            throw new EJBException("Invalid name: customer names should only contain letters & '-'");
-        }
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public void logCreateCustomer(String name) throws RemoteException, JMSException {
+        LogMessage lm = new LogMessage();
+        lm.setMessage("Attempt to create record for customer: '" + name + "'");
+        entityManager.persist(lm);
     }
 
-    static boolean nameIsValid(String name) {
-        return name.matches("[\\p{L}-]+");
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public void blaMethod() throws RemoteException, JMSException {
+        logCreateCustomer("Niks");
     }
 
     /**
-     * List all the customers.
+     * List all the log-messages.
      * 
      * @return
      * @throws NamingException
@@ -85,7 +66,7 @@ public class CustomerManagerEJB {
      */
     @TransactionAttribute(TransactionAttributeType.NEVER)
     @SuppressWarnings("unchecked")
-    public List<Customer> listCustomers() {
-        return entityManager.createQuery("select c from Customer c").getResultList();
+    public List<LogMessage> listLogMessages() {
+        return entityManager.createQuery("select lm from LogMessage lm").getResultList();
     }
 }

--- a/cmt/src/main/java/org/jboss/as/quickstarts/cmt/mdb/HelloWorldMDB.java
+++ b/cmt/src/main/java/org/jboss/as/quickstarts/cmt/mdb/HelloWorldMDB.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
  * contributors by the @authors tag. See the copyright.txt in the
  * distribution for a full listing of individual contributors.
  *

--- a/cmt/src/main/java/org/jboss/as/quickstarts/cmt/model/Customer.java
+++ b/cmt/src/main/java/org/jboss/as/quickstarts/cmt/model/Customer.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
  * contributors by the @authors tag. See the copyright.txt in the
  * distribution for a full listing of individual contributors.
  *

--- a/cmt/src/main/java/org/jboss/as/quickstarts/cmt/model/LogMessage.java
+++ b/cmt/src/main/java/org/jboss/as/quickstarts/cmt/model/LogMessage.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cmt.model;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "LogMessage")
+public class LogMessage implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue
+    private int id;
+
+    @Column(unique = true, nullable = false)
+    private String message;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String name) {
+        this.message = name;
+    }
+}

--- a/cmt/src/main/resources/META-INF/persistence.xml
+++ b/cmt/src/main/resources/META-INF/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/cmt/src/main/resources/import.sql
+++ b/cmt/src/main/resources/import.sql
@@ -1,6 +1,6 @@
 --
 -- JBoss, Home of Professional Open Source
--- Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+-- Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
 -- contributors by the @authors tag. See the copyright.txt in the
 -- distribution for a full listing of individual contributors.
 --

--- a/cmt/src/main/webapp/WEB-INF/beans.xml
+++ b/cmt/src/main/webapp/WEB-INF/beans.xml
@@ -1,6 +1,6 @@
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/cmt/src/main/webapp/WEB-INF/cmt-quickstart-ds.xml
+++ b/cmt/src/main/webapp/WEB-INF/cmt-quickstart-ds.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/cmt/src/main/webapp/WEB-INF/faces-config.xml
+++ b/cmt/src/main/webapp/WEB-INF/faces-config.xml
@@ -32,6 +32,12 @@
       <to-view-id>/duplicate.xhtml</to-view-id>
       <redirect />
     </navigation-case>
+    <navigation-case>
+      <from-action>#{customerManager.addCustomer(name)}</from-action>
+      <from-outcome>customerInvalidName</from-outcome>
+      <to-view-id>/invalidName.xhtml</to-view-id>
+      <redirect />
+    </navigation-case>
   </navigation-rule>
 
 </faces-config>

--- a/cmt/src/main/webapp/WEB-INF/faces-config.xml
+++ b/cmt/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,6 +1,6 @@
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/cmt/src/main/webapp/WEB-INF/hornetq-jms.xml
+++ b/cmt/src/main/webapp/WEB-INF/hornetq-jms.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/cmt/src/main/webapp/addCustomer.xhtml
+++ b/cmt/src/main/webapp/addCustomer.xhtml
@@ -1,6 +1,6 @@
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/cmt/src/main/webapp/customers.xhtml
+++ b/cmt/src/main/webapp/customers.xhtml
@@ -1,6 +1,6 @@
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/cmt/src/main/webapp/duplicate.xhtml
+++ b/cmt/src/main/webapp/duplicate.xhtml
@@ -1,6 +1,6 @@
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/cmt/src/main/webapp/index.html
+++ b/cmt/src/main/webapp/index.html
@@ -1,6 +1,6 @@
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/cmt/src/main/webapp/invalidName.xhtml
+++ b/cmt/src/main/webapp/invalidName.xhtml
@@ -22,20 +22,10 @@
 
 <ui:composition template="template.xhtml">
 	<ui:define name="content">
-		<h:messages />
-		<h:form id="addCustomerForm">
-			<h:panelGrid columns="3">
-				<h:outputLabel for="name">Name:</h:outputLabel>
-				<h:inputText value="#{name}" />
-				<h:commandButton id="add" value="Add"
-					action="#{customerManager.addCustomer(name)}">
-				</h:commandButton>
-			</h:panelGrid>
-		</h:form>
-		<ul>
-			<li><h:link outcome="/customers.xhtml">List customers</h:link></li>
-			<li><h:link outcome="/logMessages.xhtml">List log messages</h:link></li>
-		</ul>
+		<Count />
+		<h1>Name of the customer is invalid</h1>
+		<h:outputText value="Name of the customer is invalid: #{name}" />
+		<h:link outcome="/addCustomer.xhtml">Go back</h:link>
 	</ui:define>
 </ui:composition>
 </html>

--- a/cmt/src/main/webapp/invalidName.xhtml
+++ b/cmt/src/main/webapp/invalidName.xhtml
@@ -1,6 +1,6 @@
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/cmt/src/main/webapp/logMessages.xhtml
+++ b/cmt/src/main/webapp/logMessages.xhtml
@@ -23,19 +23,22 @@
 <ui:composition template="template.xhtml">
 	<ui:define name="content">
 		<h:messages />
-		<h:form id="addCustomerForm">
-			<h:panelGrid columns="3">
-				<h:outputLabel for="name">Name:</h:outputLabel>
-				<h:inputText value="#{name}" />
-				<h:commandButton id="add" value="Add"
-					action="#{customerManager.addCustomer(name)}">
-				</h:commandButton>
-			</h:panelGrid>
-		</h:form>
-		<ul>
-			<li><h:link outcome="/customers.xhtml">List customers</h:link></li>
-			<li><h:link outcome="/logMessages.xhtml">List log messages</h:link></li>
-		</ul>
+		<h1>List of log-messages</h1>
+		<h:dataTable value="#{logMessageManager.logMessages}" var="lm">
+			<h:column>
+				<f:facet name="header">
+               Message
+            </f:facet>
+				<h:outputText value="#{lm.message}" />
+			</h:column>
+			<h:column>
+				<f:facet name="header">
+               Id
+            </f:facet>
+				<h:outputText value="#{lm.id}" />
+			</h:column>
+		</h:dataTable>
+		<a href="javascript:history.back(-1)">Go Back</a>
 	</ui:define>
 </ui:composition>
 </html>

--- a/cmt/src/main/webapp/logMessages.xhtml
+++ b/cmt/src/main/webapp/logMessages.xhtml
@@ -1,6 +1,6 @@
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/cmt/src/main/webapp/template.xhtml
+++ b/cmt/src/main/webapp/template.xhtml
@@ -1,6 +1,6 @@
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/cmt/src/test/java/org/jboss/as/quickstarts/cmt/ejb/CustomerManagerEJBTest.java
+++ b/cmt/src/test/java/org/jboss/as/quickstarts/cmt/ejb/CustomerManagerEJBTest.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.cmt.ejb;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class CustomerManagerEJBTest {
+    @Test
+    public void testNameIsValid() {
+        assertTrue(CustomerManagerEJB.nameIsValid("Jan"));
+        assertFalse(CustomerManagerEJB.nameIsValid("Jan1"));
+        assertTrue(CustomerManagerEJB.nameIsValid("Jan-Piet"));
+        assertFalse(CustomerManagerEJB.nameIsValid("Jan_Piet"));
+        assertTrue(CustomerManagerEJB.nameIsValid("gefräßig"));
+    }
+}


### PR DESCRIPTION
An example to show how a method marked with TransactionAttributeType.REQUIRES_NEW does commit a record while the former transaction can still fail.
One can see this by running the application and adding a 'customer' whose name contains non letters (e.g. John1). This will result in a LogMessage-record in the database but not a customer-record neither will a JMS-message be delivered.

Signed-off-by: Gerke - Ephorus gerke.ephorus@gmail.com
