### PR TITLE
Update JPA version to 2.1 in persistence.xml

### DIFF
--- a/spring-greeter/src/main/resources/META-INF/persistence.xml
+++ b/spring-greeter/src/main/resources/META-INF/persistence.xml
@@ -17,7 +17,7 @@
 <persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
-             version="2.0">
+             version="2.1">
 
     <persistence-unit name="helloPU" transaction-type="JTA">
         <!--


### PR DESCRIPTION
JPA 2.1 is part of Java EE 7 Specification, EAP 7 is Java EE 7 container, thus every quickstart targeting EAP7 should use JPA 2.1.
