### PR TITLE
Remove versions in Spring schema locations in spring-greeter example

### DIFF
--- a/spring-greeter/src/main/webapp/WEB-INF/spring-mvc-context.xml
+++ b/spring-greeter/src/main/webapp/WEB-INF/spring-mvc-context.xml
@@ -18,9 +18,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
    xmlns:mvc="http://www.springframework.org/schema/mvc"
-   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
-        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
    <context:component-scan base-package="org.jboss.spring.quickstarts.greeter.greeter_spring.web" />
 


### PR DESCRIPTION
In Spring, recommended practice is not to specify versions in XSD files. In that case the latest version is used, which is perfectly ok, even if latest version is not used in application. Specific versions should be used only if application doesn't work with latest (unversioned) XSD files.
