### PR TITLE
[BZ-1178748] Remove versions of security jars from pom

### DIFF
--- a/ejb-security-interceptors/pom.xml
+++ b/ejb-security-interceptors/pom.xml
@@ -92,7 +92,6 @@
         <dependency>
             <groupId>org.jboss.as</groupId>
             <artifactId>jboss-as-security-api</artifactId>
-            <version>${version.jboss.as}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.as</groupId>
@@ -112,7 +111,6 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-core-security-api</artifactId>
-            <version>${version.jboss.as}</version>
             <exclusions>
                     <exclusion>
                     <groupId>org.jboss.as</groupId>


### PR DESCRIPTION
These two versions are already set in the ejb-client-bom
