### PR TITLE
Changing artifact id for PicketLink component

### DIFF
--- a/picketlink-sts/pom.xml
+++ b/picketlink-sts/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.quickstarts.eap</groupId>
     <artifactId>jboss-picketlink-sts</artifactId>
-    <version>6.2.0-redhat-SNAPSHOT</version>
+    <version>6.3.0-redhat-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>JBoss EAP Quickstart: picketlink-sts</name>
     <description>This project is an implementation of a WS-Trust Security Token Service.</description>
@@ -43,7 +43,7 @@
         <!-- JBoss dependency versions -->
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom.eap>6.2.0-build-7</version.jboss.bom.eap>
+        <version.jboss.bom.eap>6.3.0-build-SNAPSHOT</version.jboss.bom.eap>
 
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
@@ -89,7 +89,7 @@
 
         <dependency>
             <groupId>org.picketlink</groupId>
-            <artifactId>picketlink-core</artifactId>
+            <artifactId>picketlink-federation</artifactId>
             <scope>provided</scope>
             <exclusions>
               <exclusion>

--- a/picketlink-sts/src/main/java/org/jboss/as/quickstarts/picketlink/WSTrustClientExample.java
+++ b/picketlink-sts/src/main/java/org/jboss/as/quickstarts/picketlink/WSTrustClientExample.java
@@ -16,10 +16,10 @@
  */
 package org.jboss.as.quickstarts.picketlink;
 
+import org.picketlink.common.exceptions.fed.WSTrustException;
+import org.picketlink.common.util.DocumentUtil;
 import org.picketlink.identity.federation.api.wstrust.WSTrustClient;
 import org.picketlink.identity.federation.api.wstrust.WSTrustClient.SecurityInfo;
-import org.picketlink.identity.federation.core.saml.v2.util.DocumentUtil;
-import org.picketlink.identity.federation.core.wstrust.WSTrustException;
 import org.picketlink.identity.federation.core.wstrust.plugins.saml.SAMLUtil;
 import org.w3c.dom.Element;
 

--- a/picketlink-sts/src/main/java/org/picketlink/identity/federation/app/sts/PicketLinkSTService.java
+++ b/picketlink-sts/src/main/java/org/picketlink/identity/federation/app/sts/PicketLinkSTService.java
@@ -22,7 +22,7 @@ import javax.xml.ws.ServiceMode;
 import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.WebServiceProvider;
 
-import org.apache.log4j.Logger;
+import org.jboss.logging.Logger;
 import org.picketlink.identity.federation.core.wstrust.PicketLinkSTS;
 
 /**
@@ -36,7 +36,7 @@ import org.picketlink.identity.federation.core.wstrust.PicketLinkSTS;
 @WebServiceProvider(serviceName = "PicketLinkSTS", portName = "PicketLinkSTSPort", targetNamespace = "urn:picketlink:identity-federation:sts", wsdlLocation = "WEB-INF/wsdl/PicketLinkSTS.wsdl")
 @ServiceMode(value = Service.Mode.MESSAGE)
 public class PicketLinkSTService extends PicketLinkSTS {
-    private static Logger log = Logger.getLogger(PicketLinkSTService.class);
+    private static Logger log = Logger.getLogger(PicketLinkSTService.class.getName());
 
     @Resource
     public void setWSC(WebServiceContext wctx) {


### PR DESCRIPTION
Changing artifact id for PicketLink component as it was upgraded in EAP 6.3, changing BOM version to 6.3.0 as well
