### PR TITLE
FORGE-2026: Configuring JavaEE 6 to avoid missing dependencies

### DIFF
--- a/forge-from-scratch/generate.fsh
+++ b/forge-from-scratch/generate.fsh
@@ -6,6 +6,9 @@ clear;
 # Create a new project in the current directory;
 project-new --named forge-example --topLevelPackage org.example;
 
+# Setup this project to have the necessary Java EE 6 dependencies
+javaee-setup --javaEEVersion 6
+
 #Turn our Java project into a Web project with JSF, CDI, EJB, and JPA;
 scaffold-setup --provider Faces;
 


### PR DESCRIPTION
When the techpreview repository is the only one configured, the scaffold-setup fails to execute. 

This is because it misses the version information (maven-metadata.xml) for the following artifact:

```
org.jboss.spec.javax.faces:jboss-jsf-api_2.0_spec
```
