### PR TITLE
Fixes BZ1178874 (CDI warnings in tasks-jsf)

### DIFF
--- a/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/DefaultDeployment.java
+++ b/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/DefaultDeployment.java
@@ -30,12 +30,22 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 public class DefaultDeployment {
 
     private static final String WEBAPP_SRC = "src/main/webapp";
+    private static final String TEST_WEBAPP_SRC = "src/test/webapp";
 
     private WebArchive webArchive;
 
     public DefaultDeployment() {
-        webArchive = ShrinkWrap.create(WebArchive.class, "test.war").addAsWebInfResource(
-                new File(WEBAPP_SRC, "WEB-INF/beans.xml"));
+        this(false);
+    }
+    
+    public DefaultDeployment(boolean useAlternative) {
+    	if (useAlternative) {
+    		webArchive = ShrinkWrap.create(WebArchive.class, "test.war").addAsWebInfResource(
+                    new File(TEST_WEBAPP_SRC, "WEB-INF/beans.xml"));
+    	} else {
+    		webArchive = ShrinkWrap.create(WebArchive.class, "test.war").addAsWebInfResource(
+                    new File(WEBAPP_SRC, "WEB-INF/beans.xml"));
+    	}
     }
 
     public DefaultDeployment withPersistence() {

--- a/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskDaoStub.java
+++ b/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskDaoStub.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.tasksJsf;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Testing
+public class TaskDaoStub implements TaskDao {
+
+    private int getAllCallsCount = 0;
+
+    @Override
+    public void createTask(User user, Task task) {
+    }
+
+    @Override
+    public List<Task> getAll(User user) {
+        getAllCallsCount += 1;
+        return Arrays.asList(new Task[] {});
+    }
+
+    @Override
+    public List<Task> getRange(User user, int offset, int count) {
+        return null;
+    }
+
+    @Override
+    public List<Task> getForTitle(User user, String title) {
+        return null;
+    }
+
+    @Override
+    public void deleteTask(Task task) {
+    }
+
+    public int getGetAllCallsCount() {
+        return getAllCallsCount;
+    }
+}

--- a/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskListBeanTest.java
+++ b/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskListBeanTest.java
@@ -19,10 +19,7 @@ package org.jboss.as.quickstarts.tasksJsf;
 import static org.junit.Assert.assertEquals;
 
 import java.io.FileNotFoundException;
-import java.util.Arrays;
-import java.util.List;
 
-import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -46,12 +43,12 @@ public class TaskListBeanTest {
 
     @Deployment
     public static WebArchive deployment() throws IllegalArgumentException, FileNotFoundException {
-        return new DefaultDeployment().withPersistence().withImportedData().getArchive()
-                .addClasses(User.class, Task.class, TaskList.class, TaskListBean.class, TaskDao.class);
+        return new DefaultDeployment(true).withPersistence().withImportedData().getArchive()
+                .addClasses(User.class, Task.class, TaskList.class, TaskListBean.class, TaskDao.class, TaskDaoStub.class, Testing.class);
     }
 
     @Inject
-    private TaskDaoStub taskDaoStub;
+    private TaskDao taskDaoStub;
 
     @Inject
     private TaskList taskList;
@@ -61,52 +58,18 @@ public class TaskListBeanTest {
         taskList.getAll();
         taskList.getAll();
         taskList.getAll();
-        assertEquals(1, taskDaoStub.getGetAllCallsCount());
+        assertEquals(1, ((TaskDaoStub) taskDaoStub).getGetAllCallsCount());
     }
 
     @Test
     public void dao_method_getAll_should_be_called_after_invalidation() {
         taskList.getAll();
         taskList.getAll();
-        assertEquals(1, taskDaoStub.getGetAllCallsCount());
+        assertEquals(1, ((TaskDaoStub) taskDaoStub).getGetAllCallsCount());
         taskList.invalidate();
-        assertEquals(1, taskDaoStub.getGetAllCallsCount());
+        assertEquals(1, ((TaskDaoStub) taskDaoStub).getGetAllCallsCount());
         taskList.getAll();
         taskList.getAll();
-        assertEquals(2, taskDaoStub.getGetAllCallsCount());
-    }
-
-    @RequestScoped
-    public static class TaskDaoStub implements TaskDao {
-
-        private int getAllCallsCount = 0;
-
-        @Override
-        public void createTask(User user, Task task) {
-        }
-
-        @Override
-        public List<Task> getAll(User user) {
-            getAllCallsCount += 1;
-            return Arrays.asList(new Task[] {});
-        }
-
-        @Override
-        public List<Task> getRange(User user, int offset, int count) {
-            return null;
-        }
-
-        @Override
-        public List<Task> getForTitle(User user, String title) {
-            return null;
-        }
-
-        @Override
-        public void deleteTask(Task task) {
-        }
-
-        public int getGetAllCallsCount() {
-            return getAllCallsCount;
-        }
+        assertEquals(2, ((TaskDaoStub) taskDaoStub).getGetAllCallsCount());
     }
 }

--- a/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/Testing.java
+++ b/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/Testing.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.tasksJsf;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Stereotype;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Alternative testing annotation, used to enable all testing alternatives.
+ * @author jporter
+ */
+@Stereotype
+@Inherited
+@Alternative
+@RequestScoped
+@Target({ TYPE, METHOD, FIELD })
+@Retention(RUNTIME)
+@Documented
+public @interface Testing {
+
+}

--- a/tasks-jsf/src/test/webapp/WEB-INF/beans.xml
+++ b/tasks-jsf/src/test/webapp/WEB-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ This file can be an empty text file (0 bytes) 
+ We're declaring the schema to save you time if you do have to configure 
+   this in the future -->
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="         http://java.sun.com/xml/ns/javaee          http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+ <alternatives>
+  <stereotype>org.jboss.as.quickstarts.tasksJsf.Testing</stereotype>
+ </alternatives>
+</beans>


### PR DESCRIPTION
I went with the alternative approach with a new Stereotype. This is
activated by a new beans.xml for testing. Unfortunately I had to do some
type casting because eclipse doesn't seem to know to look into / add /
whatever the test classes as possible injection points.
