### PR TITLE
Move WFK Spring and Contacts quickstarts over to EAP quickstarts repo. 

### DIFF
--- a/contacts-mobile-basic/README.md
+++ b/contacts-mobile-basic/README.md
@@ -4,9 +4,9 @@ Author: Joshua Wilson
 Level: Beginner  
 Technologies: jQuery Mobile, jQuery, JavaScript, HTML5, REST  
 Summary: The `contacts-mobile-basic` quickstart demonstrates a Java EE 6 mobile database application using HTML5, jQuery Mobile, JAX-RS, JPA 2.0, and REST.  
-Target Product: WFK  
-Product Versions: EAP 6.1, EAP 6.2, EAP 6.3, EAP 6.3, WFK 2.7  
-Source: <https://github.com/jboss-developer/jboss-wfk-quickstarts>  
+Target Product: JBoss EAP  
+Product Versions: EAP 6.1, EAP 6.2, EAP 6.3, EAP 6.3  
+Source: <https://github.com/jboss-developer/jboss-eap-quickstarts>  
 
 What is it?
 -----------
@@ -49,8 +49,7 @@ and [Does JBoss EAP support the use of Jackson libraries?](https://access.redhat
 System requirements
 -------------------
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or 
-later with the  Red Hat JBoss Web Framework Kit (WFK) 2.7.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or later.
 
 All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 

--- a/contacts-mobile-basic/functional-tests/pom.xml
+++ b/contacts-mobile-basic/functional-tests/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.as.quickstarts.wfk</groupId>
+    <groupId>org.jboss.as.quickstarts.eap</groupId>
     <artifactId>jboss-contacts-mobile-basic-test-webdriver</artifactId>
     <version>2.7.0-SNAPSHOT</version>
     <name>JBoss AS Quickstarts: Contacts test via WebDriver with Arquillian</name>
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.7.0-redhat-1</version.jboss.bom.wfk>
+        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>
@@ -70,10 +70,19 @@
     <dependencyManagement>
         <dependencies>
             <!-- Arquillian dependency -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
+                <groupId>org.jboss.bom.eap</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/contacts-mobile-basic/pom.xml
+++ b/contacts-mobile-basic/pom.xml
@@ -17,13 +17,13 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.jboss.quickstarts.wfk</groupId>
+    <groupId>org.jboss.quickstarts.eap</groupId>
     <artifactId>jboss-contacts-mobile-basic</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>6.4.0-redhat-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss WFK Quickstart: contacts-mobile-basic</name>
+    <name>JBoss EAP Quickstart: contacts-mobile-basic</name>
     <description>A Java EE 6 HTML5 mobile web application for use with JBoss.</description>
-    <url>http://jboss.org/</url>
+    <url>http://jboss.org/jbossas</url>
 
     <licenses>
         <license>
@@ -83,7 +83,6 @@
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
-        <version.jboss.bom.wfk>2.7.0-redhat-1</version.jboss.bom.wfk>
 
         <!-- Other dependency versions -->
         <version.org.eclipse.m2e>1.0.0</version.org.eclipse.m2e>
@@ -100,18 +99,19 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- JBoss distributes a complete set of Java EE 6 APIs including 
-                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or 
-                a collection) of artifacts. We use this here so that we always get the correct 
-                versions of artifacts. Here we use the jboss-javaee-6.0-with-tools stack 
-                (you can read this as the JBoss stack of the Java EE 6 APIs, with some extras 
-                tools for your project, such as Arquillian for testing) and the jboss-javaee-6.0-with-hibernate 
-                stack you can read this as the JBoss stack of the Java EE 6 APIs, with extras 
-                from the Hibernate family of projects) -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
+                <groupId>org.jboss.bom.eap</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/contact/Contact.java
+++ b/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/contact/Contact.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.quickstarts.wfk.contact;
+package org.jboss.quickstarts.contact;
 
 import java.io.Serializable;
 import java.util.Date;

--- a/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/contact/ContactRESTService.java
+++ b/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/contact/ContactRESTService.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.quickstarts.wfk.contact;
+package org.jboss.quickstarts.contact;
 
 import java.util.HashMap;
 import java.util.List;
@@ -211,7 +211,7 @@ public class ContactRESTService {
             Map<String, String> responseObj = new HashMap<String, String>();
             responseObj.put("email", "That email is already used, please use a unique email");
             responseObj.put("error", "This is where errors are displayed that are not related to a specific field");
-            responseObj.put("anotherError", "You can find this error message in /src/main/java/org/jboss/quickstarts/wfk/rest/ContactRESTService.java line 242.");
+            responseObj.put("anotherError", "You can find this error message in /src/main/java/org/jboss/quickstarts/contact/ContactRESTService.java line 242.");
             builder = Response.status(Response.Status.CONFLICT).entity(responseObj);
         } catch (Exception e) {
             log.info("Exception - " + e.toString());

--- a/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/contact/ContactRepository.java
+++ b/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/contact/ContactRepository.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.quickstarts.wfk.contact;
+package org.jboss.quickstarts.contact;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;

--- a/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/contact/ContactService.java
+++ b/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/contact/ContactService.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.quickstarts.wfk.contact;
+package org.jboss.quickstarts.contact;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;

--- a/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/contact/ContactValidator.java
+++ b/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/contact/ContactValidator.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.quickstarts.wfk.contact;
+package org.jboss.quickstarts.contact;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/contact/JaxRsActivator.java
+++ b/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/contact/JaxRsActivator.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.quickstarts.wfk.contact;
+package org.jboss.quickstarts.contact;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;

--- a/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/util/JSONPRequestFilter.java
+++ b/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/util/JSONPRequestFilter.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.quickstarts.wfk.util;
+package org.jboss.quickstarts.util;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/util/JacksonConfig.java
+++ b/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/util/JacksonConfig.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.quickstarts.wfk.util;
+package org.jboss.quickstarts.util;
 
 import java.text.SimpleDateFormat;
 

--- a/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/util/Resources.java
+++ b/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/util/Resources.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.quickstarts.wfk.util;
+package org.jboss.quickstarts.util;
 
 import java.util.logging.Logger;
 

--- a/contacts-mobile-basic/src/test/java/org/jboss/quickstarts/contact/test/ContactRegistrationTest.java
+++ b/contacts-mobile-basic/src/test/java/org/jboss/quickstarts/contact/test/ContactRegistrationTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.quickstarts.wfk.contact.test;
+package org.jboss.quickstarts.contact.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -29,14 +29,12 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
-
-import org.jboss.quickstarts.wfk.contact.Contact;
-import org.jboss.quickstarts.wfk.contact.ContactRepository;
-import org.jboss.quickstarts.wfk.contact.ContactRESTService;
-import org.jboss.quickstarts.wfk.contact.ContactService;
-import org.jboss.quickstarts.wfk.contact.ContactValidator;
-import org.jboss.quickstarts.wfk.util.Resources;
-
+import org.jboss.quickstarts.contact.Contact;
+import org.jboss.quickstarts.contact.ContactRESTService;
+import org.jboss.quickstarts.contact.ContactRepository;
+import org.jboss.quickstarts.contact.ContactService;
+import org.jboss.quickstarts.contact.ContactValidator;
+import org.jboss.quickstarts.util.Resources;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
                 <module>cdi-portable-extension</module>
                 <module>cdi-stereotype</module>
                 <module>cdi-veto</module>
+                <module>contacts-mobile-basic</module>
                 <module>ejb-asynchronous</module>
                 <module>ejb-in-ear</module>
                 <module>ejb-in-war</module>
@@ -163,6 +164,14 @@
                 <module>servlet-security</module>
                 <module>servlet-security-genericheader-auth</module>
                 <module>shopping-cart</module>
+                <module>spring-resteasy</module>
+                <module>spring-petclinic</module>
+                <module>spring-kitchensink-springmvctest</module>
+                <module>spring-kitchensink-matrixvariables</module>
+                <module>spring-kitchensink-controlleradvice</module>
+                <module>spring-kitchensink-basic</module>
+                <module>spring-kitchensink-asyncrequestmapping</module>
+                <module>spring-greeter</module>
                 <module>tasks</module>
                 <module>tasks-jsf</module>
                 <module>tasks-rs</module>

--- a/spring-greeter/README.md
+++ b/spring-greeter/README.md
@@ -4,15 +4,14 @@ Author: Marius Bogoevici
 Level: Beginner  
 Technologies: Spring MVC, JSP, JPA 2.0  
 Summary: The `spring-greeter` quickstart is based on the `greeter` quickstart, but differs in that it uses Spring MVC for Mapping GET and POST requests.  
-Target Product: WFK  
-Product Versions: EAP 6.1, EAP 6.2, EAP 6.3, WFK 2.7  
-Source: <https://github.com/jboss-developer/jboss-wfk-quickstarts/>  
+Target Product: JBoss EAP  
+Product Versions: EAP 6.1, EAP 6.2, EAP 6.3  
+Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 
 What is this?
 -------------
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or 
-later with the Red Hat JBoss Web Framework Kit (WFK) 2.7.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or later.
 
 The `spring-greeter` quickstart is based on the `greeter` quickstart, but differs in that it uses Spring MVC for Mapping GET and POST requests:
 
@@ -42,8 +41,7 @@ The user is added and a message displays the new user id number.
 System requirements
 -------------------
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or 
-later with the Red Hat JBoss Web Framework Kit (WFK) 2.7.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or later.
 
 All you need to build this project is Java 6.0 (Java SDK 1.6) or later, Maven 3.0 or later.
 

--- a/spring-greeter/functional-tests/pom.xml
+++ b/spring-greeter/functional-tests/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.as.quickstarts.wfk</groupId>
+    <groupId>org.jboss.as.quickstarts.eap</groupId>
     <artifactId>jboss-spring-greeter-test-webdriver</artifactId>
     <version>2.7.0-SNAPSHOT</version>
     <name>JBoss AS Quickstarts: Greeter Spring test via WebDriver with Arquillian</name>
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.7.0-redhat-1</version.jboss.bom.wfk>
+        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>
@@ -70,10 +70,19 @@
     <dependencyManagement>
         <dependencies>
             <!-- Arquillian dependency -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
+                <groupId>org.jboss.bom.eap</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spring-greeter/pom.xml
+++ b/spring-greeter/pom.xml
@@ -17,12 +17,12 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.jboss.quickstarts.wfk</groupId>
+    <groupId>org.jboss.quickstarts.eap</groupId>
     <artifactId>jboss-spring-greeter</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>6.4.0-redhat-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss WFK Quickstart: spring-greeter</name>
-    <description>JBoss WFK Quickstart: Spring Greeter</description>
+    <name>JBoss EAP Quickstart: spring-greeter</name>
+    <description>JBoss EAP Quickstart: Spring Greeter</description>
     <url>http://jboss.org/jbossas</url>
 
     <licenses>
@@ -99,19 +99,16 @@
     </properties>
 
     <dependencyManagement>
-
         <dependencies>
-            <!-- Define the version of JBoss' Java EE 6 APIs we want to import. Any
-                dependencies from org.jboss.spec will have their version defined by this
-                BOM -->
-            <!-- JBoss distributes a complete set of Java EE 6 APIs including a Bill
-                of Materials (BOM). A BOM specifies the versions of a "stack" (or a collection)
-                of artifacts. We use this here so that we always get the correct versions
-                of artifacts. Here we use the jboss-javaee-web-6.0 stack (you can read this
-                as the JBoss stack of the Java EE Web Profile 6 APIs), and we use version
-                2.0.0.Beta1 which is the latest release of the stack. You can actually use
-                this stack with any version of JBoss that implements Java EE 6, not just
-                JBoss EAP 6! -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
                 <groupId>org.jboss.bom.eap</groupId>
                 <artifactId>jboss-javaee-6.0-with-hibernate</artifactId>
@@ -169,8 +166,7 @@
             <artifactId>jboss-transaction-api_1.1_spec</artifactId>
         </dependency>
 
-        <!-- Import Spring dependencies, these are either from community or versions
-            certified in WFK2 -->
+        <!-- Import Spring dependencies -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>

--- a/spring-kitchensink-asyncrequestmapping/README.md
+++ b/spring-kitchensink-asyncrequestmapping/README.md
@@ -4,9 +4,9 @@ Author: Marius Bogoevici, Tejas Mehta, Joshua Wilson
 Level: Intermediate  
 Technologies: JSP, JPA, JSON, Spring, JUnit  
 Summary: The `spring-kitchensink-asyncrequestmapping` quickstart showcases the use of asynchronous requests is an example using JSP, JPA 2.0 and Spring 4.x.  
-Target Product: WFK  
-Product Versions: EAP 6.1, EAP 6.2, EAP 6.3, WFK 2.7  
-Source: <https://github.com/jboss-developer/jboss-wfk-quickstarts/>  
+Target Product: JBoss EAP  
+Product Versions: EAP 6.1, EAP 6.2, EAP 6.3  
+Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 
 What is it?
 -----------
@@ -29,8 +29,7 @@ and `<mvc:annotation-driven/>` are used to register both the non-rest and rest c
 System Requirements
 -------------------
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or 
-later with the Red Hat JBoss Web Framework Kit (WFK) 2.7.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or later.
 
 To run the quickstart with the provided build script, you need the following:
 

--- a/spring-kitchensink-asyncrequestmapping/functional-tests/pom.xml
+++ b/spring-kitchensink-asyncrequestmapping/functional-tests/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.as.quickstarts.wfk</groupId>
+    <groupId>org.jboss.as.quickstarts.eap</groupId>
     <artifactId>jboss-spring-kitchensink-asyncrequestmapping-test-webdriver</artifactId>
     <version>2.7.0-SNAPSHOT</version>
     <name>JBoss AS Quickstarts: Kitchensink test via WebDriver with Arquillian</name>
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.7.0-redhat-1</version.jboss.bom.wfk>
+        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>
@@ -70,10 +70,19 @@
     <dependencyManagement>
         <dependencies>
             <!-- Arquillian dependency -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
+                <groupId>org.jboss.bom.eap</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spring-kitchensink-asyncrequestmapping/pom.xml
+++ b/spring-kitchensink-asyncrequestmapping/pom.xml
@@ -17,11 +17,11 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.jboss.quickstarts.wfk</groupId>
+    <groupId>org.jboss.quickstarts.eap</groupId>
     <artifactId>jboss-spring-kitchensink-asyncrequestmapping</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>6.4.0-redhat-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss WFK Quickstart: spring-kitchensink-asyncrequestmapping</name>
+    <name>JBoss EAP Quickstart: spring-kitchensink-asyncrequestmapping</name>
     <description>Getting Started with Spring 4.0 on JBoss - AsyncRequests</description>
     <url>http://jboss.org/jbossas</url>
 
@@ -101,26 +101,19 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- JBoss distributes a complete set of Java EE 6 APIs including
-                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
-                a collection) of artifacts. We use this here so that we always get the correct
-                versions of artifacts. Here we use the jboss-javaee-6.0-with-tools stack
-                (you can read this as the JBoss stack of the Java EE 6 APIs, with some extras
-                tools for your project, such as Arquillian for testing) and the jboss-javaee-6.0-with-hibernate
-                stack you can read this as the JBoss stack of the Java EE 6 APIs, with extras
-                from the Hibernate family of projects) -->
-            <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-spring4.1</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
 
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
+                <groupId>org.jboss.bom.eap</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -129,6 +122,14 @@
                 <groupId>org.jboss.bom.eap</groupId>
                 <artifactId>jboss-javaee-6.0-with-hibernate</artifactId>
                 <version>${version.jboss.bom.eap}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.bom.wfk</groupId>
+                <artifactId>jboss-javaee-6.0-with-spring4.1</artifactId>
+                <version>${version.jboss.bom.wfk}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -229,8 +230,7 @@
             <artifactId>jboss-jstl-api_1.2_spec</artifactId>
         </dependency>
 
-        <!-- Import Spring dependencies, these are either from community or versions
-            certified in WFK2 -->
+        <!-- Import Spring dependencies -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>

--- a/spring-kitchensink-basic/README.md
+++ b/spring-kitchensink-basic/README.md
@@ -4,9 +4,9 @@ Author: Marius Bogoevici, Tejas Mehta, Joshua Wilson
 Level: Intermediate  
 Technologies: JSP, JPA, JSON, Spring, JUnit  
 Summary: The `spring-kitchensink-basic` quickstart is an example of a Java EE 6 application using JSP, JPA 2.0 and Spring 4.x.  
-Target Product: WFK  
-Product Versions: EAP 6.1, EAP 6.2, EAP 6.3, WFK 2.7  
-Source: <https://github.com/jboss-developer/jboss-wfk-quickstarts/>  
+Target Product: JBoss EAP  
+Product Versions: EAP 6.1, EAP 6.2, EAP 6.3  
+Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 
 What is it?
 -----------
@@ -27,8 +27,7 @@ and `<mvc:annotation-driven/>` are used to register both the non-rest and rest c
 System Requirements
 -------------------
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or 
-later with the Red Hat JBoss Web Framework Kit (WFK) 2.7.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or later.
 
 To run the quickstart with the provided build script, you need the following:
 

--- a/spring-kitchensink-basic/functional-tests/pom.xml
+++ b/spring-kitchensink-basic/functional-tests/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.as.quickstarts.wfk</groupId>
+    <groupId>org.jboss.as.quickstarts.eap</groupId>
     <artifactId>jboss-spring-kitchensink-basic-test-webdriver</artifactId>
     <version>2.7.0-SNAPSHOT</version>
     <name>JBoss AS Quickstarts: Kitchensink test via WebDriver with Arquillian</name>
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.7.0-redhat-1</version.jboss.bom.wfk>
+        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>
@@ -70,10 +70,19 @@
     <dependencyManagement>
         <dependencies>
             <!-- Arquillian dependency -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
+                <groupId>org.jboss.bom.eap</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spring-kitchensink-basic/pom.xml
+++ b/spring-kitchensink-basic/pom.xml
@@ -17,11 +17,11 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.jboss.quickstarts.wfk</groupId>
+    <groupId>org.jboss.quickstarts.eap</groupId>
     <artifactId>jboss-spring-kitchensink-basic</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>6.4.0-redhat-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss WFK Quickstart: spring-kitchensink-basic</name>
+    <name>JBoss EAP Quickstart: spring-kitchensink-basic</name>
     <description>Getting Started with Spring 4.0 on JBoss</description>
     <url>http://jboss.org/jbossas</url>
 
@@ -101,25 +101,26 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- JBoss distributes a complete set of Java EE 6 APIs including
-                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
-                a collection) of artifacts. We use this here so that we always get the correct
-                versions of artifacts. Here we use the jboss-javaee-6.0-with-tools stack
-                (you can read this as the JBoss stack of the Java EE 6 APIs, with some extras
-                tools for your project, such as Arquillian for testing) and the jboss-javaee-6.0-with-hibernate
-                stack you can read this as the JBoss stack of the Java EE 6 APIs, with extras
-                from the Hibernate family of projects) -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-spring4.1</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <groupId>org.jboss.bom.eap</groupId>
+                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
+                <artifactId>jboss-javaee-6.0-with-spring4.1</artifactId>
                 <version>${version.jboss.bom.wfk}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -235,8 +236,7 @@
             <artifactId>jboss-jstl-api_1.2_spec</artifactId>
         </dependency>
 
-        <!-- Import Spring dependencies, these are either from community or versions
-            certified in WFK2 -->
+        <!-- Import Spring dependencies -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>

--- a/spring-kitchensink-controlleradvice/README.md
+++ b/spring-kitchensink-controlleradvice/README.md
@@ -4,9 +4,9 @@ Author: Marius Bogoevici, Tejas Mehta, Joshua Wilson
 Level: Intermediate  
 Technologies: JSP, JPA, JSON, Spring, JUnit  
 Summary: The `spring-kitchensink-controlleradvice` quickstart showcases Spring 4.x's `@ControllerAdvice`, which was introduced in Spring 3.2.  
-Target Product: WFK  
-Product Versions: EAP 6.1, EAP 6.2, EAP 6.3, WFK 2.7  
-Source: <https://github.com/jboss-developer/jboss-wfk-quickstarts/>  
+Target Product: JBoss EAP  
+Product Versions: EAP 6.1, EAP 6.2, EAP 6.3  
+Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 
 What is it?
 -----------
@@ -30,8 +30,7 @@ and `<mvc:annotation-driven/>` are used to register both the non-rest and rest c
 System Requirements
 -------------------
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or 
-later with the Red Hat JBoss Web Framework Kit (WFK) 2.7.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or later.
 
 To run the quickstart with the provided build script, you need the following:
 

--- a/spring-kitchensink-controlleradvice/functional-tests/pom.xml
+++ b/spring-kitchensink-controlleradvice/functional-tests/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.as.quickstarts.wfk</groupId>
+    <groupId>org.jboss.as.quickstarts.eap</groupId>
     <artifactId>jboss-spring-kitchensink-controlleradvice-test-webdriver</artifactId>
     <version>2.7.0-SNAPSHOT</version>
     <name>JBoss AS Quickstarts: Kitchensink test via WebDriver with Arquillian</name>
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.7.0-redhat-1</version.jboss.bom.wfk>
+        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>
@@ -70,10 +70,19 @@
     <dependencyManagement>
         <dependencies>
             <!-- Arquillian dependency -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
+                <groupId>org.jboss.bom.eap</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spring-kitchensink-controlleradvice/pom.xml
+++ b/spring-kitchensink-controlleradvice/pom.xml
@@ -17,11 +17,11 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.jboss.quickstarts.wfk</groupId>
+    <groupId>org.jboss.quickstarts.eap</groupId>
     <artifactId>jboss-spring-kitchensink-controlleradvice</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>6.4.0-redhat-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss WFK Quickstart: spring-kitchensink-controlleradvice</name>
+    <name>JBoss EAP Quickstart: spring-kitchensink-controlleradvice</name>
     <description>Getting Started with Spring 4.0 on JBoss - Controller Advice</description>
     <url>http://jboss.org/jbossas</url>
 
@@ -101,25 +101,26 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- JBoss distributes a complete set of Java EE 6 APIs including
-                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
-                a collection) of artifacts. We use this here so that we always get the correct
-                versions of artifacts. Here we use the jboss-javaee-6.0-with-tools stack
-                (you can read this as the JBoss stack of the Java EE 6 APIs, with some extras
-                tools for your project, such as Arquillian for testing) and the jboss-javaee-6.0-with-hibernate
-                stack you can read this as the JBoss stack of the Java EE 6 APIs, with extras
-                from the Hibernate family of projects) -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-spring4.1</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <groupId>org.jboss.bom.eap</groupId>
+                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
+                <artifactId>jboss-javaee-6.0-with-spring4.1</artifactId>
                 <version>${version.jboss.bom.wfk}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -229,8 +230,7 @@
             <artifactId>jboss-jstl-api_1.2_spec</artifactId>
         </dependency>
 
-        <!-- Import Spring dependencies, these are either from community or versions
-            certified in WFK2 -->
+        <!-- Import Spring dependencies -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>

--- a/spring-kitchensink-matrixvariables/README.md
+++ b/spring-kitchensink-matrixvariables/README.md
@@ -4,9 +4,9 @@ Author: Marius Bogoevici, Tejas Mehta, Joshua Wilson
 Level: Intermediate  
 Technologies: JSP, JPA, JSON, Spring, JUnit  
 Summary: The `spring-kitchensink-matrixvariables` quickstart showcases Spring 4.x's support for **Matrix Variables** in URLs that was introduced in Spring 3.2.  
-Target Product: WFK  
-Product Versions: EAP 6.1, EAP 6.2, EAP 6.3, WFK 2.7  
-Source: <https://github.com/jboss-developer/jboss-wfk-quickstarts/>  
+Target Product: JBoss EAP  
+Product Versions: EAP 6.1, EAP 6.2, EAP 6.3  
+Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 
 What is it?
 -----------
@@ -40,8 +40,7 @@ the url form: `/filter;n=Name;e=Email`.
 System Requirements
 -------------------
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or 
-later with the Red Hat JBoss Web Framework Kit (WFK) 2.7.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or later.
 
 To run the quickstart with the provided build script, you need the following:
 

--- a/spring-kitchensink-matrixvariables/functional-tests/pom.xml
+++ b/spring-kitchensink-matrixvariables/functional-tests/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.as.quickstarts.wfk</groupId>
+    <groupId>org.jboss.as.quickstarts.eap</groupId>
     <artifactId>jboss-spring-kitchensink-matrixvariables-test-webdriver</artifactId>
     <version>2.7.0-SNAPSHOT</version>
     <name>JBoss AS Quickstarts: Kitchensink test via WebDriver with Arquillian</name>
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.7.0-redhat-1</version.jboss.bom.wfk>
+        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>
@@ -70,10 +70,19 @@
     <dependencyManagement>
         <dependencies>
             <!-- Arquillian dependency -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
+                <groupId>org.jboss.bom.eap</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spring-kitchensink-matrixvariables/pom.xml
+++ b/spring-kitchensink-matrixvariables/pom.xml
@@ -17,11 +17,11 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.jboss.quickstarts.wfk</groupId>
+    <groupId>org.jboss.quickstarts.eap</groupId>
     <artifactId>jboss-spring-kitchensink-matrixvariables</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>6.4.0-redhat-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss WFK Quickstart: spring-kitchensink-matrixvariables</name>
+    <name>JBoss EAP Quickstart: spring-kitchensink-matrixvariables</name>
     <description>Getting Started with Spring 4.0 on JBoss - Matrix Variables</description>
     <url>http://jboss.org/jbossas</url>
 
@@ -101,25 +101,26 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- JBoss distributes a complete set of Java EE 6 APIs including
-                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
-                a collection) of artifacts. We use this here so that we always get the correct
-                versions of artifacts. Here we use the jboss-javaee-6.0-with-tools stack
-                (you can read this as the JBoss stack of the Java EE 6 APIs, with some extras
-                tools for your project, such as Arquillian for testing) and the jboss-javaee-6.0-with-hibernate
-                stack you can read this as the JBoss stack of the Java EE 6 APIs, with extras
-                from the Hibernate family of projects) -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-spring4.1</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <groupId>org.jboss.bom.eap</groupId>
+                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
+                <artifactId>jboss-javaee-6.0-with-spring4.1</artifactId>
                 <version>${version.jboss.bom.wfk}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -229,8 +230,7 @@
             <artifactId>jboss-jstl-api_1.2_spec</artifactId>
         </dependency>
 
-        <!-- Import Spring dependencies, these are either from community or versions
-            certified in WFK2 -->
+        <!-- Import Spring dependencies -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>

--- a/spring-kitchensink-springmvctest/README.md
+++ b/spring-kitchensink-springmvctest/README.md
@@ -4,9 +4,9 @@ Author: Marius Bogoevici, Tejas Mehta, Joshua Wilson
 Level: Intermediate  
 Technologies: JSP, JPA, JSON, Spring, JUnit  
 Summary: The  `spring-kitchensink-springmvctest` quickstart demonstrates how to create an MVC application using JSP, JPA 2.0 and Spring 4.x.   
-Target Product: WFK  
-Product Versions: EAP 6.1, EAP 6.2, EAP 6.3, WFK 2.7  
-Source: <https://github.com/jboss-developer/jboss-wfk-quickstarts/>  
+Target Product: JBoss EAP  
+Product Versions: EAP 6.1, EAP 6.2, EAP 6.3  
+Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 
 What is it?
 -----------
@@ -30,8 +30,7 @@ and `<mvc:annotation-driven/>` are used to register both the non-rest and rest c
 System Requirements
 -------------------
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or 
-later with the Red Hat JBoss Web Framework Kit (WFK) 2.7.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or later.
 
 To run the quickstart with the provided build script, you need the following:
 

--- a/spring-kitchensink-springmvctest/functional-tests/pom.xml
+++ b/spring-kitchensink-springmvctest/functional-tests/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.as.quickstarts.wfk</groupId>
+    <groupId>org.jboss.as.quickstarts.eap</groupId>
     <artifactId>jboss-spring-kitchensink-springmvctest-test-webdriver</artifactId>
     <version>2.7.0-SNAPSHOT</version>
     <name>JBoss AS Quickstarts: Kitchensink test via WebDriver with Arquillian</name>
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.7.0-redhat-1</version.jboss.bom.wfk>
+        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>
@@ -70,10 +70,19 @@
     <dependencyManagement>
         <dependencies>
             <!-- Arquillian dependency -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
+                <groupId>org.jboss.bom.eap</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spring-kitchensink-springmvctest/pom.xml
+++ b/spring-kitchensink-springmvctest/pom.xml
@@ -17,11 +17,11 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.jboss.quickstarts.wfk</groupId>
+    <groupId>org.jboss.quickstarts.eap</groupId>
     <artifactId>jboss-spring-kitchensink-springmvctest</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>6.4.0-redhat-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss WFK Quickstart: spring-kitchensink-springmvctest</name>
+    <name>JBoss EAP Quickstart: spring-kitchensink-springmvctest</name>
     <description>Getting Started with Spring 4.0 on JBoss - MVC Tests</description>
     <url>http://jboss.org/jbossas</url>
 
@@ -105,25 +105,26 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- JBoss distributes a complete set of Java EE 6 APIs including
-                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
-                a collection) of artifacts. We use this here so that we always get the correct
-                versions of artifacts. Here we use the jboss-javaee-6.0-with-tools stack
-                (you can read this as the JBoss stack of the Java EE 6 APIs, with some extras
-                tools for your project, such as Arquillian for testing) and the jboss-javaee-6.0-with-hibernate
-                stack you can read this as the JBoss stack of the Java EE 6 APIs, with extras
-                from the Hibernate family of projects) -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-spring4.1</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <groupId>org.jboss.bom.eap</groupId>
+                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
+                <artifactId>jboss-javaee-6.0-with-spring4.1</artifactId>
                 <version>${version.jboss.bom.wfk}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -247,8 +248,7 @@
             <artifactId>jboss-jstl-api_1.2_spec</artifactId>
         </dependency>
 
-        <!-- Import Spring dependencies, these are either from community or versions
-            certified in WFK2 -->
+        <!-- Import Spring dependencies -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>

--- a/spring-petclinic/CHANGES.md
+++ b/spring-petclinic/CHANGES.md
@@ -10,7 +10,7 @@ CHANGES
 
 1. Addition of `webapp/WEB-INF/jboss-deployment-structure.xml`, ensuring no conflict with JBOSS' Hibernate module with 
 those packaged by this quickstart. See [JBOSS DEPLOYMENT STRUCTURE](<https://docs.jboss.org/author/display/AS7/Class+Loading+in+AS7#ClassLoadinginAS7-JBossDeploymentStructureFile>) for more details.
-2. Configured to use Red Hat JBoss EAP & WFK BOMs.
+2. Configured to use Red Hat JBoss EAP BOMs.
 3. Regressed the jQuery version to 1.9 as that is what is currently certified on EAP.
 4. Add plugin to deploy directly to running JBoss from mvn build.
 5. Add loadtime-weaving support.

--- a/spring-petclinic/README.md
+++ b/spring-petclinic/README.md
@@ -3,15 +3,15 @@ spring-petclinic: PetClinic Example using Spring 4.x
 Author: Ken Krebs, Juergen Hoeller, Rob Harrop, Costin Leau, Sam Brannen, Scott Andrews  
 Level: Advanced  
 Technologies: JPA 2.0, Junit, JMX, Spring MVC Annotations, AOP, Spring Data, JSP, webjars, Dandellion  
-Summary: The `spring-petclinic` quickstart shows how to run the Spring PetClinic Application in JBoss EAP using the JBoss EAP and WFK BOMs.  
-Target Product: WFK  
-Product Versions: EAP 6.1, EAP 6.2, EAP 6.3, WFK 2.7  
-Source: <https://github.com/jboss-developer/jboss-wfk-quickstarts/>  
+Summary: The `spring-petclinic` quickstart shows how to run the Spring PetClinic Application in JBoss EAP using the JBoss EAP BOMs.  
+Target Product: JBoss EAP  
+Product Versions: EAP 6.1, EAP 6.2, EAP 6.3  
+Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 
 What is it?  
 -----------
 The `spring-petclinic` quickstart shows how to run the [Spring PetClinic](<http://github.com/spring-projects/spring-petclinic>) Application 
-in Red Hat JBoss Enterprise Application Platform with the use of Red Hat JBoss EAP & WFK BOMs (_for the best compatibility_). One of the major 
+in Red Hat JBoss Enterprise Application Platform with the use of Red Hat JBoss EAP BOMs (_for the best compatibility_). One of the major 
 changes is the use of the `webapp/WEB-INF/jboss-deployment-structure.xml` file. This file specifies which modules 
 to include or exclude when building the application. In this case, we exclude Hibernate libraries since the application 
 uses Spring Data JPA. Additionally, this is only required when using the spring-data-jpa profile, see `resources/spring/business-config.xml`.
@@ -45,8 +45,7 @@ DBCP project for connection pooling. See `datasource-config.xml`._
 System requirements  
 -------------------
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or 
-later with the Red Hat JBoss Web Framework Kit (WFK) 2.7.
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (JBoss EAP) 6.1 or later.
 
 All you need to build this project is Java 7.0 or later and Maven 3.0 or later.
 

--- a/spring-petclinic/functional-tests/pom.xml
+++ b/spring-petclinic/functional-tests/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.as.quickstarts.wfk</groupId>
+    <groupId>org.jboss.as.quickstarts.eap</groupId>
     <artifactId>jboss-spring-petclinic-test-webdriver</artifactId>
     <version>2.7.0-SNAPSHOT</version>
     <name>JBoss AS Quickstarts: Spring Petclinic Demo ftest via WebDriver with Arquillian</name>
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.7.0-redhat-1</version.jboss.bom.wfk>
+        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>
@@ -60,10 +60,19 @@
     <dependencyManagement>
         <dependencies>
             <!-- Arquillian dependency -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
             <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
+                <groupId>org.jboss.bom.eap</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
+                <version>${version.jboss.bom.eap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spring-petclinic/pom.xml
+++ b/spring-petclinic/pom.xml
@@ -16,12 +16,12 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.jboss.quickstarts.wfk</groupId>
+    <groupId>org.jboss.quickstarts.eap</groupId>
     <artifactId>jboss-spring-petclinic</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>6.4.0-redhat-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss WFK Quickstart: spring-petclinic</name>
-    <description>JBoss WFK Quickstart: PetClinic</description>
+    <name>JBoss EAP Quickstart: spring-petclinic</name>
+    <description>JBoss EAP Quickstart: PetClinic</description>
     <url>http://jboss.org/jbossas</url>
 
     <licenses>
@@ -76,7 +76,7 @@
 
 		<!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
 		<jboss.bom.wfk.version>2.7.0-redhat-1</jboss.bom.wfk.version>
-		<jboss.bom.eap.version>6.3.2.GA</jboss.bom.eap.version>
+        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
 
 		<!-- Generic properties -->
 		<java.version>1.6</java.version>
@@ -153,24 +153,34 @@
 
     <dependencyManagement>
 		<dependencies>
-			<!-- JBoss Boms -->
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
+            <dependency>
+                <groupId>org.jboss.bom.eap</groupId>
+                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
+                <version>${version.jboss.bom.eap}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
 			<dependency>
 				<groupId>org.jboss.bom.eap</groupId>
 				<artifactId>jboss-javaee-6.0-with-hibernate</artifactId>
-				<version>${jboss.bom.eap.version}</version>
+                <version>${version.jboss.bom.eap}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+
 			<dependency>
 				<groupId>org.jboss.bom.wfk</groupId>
 				<artifactId>jboss-javaee-6.0-with-spring4.1</artifactId>
-				<version>${jboss.bom.wfk.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.jboss.bom.wfk</groupId>
-				<artifactId>jboss-javaee-6.0-with-tools</artifactId>
 				<version>${jboss.bom.wfk.version}</version>
 				<type>pom</type>
 				<scope>import</scope>

--- a/spring-resteasy/README.md
+++ b/spring-resteasy/README.md
@@ -4,9 +4,9 @@ Author: Weinan Li <l.weinan@gmail.com>, Paul Gier <pgier@redhat.com>
 Level: Beginner  
 Technologies: Resteasy, Spring  
 Summary: The `spring-resteasy` quickstart demonstrates how to package and deploy a web application that includes resteasy-spring integration.  
-Target Product: WFK  
-Product Versions: EAP 6.2, EAP 6.3, WFK 2.7  
-Source: <https://github.com/jboss-developer/jboss-wfk-quickstarts/>  
+Target Product: JBoss EAP  
+Product Versions: EAP 6.2, EAP 6.3  
+Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 
 What is it?
 -----------

--- a/spring-resteasy/pom.xml
+++ b/spring-resteasy/pom.xml
@@ -17,12 +17,12 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.jboss.quickstarts.wfk</groupId>
+    <groupId>org.jboss.quickstarts.eap</groupId>
     <artifactId>jboss-spring-resteasy</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>6.4.0-redhat-SNAPSHOT</version>
     <packaging>war</packaging>
-    <name>JBoss WFK Quickstart: spring-resteasy</name>
-    <description>JBoss WFK Quickstart: Resteasy Spring Demonstrates the use of a JAX-RS RestEasy client</description>
+    <name>JBoss EAP Quickstart: spring-resteasy</name>
+    <description>JBoss EAP Quickstart: Resteasy Spring Demonstrates the use of a JAX-RS RestEasy client</description>
     <url>http://jboss.org/jbossas</url>
 
     <licenses>
@@ -106,6 +106,23 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import.
+                 Any dependencies from org.jboss.spec will have their version defined by this BOM
+
+                 JBoss distributes a complete set of Java EE 6 APIs including
+                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                 a collection) of artifacts. We use this here so that we always get the correct
+                 versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+                 read this as the JBoss stack of the Java EE 6 APIs). You can actually
+                 use this stack with any version of JBoss EAP that implements Java EE 6. -->
+            <dependency>
+                <groupId>org.jboss.bom.eap</groupId>
+                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
+                <version>${version.jboss.bom.eap}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <groupId>org.jboss.bom.eap</groupId>
                 <artifactId>jboss-javaee-6.0-with-resteasy</artifactId>
@@ -113,6 +130,7 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+
             <dependency>
                 <groupId>org.jboss.bom.wfk</groupId>
                 <artifactId>jboss-javaee-6.0-with-spring4.1</artifactId>
@@ -120,13 +138,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>${version.jboss.bom.wfk}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
+
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>


### PR DESCRIPTION
Move WFK Spring and Contacts quickstarts over to EAP quickstarts repo. Change and configure to point to EAP.

These Quickstarts still need to have the QSTools applied. 
