### PR TITLE
Declared the proxy server settings in Maven configuration file (settings.xml)

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -1,90 +1,107 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    JBoss, Home of Professional Open Source
-    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
-    contributors by the @authors tag. See the copyright.txt in the
-    distribution for a full listing of individual contributors.
+<!-- JBoss, Home of Professional Open Source Copyright 2013, Red Hat, Inc. 
+	and/or its affiliates, and individual contributors by the @authors tag. See 
+	the copyright.txt in the distribution for a full listing of individual contributors. 
+	Licensed under the Apache License, Version 2.0 (the "License"); you may not 
+	use this file except in compliance with the License. You may obtain a copy 
+	of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
--->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
 
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" 
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-  
-  <profiles>
+<!-- proxies
+     This is a list of proxies which can be used on this machine to connect to the network.
+     Unless otherwise specified (by system property or command-line switch), the first proxy
+     specification in this list marked as active will be used.If you are accessing network
+     via a proxy server, Un-comment the proxy options and fill in your proxy server detail.
+   -->
+	<proxies>
+    <!-- proxy
+      Specification for one proxy, to be used in connecting to the network.
 
-    <!-- Configure the JBoss GA Maven repository -->
-    <profile>
-      <id>jboss-ga-repository</id>
-      <repositories>
-        <repository>
-          <id>jboss-ga-repository</id>
-          <url>http://maven.repository.redhat.com/techpreview/all</url>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <id>jboss-ga-plugin-repository</id>
-          <url>http://maven.repository.redhat.com/techpreview/all</url>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </pluginRepository>
-      </pluginRepositories>
-    </profile>
-    <!-- Configure the JBoss Early Access Maven repository -->
-    <profile>
-      <id>jboss-earlyaccess-repository</id>
-      <repositories>
-        <repository>
-          <id>jboss-earlyaccess-repository</id>
-          <url>http://maven.repository.redhat.com/earlyaccess/all/</url>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <id>jboss-earlyaccess-plugin-repository</id>
-          <url>http://maven.repository.redhat.com/earlyaccess/all/</url>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </pluginRepository>
-      </pluginRepositories>
-    </profile>
+		<proxy>
+      		<id>optional</id>
+      		<active>true</active>
+      		<protocol>http</protocol>
+      		<username>proxyuser</</username>
+      		<password>proxypass</password>
+      		<host>proxy.host.net</host>
+      		<port>80</port>
+      		<nonProxyHosts>local.net|some.host.com</nonProxyHosts>
+    	</proxy>
+    -->
+	</proxies>
+	
+	<profiles>
 
-  </profiles>
+		<!-- Configure the JBoss GA Maven repository -->
+		<profile>
+			<id>jboss-ga-repository</id>
+			<repositories>
+				<repository>
+					<id>jboss-ga-repository</id>
+					<url>http://maven.repository.redhat.com/techpreview/all</url>
+					<releases>
+						<enabled>true</enabled>
+					</releases>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+				</repository>
+			</repositories>
+			<pluginRepositories>
+				<pluginRepository>
+					<id>jboss-ga-plugin-repository</id>
+					<url>http://maven.repository.redhat.com/techpreview/all</url>
+					<releases>
+						<enabled>true</enabled>
+					</releases>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+				</pluginRepository>
+			</pluginRepositories>
+		</profile>
+		<!-- Configure the JBoss Early Access Maven repository -->
+		<profile>
+			<id>jboss-earlyaccess-repository</id>
+			<repositories>
+				<repository>
+					<id>jboss-earlyaccess-repository</id>
+					<url>http://maven.repository.redhat.com/earlyaccess/all/</url>
+					<releases>
+						<enabled>true</enabled>
+					</releases>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+				</repository>
+			</repositories>
+			<pluginRepositories>
+				<pluginRepository>
+					<id>jboss-earlyaccess-plugin-repository</id>
+					<url>http://maven.repository.redhat.com/earlyaccess/all/</url>
+					<releases>
+						<enabled>true</enabled>
+					</releases>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+				</pluginRepository>
+			</pluginRepositories>
+		</profile>
 
-  <activeProfiles>
-    <!-- Optionally, make the repositories active by default -->
-    <activeProfile>jboss-ga-repository</activeProfile>
-    <activeProfile>jboss-earlyaccess-repository</activeProfile>
-  </activeProfiles>
+	</profiles>
+
+	<activeProfiles>
+		<!-- Optionally, make the repositories active by default -->
+		<activeProfile>jboss-ga-repository</activeProfile>
+		<activeProfile>jboss-earlyaccess-repository</activeProfile>
+	</activeProfiles>
 
 </settings>


### PR DESCRIPTION
Declared the proxy server settings in Maven configuration file (settings.xml) to enable downloading of dependencies through Maven in case of proxy servers. 

Signed-off-by: girirajSharma giriraj.sharma27@gmail.com
