### PR TITLE
Bz1073903: Fix EAP_HOME server and path problems

### DIFF
--- a/cluster-ha-singleton/README.md
+++ b/cluster-ha-singleton/README.md
@@ -49,13 +49,13 @@ Start the servers with the HA provile, passing a unique node ID by typing the fo
 
 If you are using Linux:
 
-        Server 1: EAP_HOME_SERVER_1/standalone.sh --server-config=standalone-ha.xml -Djboss.node.name=nodeOne
-        Server 2: EAP_HOME_SERVER_2/standalone.sh --server-config=standalone-ha.xml -Djboss.node.name=nodeTwo -Djboss.socket.binding.port-offset=100
+        Server 1: EAP_HOME_1/bin/standalone.sh --server-config=standalone-ha.xml -Djboss.node.name=nodeOne
+        Server 2: EAP_HOME_2/bin/standalone.sh --server-config=standalone-ha.xml -Djboss.node.name=nodeTwo -Djboss.socket.binding.port-offset=100
 
 If you are using Windows
 
-        Server 1: EAP_HOME_SERVER_1\standalone.bat --server-config=standalone-ha.xml -Djboss.node.name=nodeOne
-        Server 2: EAP_HOME_SERVER_2\standalone.bat --server-config=standalone-ha.xml -Djboss.node.name=nodeTwo -Djboss.socket.binding.port-offset=100
+        Server 1: EAP_HOME_1\bin\standalone.bat --server-config=standalone-ha.xml -Djboss.node.name=nodeOne
+        Server 2: EAP_HOME_2\bin\standalone.bat --server-config=standalone-ha.xml -Djboss.node.name=nodeTwo -Djboss.socket.binding.port-offset=100
 
 
 Build and Deploy the Quickstart

--- a/ejb-security-interceptors/README.md
+++ b/ejb-security-interceptors/README.md
@@ -433,8 +433,8 @@ You can remove the security domain configuration by running the  `remove-securit
 
 1. Start the JBoss EAP server by typing the following: 
 
-        For Linux:  EAP_HOME_SERVER_1/bin/standalone.sh
-        For Windows:  EAP_HOME_SERVER_1\bin\standalone.bat
+        For Linux:  EAP_HOME/bin/standalone.sh
+        For Windows:  EAP_HOME\bin\standalone.bat
 2. Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing EAP_HOME with the path to your server:
 
         EAP_HOME/bin/jboss-cli.sh --connect --file=remove-security-domain.cli 

--- a/helloworld-jms/README.md
+++ b/helloworld-jms/README.md
@@ -63,8 +63,8 @@ You configure the the JMS `test` queue by running JBoss CLI commands. For your c
     * After you have completed testing this quickstart, you can replace this file to restore the server to its original configuration.
 2. Start the JBoss EAP server by typing the following: 
 
-        For Linux:  EAP_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml
-        For Windows:  EAP_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml
+        For Linux:  EAP_HOME/bin/standalone.sh -c standalone-full.xml
+        For Windows:  EAP_HOME\bin\standalone.bat -c standalone-full.xml
 3. Review the `configure-jms.cli` file in the root of this quickstart directory. This script adds the `test` queue to the `messaging` subsystem in the server configuration file.
 
 4. Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing EAP_HOME with the path to your server:
@@ -199,8 +199,8 @@ You can remove the JMS configuration by running the  `remove-jms.cli` script pro
 
 1. Start the JBoss EAP server by typing the following: 
 
-        For Linux:  EAP_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml
-        For Windows:  EAP_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml
+        For Linux:  EAP_HOME/bin/standalone.sh -c standalone-full.xml
+        For Windows:  EAP_HOME\bin\standalone.bat -c standalone-full.xml
 2. Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing EAP_HOME with the path to your server:
 
         EAP_HOME/bin/jboss-cli.sh --connect --file=remove-jms.cli 

--- a/hornetq-clustering/README.md
+++ b/hornetq-clustering/README.md
@@ -107,8 +107,8 @@ Since both application servers must be configured in the same way, you must conf
 1. Open a command prompt and navigate to the root of the JBoss EAP directory.
 2. The following shows the command line to start the server with the full-ha profile. This profile supports clustering/HA
 
-        For Linux:   EAP_HOME/bin/standalone.sh -c standalone-full-ha.xml
-        For Windows: EAP_HOME\bin\standalone.bat -c standalone-full-ha.xml
+        For Linux:   EAP_HOME_1/bin/standalone.sh -c standalone-full-ha.xml
+        For Windows: EAP_HOME_1\bin\standalone.bat -c standalone-full-ha.xml
 
 
 #### Configure the Standalone Server and Deploy the Quickstart Using the JBoss CLI
@@ -124,7 +124,7 @@ Since both application servers must be configured in the same way, you must conf
     must modify its path in this script. Find the 'NOTE:' in the file for instructions._
 2. Open a command prompt, navigate to the root directory of this quickstart, and run the following command to run the script:
 
-        EAP_HOME/bin/jboss-cli.sh --connect --file=install-standalone.cli
+        EAP_HOME_1/bin/jboss-cli.sh --connect --file=install-standalone.cli
         
    You should see "outcome" => "success" for all of the commands.
 
@@ -136,21 +136,21 @@ After you have successfully configured the server, you must make a copy of this 
 2. Make a copy of this JBoss EAP directory structure to use for the second server.
 3. Remove the following directories from the cloned instance:
 
-        EAP_HOME_SERVER_2/standalone/data/messagingbindings
-        EAP_HOME_SERVER_2/standalone/data/messagingjournal
-        EAP_HOME_SERVER_2/standalone/data/messaginglargemessages
+        EAP_HOME_2/standalone/data/messagingbindings
+        EAP_HOME_2/standalone/data/messagingjournal
+        EAP_HOME_2/standalone/data/messaginglargemessages
 
 #### Start the JBoss EAP Standalone Servers with the Full HA Profile
 
 If you are using Linux:
 
-        Server 1: EAP_HOME_SERVER_1/bin/standalone.sh -c standalone-full-ha.xml
-        Server 2: EAP_HOME_SERVER_2/bin/standalone.sh -c standalone-full-ha.xml -Djboss.socket.binding.port-offset=100
+        Server 1: EAP_HOME_1/bin/standalone.sh -c standalone-full-ha.xml
+        Server 2: EAP_HOME_2/bin/standalone.sh -c standalone-full-ha.xml -Djboss.socket.binding.port-offset=100
 
 If you are using Windows:
 
-        Server 1: EAP_HOME_SERVER_1\bin\standalone.bat -c standalone-full-ha.xml
-        Server 2: EAP_HOME_SERVER_2\bin\standalone.bat -c standalone-full-ha.xml -Djboss.socket.binding.port-offset=100
+        Server 1: EAP_HOME_1\bin\standalone.bat -c standalone-full-ha.xml
+        Server 2: EAP_HOME_2\bin\standalone.bat -c standalone-full-ha.xml -Djboss.socket.binding.port-offset=100
 
 
 Access the application 
@@ -204,7 +204,7 @@ When you are finished testing, use the following instructions to undeploy the qu
 1. Make sure you have started the JBoss EAP server in standalone mode as described above.
 3. Open a command prompt, navigate to the root directory of this quickstart, and run the following command to undeploy the helloworld-mdb quickstart:
 
-        EAP_HOME/bin/jboss-cli.sh --connect --file=undeploy-standalone.cli
+        EAP_HOME_1/bin/jboss-cli.sh --connect --file=undeploy-standalone.cli
 
 
 
@@ -250,8 +250,8 @@ You can remove the domain configuration by manually restoring the back-up copies
 
 _Note: This method ensures the server is restored to its prior configuration._
 
-1. If it is running, stop the JBoss EAP server.
-2. Restore the `EAP_HOME/standalone/configuration/standalone-full-ha.xml` file with the back-up copies of the file. Be sure to replace EAP_HOME with the path to your server.
+1. If they are running, stop both JBoss EAP servers.
+2. Restore the `EAP_HOME_1/standalone/configuration/standalone-full-ha.xml` file with the back-up copies of the file. Be sure to replace EAP_HOME_1 with the path to your server.
 
 #### Remove the Standalone Configuration by Running the JBoss CLI Script
 
@@ -259,11 +259,11 @@ _Note: This script returns the server to a default configuration and the result 
 
 1. Start the JBoss EAP server by typing the following: 
 
-        For Linux:   EAP_HOME/bin/standalone.sh -c standalone-full-ha.xml
-        For Windows: EAP_HOME\bin\domain.bat -c standalone-full-ha.xml
-2. Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing EAP_HOME with the path to your server.
+        For Linux:   EAP_HOME_1/bin/standalone.sh -c standalone-full-ha.xml
+        For Windows: EAP_HOME_1\bin\domain.bat -c standalone-full-ha.xml
+2. Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing EAP_HOME_1 with the path to your server.
 
-        EAP_HOME/bin/jboss-cli.sh --connect --file=remove-standalone.cli 
+        EAP_HOME_1/bin/jboss-cli.sh --connect --file=remove-standalone.cli 
 This script removes the server configuration that was done by the `install-standalone.cli` script. You should see the following result following the script commands:
 
         The batch executed successfully.

--- a/jts-distributed-crash-rec/README.md
+++ b/jts-distributed-crash-rec/README.md
@@ -89,13 +89,13 @@ Test the Application
 
     If you are using Linux:
 
-        Server 1: EAP_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml
-        Server 2: EAP_HOME_SERVER_2/bin/standalone.sh -c standalone-full.xml -Djboss.socket.binding.port-offset=100
+        Server 1: EAP_HOME_1/bin/standalone.sh -c standalone-full.xml
+        Server 2: EAP_HOME_2/bin/standalone.sh -c standalone-full.xml -Djboss.socket.binding.port-offset=100
 
     If you are using Windows
 
-        Server 1: EAP_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml
-        Server 2: EAP_HOME_SERVER_2\bin\standalone.bat -c standalone-full.xml -Djboss.socket.binding.port-offset=100
+        Server 1: EAP_HOME_1\bin\standalone.bat -c standalone-full.xml
+        Server 2: EAP_HOME_2\bin\standalone.bat -c standalone-full.xml -Djboss.socket.binding.port-offset=100
 
 4. Access the application at the following URL: <http://localhost:8080/jboss-jts-application-component-1/>
     * When you enter a name and click to "add" that customer, you will see the following in the application server 1 console:

--- a/jts/README.md
+++ b/jts/README.md
@@ -155,13 +155,13 @@ Start the the two JBoss EAP servers with the full profile, passing a unique node
 
 If you are using Linux:
 
-        Server 1: EAP_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml -Djboss.tx.node.id=UNIQUE_NODE_ID_1
-        Server 2: EAP_HOME_SERVER_2/bin/standalone.sh -c standalone-full.xml -Djboss.tx.node.id=UNIQUE_NODE_ID_2 -Djboss.socket.binding.port-offset=100
+        Server 1: EAP_HOME_1/bin/standalone.sh -c standalone-full.xml -Djboss.tx.node.id=UNIQUE_NODE_ID_1
+        Server 2: EAP_HOME_2/bin/standalone.sh -c standalone-full.xml -Djboss.tx.node.id=UNIQUE_NODE_ID_2 -Djboss.socket.binding.port-offset=100
 
 If you are using Windows
 
-        Server 1: EAP_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml -Djboss.tx.node.id=UNIQUE_NODE_ID_1
-        Server 2: EAP_HOME_SERVER_2\bin\standalone.bat -c standalone-full.xml -Djboss.tx.node.id=UNIQUE_NODE_ID_2 -Djboss.socket.binding.port-offset=100
+        Server 1: EAP_HOME_1\bin\standalone.bat -c standalone-full.xml -Djboss.tx.node.id=UNIQUE_NODE_ID_1
+        Server 2: EAP_HOME_2\bin\standalone.bat -c standalone-full.xml -Djboss.tx.node.id=UNIQUE_NODE_ID_2 -Djboss.socket.binding.port-offset=100
 
 
 Build and Deploy the Quickstart
@@ -219,11 +219,11 @@ You can modify the server configuration by running the `remove-jts-transactions.
 
 1. Start the JBoss EAP server with the full profile.
 
-        For Linux:  EAP_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml
-        For Windows:  EAP_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml
+        For Linux:  EAP_HOME_1/bin/standalone.sh -c standalone-full.xml
+        For Windows:  EAP_HOME_1\bin\standalone.bat -c standalone-full.xml
 2. Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing EAP_HOME with the path to your server:
 
-        EAP_HOME/bin/jboss-cli.sh --connect --file=remove-jts-transactions.cli 
+        EAP_HOME_1/bin/jboss-cli.sh --connect --file=remove-jts-transactions.cli 
 This script removes the `test` queue from the `messaging` subsystem in the server configuration. You should see the following result when you run the script:
 
         The batch executed successfully.
@@ -234,12 +234,12 @@ This script removes the `test` queue from the `messaging` subsystem in the serve
 
 1. Start the JBoss EAP server with the full profile.
 
-        For Linux:  EAP_HOME_SERVER_1/bin/standalone.sh -c standalone-full.xml
-        For Windows:  EAP_HOME_SERVER_1\bin\standalone.bat -c standalone-full.xml
+        For Linux:  EAP_HOME_1/bin/standalone.sh -c standalone-full.xml
+        For Windows:  EAP_HOME_1\bin\standalone.bat -c standalone-full.xml
 2. To start the JBoss CLI tool, open a new command prompt, navigate to the EAP_HOME directory, and type the following:
     
-        For Linux: bin/jboss-cli.sh --connect
-        For Windows: bin\jboss-cli.bat --connect
+        For Linux: EAP_HOME_1/bin/jboss-cli.sh --connect
+        For Windows: EAP_HOME_1\bin\jboss-cli.bat --connect
 3. At the prompt, type the following:
 
         /subsystem=jacorb/:write-attribute(name=transactions,value=spec)

--- a/logging/README.md
+++ b/logging/README.md
@@ -332,8 +332,8 @@ You can remove the logging configuration by running the  `remove-logging.cli` sc
 
 1. Start the JBoss EAP server by typing the following: 
 
-        For Linux:  EAP_HOME_SERVER_1/bin/standalone.sh
-        For Windows:  EAP_HOME_SERVER_1\bin\standalone.bat
+        For Linux:  EAP_HOME/bin/standalone.sh
+        For Windows:  EAP_HOME\bin\standalone.bat
 2. Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing EAP_HOME with the path to your server:
 
         EAP_HOME/bin/jboss-cli.sh --connect --file=remove-logging.cli 

--- a/servlet-security-genericheader-auth/README.md
+++ b/servlet-security-genericheader-auth/README.md
@@ -53,8 +53,8 @@ _NOTE - Before you begin:_
 
 1. Start the JBoss EAP server by typing the following: 
 
-        For Linux:  EAP_HOME_SERVER_1/bin/standalone.sh
-        For Windows:  EAP_HOME_SERVER_1\bin\standalone.bat
+        For Linux:  EAP_HOME/bin/standalone.sh
+        For Windows:  EAP_HOME\bin\standalone.bat
 
 2. Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing EAP_HOME with the path to your server:
 
@@ -69,8 +69,8 @@ This script adds the `GenericHeaderAuth` domain to the `security` subsystem in t
 
 1. Start the JBoss EAP server by typing the following: 
 
-        For Linux:  EAP_HOME_SERVER_1/bin/standalone.sh
-        For Windows:  EAP_HOME_SERVER_1\bin\standalone.bat
+        For Linux:  EAP_HOME/bin/standalone.sh
+        For Windows:  EAP_HOME\bin\standalone.bat
 2. To start the JBoss CLI tool, open a new command prompt, navigate to the EAP_HOME directory, and type the following:
     
         For Linux: bin/jboss-cli.sh --connect
@@ -172,8 +172,8 @@ You can remove the security domain configuration by running the  `remove-securit
 
 1. Start the JBoss EAP server by typing the following: 
 
-        For Linux:  EAP_HOME_SERVER_1/bin/standalone.sh
-        For Windows:  EAP_HOME_SERVER_1\bin\standalone.bat
+        For Linux:  EAP_HOME/bin/standalone.sh
+        For Windows:  EAP_HOME\bin\standalone.bat
 2. Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing EAP_HOME with the path to your server:
 
         For Linux:   EAP_HOME/bin/jboss-cli.sh --connect --file=remove-security-domain.cli

--- a/servlet-security/README.md
+++ b/servlet-security/README.md
@@ -197,8 +197,8 @@ You can remove the security domain configuration by running the  `remove-securit
 
 1. Start the JBoss EAP server by typing the following: 
 
-        For Linux:  EAP_HOME_SERVER_1/bin/standalone.sh
-        For Windows:  EAP_HOME_SERVER_1\bin\standalone.bat
+        For Linux:  EAP_HOME/bin/standalone.sh
+        For Windows:  EAP_HOME\bin\standalone.bat
 2. Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing EAP_HOME with the path to your server:
 
         EAP_HOME/bin/jboss-cli.sh --connect --file=remove-security-domain.cli 


### PR DESCRIPTION
Fixed the following issues:
Some instructions to start the folder were missing the `bin` directory in the path.
Where 2 servers are needed, removed the `_SERVER` from the path, so it's now `EAP_HOME_1` and `EAP_HOME_2` instead of `EAP_HOME_SERVER_1` and `EAP_HOME_SERVER_2`.
Some quickstart appended the `_1` even though there was only 1 server.
