### PR TITLE
Update HTML script to point to stylesheets in the jboss developer shared repository

### DIFF
--- a/dist/github-flavored-markdown.rb
+++ b/dist/github-flavored-markdown.rb
@@ -142,7 +142,7 @@ def markdown(source_path)
   rendered = markdown.render(text)
   metadata(source_path.path, rendered)
   rendered = rendered.gsub(/README.md/, "README.html").gsub(/CONTRIBUTING.md/, "CONTRIBUTING.html")
-  '<!DOCTYPE html><html><head><title>README</title><link href="http://www.jboss.org/jdf/stylesheets/documentation.css" rel="stylesheet"></link><link href="http://www.jboss.org/jdf/stylesheets/pygments.css" rel="stylesheet"></link></head><body>' + rendered + '</body></html>'
+  '<!DOCTYPE html><html><head><title>README</title><link href="https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/dist/css/documentation.css" rel="stylesheet"></link><link href="https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/dist/css/pygments.css" rel="stylesheet"></link></head><body>' + rendered + '</body></html>'
   end
 
 def optionize(options)


### PR DESCRIPTION
The old location is obsolete:  http://www.jboss.org/jdf/stylesheets/
