### PR TITLE
Fix logging quickstart README to use folder name on first line of README...

### DIFF
--- a/logging/README.md
+++ b/logging/README.md
@@ -1,4 +1,4 @@
-Logging Example: Example That Sets Up Different Logging Levels
+logging: Example That Sets Up Different Logging Levels
 ===============================================================
 Author: Joel Tosi  
 Level: Intermediate  


### PR DESCRIPTION
... file
