### PR TITLE
Add warnings to the quickstarts that do not yet build in EAP 7: cluster-...

### DIFF
--- a/cluster-ha-singleton/README.md
+++ b/cluster-ha-singleton/README.md
@@ -10,6 +10,8 @@ Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 What is it?
 -----------
 
+_NOTE: This quickstart can not yet be built in Red Hat JBoss EAP 7. It has been temporarily disabled until the API dependencies are resolved._
+
 The `cluster-ha-singleton` quickstart demonstrates the deployment of a Service that is wrapped with the 
 SingletonService decorator and used as a cluster-wide singleton service in Red Hat JBoss Enterprise Application Platform.
 The service activates a scheduled timer, which is started only once in the cluster.

--- a/ejb-security-interceptors/README.md
+++ b/ejb-security-interceptors/README.md
@@ -10,6 +10,8 @@ Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 What is it?
 -----------
 
+_NOTE: This quickstart can not yet be built in Red Hat JBoss EAP 7. It has been temporarily disabled until the API dependencies are resolved._
+
 The `ejb-security-interceptors` quickstart demonstrates how to use client and server side interceptors to switch the identity for an EJB call in Red Hat JBoss Enterprise Application Platform.
 
 By default, when you make a remote call to an EJB deployed to the application server, the connection to the server is authenticated and any request received over this connection is executed as the identity that authenticated the connection. This is true for both client-to-server and server-to-server calls. If you need to use different identities from the same client, you normally need to open multiple connections to the server so that each one is authenticated as a different identity.

--- a/servlet-security-genericheader-auth/README.md
+++ b/servlet-security-genericheader-auth/README.md
@@ -10,6 +10,8 @@ Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 What is it?
 -----------
 
+_NOTE: This quickstart can not yet be built in Red Hat JBoss EAP 7. It has been temporarily disabled until the API dependencies are resolved._
+
 The `servlet-security-genericheader-auth` quickstart demonstrates a method for HTTP authentication based upon an HTTP header in the incoming request in Red Hat JBoss Enterprise Application Platform. 
 A Tomcat Valve called "GenericHeaderAuthenticator" is used to pass these credentials to JBoss. Tomcat Valves provide a 
 powerful, flexible way to insert a Java component into the request servlet container's request processing pipeline in 


### PR DESCRIPTION
...ha-singleton, ejb-securityinterceptors, and servlet-security-genericheader-auth
