### PR TITLE
Bz1087471: Failed attempt to resolve No matching SeamConversationContext

### DIFF
--- a/wicket-ear/pom.xml
+++ b/wicket-ear/pom.xml
@@ -57,7 +57,8 @@
         <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-4</version.jboss.spec.javaee.6.0>
 
         <!-- Other dependency versions -->
-        <version.net.ftlines.wicket-cdi>6.0</version.net.ftlines.wicket-cdi>
+        <version.wicket.cdi>6.14.0</version.wicket.cdi>
+        <version.seam.conversation.weld>3.0.0.Final</version.seam.conversation.weld>
 
         <!-- other plugin versions -->
         <version.ear.plugin>2.8</version.ear.plugin>
@@ -89,9 +90,16 @@
 
             <!-- Wicket Java EE integration. -->
             <dependency>
-                <groupId>net.ftlines.wicket-cdi</groupId>
+                <groupId>org.apache.wicket</groupId>
                 <artifactId>wicket-cdi</artifactId>
-                <version>${version.net.ftlines.wicket-cdi}</version>
+                <version>${version.wicket.cdi}</version>
+            </dependency>
+
+            <!-- Seam Weld integration. -->
+            <dependency>
+                <groupId>org.jboss.seam.conversation</groupId>
+                <artifactId>seam-conversation-weld</artifactId>
+               <version>${version.seam.conversation.weld}</version>
             </dependency>
 
             <!-- EJB JAR module. -->

--- a/wicket-ear/war/pom.xml
+++ b/wicket-ear/war/pom.xml
@@ -53,10 +53,16 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Wicket Java EE integration. -->
+        <!-- Wicket CDI integration. -->
         <dependency>
-            <groupId>net.ftlines.wicket-cdi</groupId>
+            <groupId>org.apache.wicket</groupId>
             <artifactId>wicket-cdi</artifactId>
+        </dependency>
+
+        <!-- Seam Weld integration. -->
+        <dependency>
+            <groupId>org.jboss.seam.conversation</groupId>
+            <artifactId>seam-conversation-weld</artifactId>
         </dependency>
 
         <!-- EJB JAR. -->

--- a/wicket-ear/war/src/main/java/org/jboss/as/quickstarts/wicketEar/war/WicketJavaEEApplication.java
+++ b/wicket-ear/war/src/main/java/org/jboss/as/quickstarts/wicketEar/war/WicketJavaEEApplication.java
@@ -16,14 +16,12 @@
  */
 package org.jboss.as.quickstarts.wicketEar.war;
 
-import static net.ftlines.wicket.cdi.ConversationPropagation.NONE;
-
 import javax.enterprise.inject.spi.BeanManager;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import net.ftlines.wicket.cdi.CdiConfiguration;
-
+import org.apache.wicket.cdi.CdiConfiguration;
+import org.apache.wicket.cdi.ConversationPropagation;
 import org.apache.wicket.Page;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.jboss.as.quickstarts.wicketEar.war.pages.InsertContact;
@@ -53,7 +51,7 @@ public class WicketJavaEEApplication extends WebApplication {
         }
 
         // Configure CDI, disabling Conversations as we aren't using them
-        new CdiConfiguration(bm).setPropagation(NONE).configure(this);
+        new CdiConfiguration(bm).setPropagation(ConversationPropagation.NONE).configure(this);
 
         // Mount the InsertContact page at /insert
         mountPage("/insert", InsertContact.class);

--- a/wicket-war/pom.xml
+++ b/wicket-war/pom.xml
@@ -50,7 +50,8 @@
         <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-4</version.jboss.spec.javaee.6.0>
 
         <!-- Other dependency versions -->
-        <version.net.ftlines.wicket-cdi>6.0</version.net.ftlines.wicket-cdi>
+        <version.wicket.cdi>6.14.0</version.wicket.cdi>
+        <version.seam.conversation.weld>3.0.0.Final</version.seam.conversation.weld>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>
@@ -81,11 +82,19 @@
 
             <!-- Wicket Java EE integration. -->
             <dependency>
-                <groupId>net.ftlines.wicket-cdi</groupId>
+                <groupId>org.apache.wicket</groupId>
                 <artifactId>wicket-cdi</artifactId>
-                <version>${version.net.ftlines.wicket-cdi}</version>
+                <version>${version.wicket.cdi}</version>
             </dependency>
 
+            <!-- Seam Weld integration. -->
+            <dependency>
+                <groupId>org.jboss.seam.conversation</groupId>
+                <artifactId>seam-conversation-weld</artifactId>
+               <version>${version.seam.conversation.weld}</version>
+            </dependency>
+
+            
         </dependencies>
     </dependencyManagement>
 
@@ -124,8 +133,14 @@
 
         <!-- Wicket CDI integration. -->
         <dependency>
-            <groupId>net.ftlines.wicket-cdi</groupId>
+            <groupId>org.apache.wicket</groupId>
             <artifactId>wicket-cdi</artifactId>
+        </dependency>
+
+        <!-- Seam Weld integration. -->
+        <dependency>
+            <groupId>org.jboss.seam.conversation</groupId>
+            <artifactId>seam-conversation-weld</artifactId>
         </dependency>
 
     </dependencies>

--- a/wicket-war/src/main/java/org/jboss/as/quickstarts/wicketWar/WicketJavaEEApplication.java
+++ b/wicket-war/src/main/java/org/jboss/as/quickstarts/wicketWar/WicketJavaEEApplication.java
@@ -16,14 +16,13 @@
  */
 package org.jboss.as.quickstarts.wicketWar;
 
-import static net.ftlines.wicket.cdi.ConversationPropagation.NONE;
-
 import javax.enterprise.inject.spi.BeanManager;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import net.ftlines.wicket.cdi.CdiConfiguration;
 
+import org.apache.wicket.cdi.CdiConfiguration;
+import org.apache.wicket.cdi.ConversationPropagation;
 import org.apache.wicket.Page;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.jboss.as.quickstarts.wicketWar.pages.InsertContact;
@@ -54,7 +53,7 @@ public class WicketJavaEEApplication extends WebApplication {
         }
 
         // Configure CDI, disabling Conversations as we aren't using them
-        new CdiConfiguration(bm).setPropagation(NONE).configure(this);
+        new CdiConfiguration(bm).setPropagation(ConversationPropagation.NONE).configure(this);
 
         // Mount the InsertContact page at /insert
         mountPage("/insert", InsertContact.class);


### PR DESCRIPTION
Updated to wicket-cdi 6.14.0 and added seam-conversation-weld dependency to get rid of the warning message.
