### PR TITLE
Bz1148848: Remove local CONTRIBUTING file and stop generating HTML for CONTRIBUTING.md files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,0 @@
-Quickstarts Contributing Guide
-==============================
-
-If you would like to contribute a quickstart, follow the instructions located in the JBoss Developer [Contributing Guide](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONTRIBUTING.md).
-

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Be sure to read this entire document before you attempt to work with the quickst
 
 * [Optional Components](#optional-components): How to install and configure optional components required by some of the quickstarts.
 
+* [Contributing Guide](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONTRIBUTING.md#jboss-developer-contributing-guide): This document contains information targeted for developers who want to contribute to JBoss developer projects.
+
 Use of EAP_HOME and JBOSS_HOME Variables
 ---------------------------------
 

--- a/dist/github-flavored-markdown.rb
+++ b/dist/github-flavored-markdown.rb
@@ -141,7 +141,7 @@ def markdown(source_path)
   text.gsub!("\[TOC\]", toc)
   rendered = markdown.render(text)
   metadata(source_path.path, rendered)
-  rendered = rendered.gsub(/README.md/, "README.html").gsub(/CONTRIBUTING.md/, "CONTRIBUTING.html")
+  rendered = rendered.gsub(/README.md/, "README.html")
   '<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body>' + rendered + '</body></html>'
   end
 

--- a/dist/release-utils.sh
+++ b/dist/release-utils.sh
@@ -113,14 +113,6 @@ markdown_to_html()
    output_filename=${output_filename//.MD/.html}
    $DIR/github-flavored-markdown.rb $readme > $output_filename  
 
-   # Now process the contributing markdown
-   cd $DIR/../
-   markdown_filename=CONTRIBUTING.md
-   echo "Processing $markdown_filename"
-   output_filename=${markdown_filename//.md/.html}
-   output_filename=${output_filename//.MD/.html}
-   $DIR/github-flavored-markdown.rb $markdown_filename > $output_filename  
-
    # Now process the release procedure markdown
    cd $DIR/../
    markdown_filename=RELEASE_PROCEDURE.md


### PR DESCRIPTION
I removed the CONTRIBUTING.md file since it just pointed to the one in the shared repository and added that link to the root README file instead.
