### PR TITLE
Update javaee specs version for EAP 6.3.0.ER4

### DIFF
--- a/bmt/pom.xml
+++ b/bmt/pom.xml
@@ -46,7 +46,7 @@
         
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/cdi-alternative/pom.xml
+++ b/cdi-alternative/pom.xml
@@ -50,7 +50,7 @@
         
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0> 
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0> 
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/cdi-decorator/pom.xml
+++ b/cdi-decorator/pom.xml
@@ -50,7 +50,7 @@
 
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/cdi-injection/pom.xml
+++ b/cdi-injection/pom.xml
@@ -44,7 +44,7 @@
         
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/cluster-ha-singleton/pom.xml
+++ b/cluster-ha-singleton/pom.xml
@@ -47,7 +47,7 @@
 
         <version.jboss.as>7.4.0.Final-redhat-SNAPSHOT</version.jboss.as>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.ejb.plugin>2.3</version.ejb.plugin>

--- a/ejb-asynchronous/pom.xml
+++ b/ejb-asynchronous/pom.xml
@@ -52,7 +52,7 @@
 
         <version.jboss.as>7.4.0.Final-redhat-SNAPSHOT</version.jboss.as>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.ejb.plugin>2.3</version.ejb.plugin>

--- a/ejb-in-ear/pom.xml
+++ b/ejb-in-ear/pom.xml
@@ -53,7 +53,7 @@
         
         <version.jboss.as>7.4.0.Final-redhat-SNAPSHOT</version.jboss.as>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.ear.plugin>2.8</version.ear.plugin>

--- a/ejb-multi-server/pom.xml
+++ b/ejb-multi-server/pom.xml
@@ -56,7 +56,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         <version.jboss.as>7.4.0.Final-redhat-SNAPSHOT</version.jboss.as>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
     <!-- other versions -->
         <version.jboss.ejb.client>1.0.25.Final-redhat-1</version.jboss.ejb.client>

--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -48,7 +48,7 @@
 
         <version.jboss.as>7.4.0.Final-redhat-SNAPSHOT</version.jboss.as>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
        <!-- other plugin versions -->
        <version.exec.plugin>1.2.1</version.exec.plugin>

--- a/ejb-remote/server-side/pom.xml
+++ b/ejb-remote/server-side/pom.xml
@@ -44,7 +44,7 @@
         
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.ejb.plugin>2.3</version.ejb.plugin>

--- a/ejb-security-interceptors/pom.xml
+++ b/ejb-security-interceptors/pom.xml
@@ -48,7 +48,7 @@
 
         <version.jboss.as>7.4.0.Final-redhat-SNAPSHOT</version.jboss.as>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.exec.plugin>1.2.1</version.exec.plugin>

--- a/ejb-security/pom.xml
+++ b/ejb-security/pom.xml
@@ -47,7 +47,7 @@
 
         <version.jboss.as>7.4.0.Final-redhat-SNAPSHOT</version.jboss.as>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>

--- a/ejb-throws-exception/pom.xml
+++ b/ejb-throws-exception/pom.xml
@@ -55,7 +55,7 @@
 
         <version.jboss.as>7.4.0.Final-redhat-SNAPSHOT</version.jboss.as>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.ear.plugin>2.8</version.ear.plugin>

--- a/ejb-timer/pom.xml
+++ b/ejb-timer/pom.xml
@@ -42,7 +42,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         <!-- Define the version of JBoss' Java EE 6 APIs we want to import. -->
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.6</maven.compiler.target>

--- a/greeter/pom.xml
+++ b/greeter/pom.xml
@@ -46,7 +46,7 @@
 
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/helloworld-mdb/pom.xml
+++ b/helloworld-mdb/pom.xml
@@ -46,7 +46,7 @@
 
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/helloworld-rs/pom.xml
+++ b/helloworld-rs/pom.xml
@@ -44,7 +44,7 @@
 
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/helloworld-singleton/pom.xml
+++ b/helloworld-singleton/pom.xml
@@ -45,7 +45,7 @@
 
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
  
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/helloworld/pom.xml
+++ b/helloworld/pom.xml
@@ -45,7 +45,7 @@
 
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/hibernate3/pom.xml
+++ b/hibernate3/pom.xml
@@ -45,7 +45,7 @@
 
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <version.org.hibernate3.commons.annotations>3.2.0.Final</version.org.hibernate3.commons.annotations>
         <version.org.hibernate>3.6.8.Final</version.org.hibernate>

--- a/inter-app/pom.xml
+++ b/inter-app/pom.xml
@@ -53,7 +53,7 @@
         
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/jta-crash-rec/pom.xml
+++ b/jta-crash-rec/pom.xml
@@ -47,7 +47,7 @@
 
         <version.jboss.as>7.4.0.Final-redhat-SNAPSHOT</version.jboss.as>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/jts/pom.xml
+++ b/jts/pom.xml
@@ -52,7 +52,7 @@
         
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.ejb.plugin>2.3</version.ejb.plugin>

--- a/log4j/pom.xml
+++ b/log4j/pom.xml
@@ -44,7 +44,7 @@
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- Other dependency versions -->
         <version.log4j>1.2.16</version.log4j>

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -43,7 +43,7 @@
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/numberguess/pom.xml
+++ b/numberguess/pom.xml
@@ -44,7 +44,7 @@
         
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/payment-cdi-event/pom.xml
+++ b/payment-cdi-event/pom.xml
@@ -48,7 +48,7 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <version.jboss.bom.eap>6.3.0-build-SNAPSHOT</version.jboss.bom.eap>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <version.jboss.bom.eap>6.3.0-build-SNAPSHOT</version.jboss.bom.eap>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <version.org.hibernate3.commons.annotations>3.2.0.Final</version.org.hibernate3.commons.annotations>
         <version.org.hibernate>3.6.8.Final</version.org.hibernate>

--- a/servlet-async/pom.xml
+++ b/servlet-async/pom.xml
@@ -45,7 +45,7 @@
         
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/servlet-filterlistener/pom.xml
+++ b/servlet-filterlistener/pom.xml
@@ -45,7 +45,7 @@
        
        <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
        
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/servlet-security/pom.xml
+++ b/servlet-security/pom.xml
@@ -44,7 +44,7 @@
        
        <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
        
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/shopping-cart/pom.xml
+++ b/shopping-cart/pom.xml
@@ -55,7 +55,7 @@
         
         <version.jboss.as>7.4.0.Final-redhat-SNAPSHOT</version.jboss.as>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.exec.plugin>1.2.1</version.exec.plugin>

--- a/temperature-converter/pom.xml
+++ b/temperature-converter/pom.xml
@@ -45,7 +45,7 @@
         
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -44,7 +44,7 @@
 
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/wicket-ear/pom.xml
+++ b/wicket-ear/pom.xml
@@ -54,7 +54,7 @@
         
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- Other dependency versions -->
         <version.wicket.cdi>6.14.0</version.wicket.cdi>

--- a/wicket-war/pom.xml
+++ b/wicket-war/pom.xml
@@ -47,7 +47,7 @@
         
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- Other dependency versions -->
         <version.wicket.cdi>6.14.0</version.wicket.cdi>

--- a/xml-dom4j/pom.xml
+++ b/xml-dom4j/pom.xml
@@ -46,7 +46,7 @@
         
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- Other dependency versions -->
         <version.dom4j>1.6</version.dom4j>

--- a/xml-jaxp/pom.xml
+++ b/xml-jaxp/pom.xml
@@ -46,7 +46,7 @@
 
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-10</version.jboss.spec.javaee.6.0>
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-11</version.jboss.spec.javaee.6.0>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>


### PR DESCRIPTION
Please merge this version update for building Quickstarts for EAP 6.3.0.ER4 (Beta2).
Thanks.
