### PR TITLE
Update of EAP BOMs to 7.0.0-build-7 in functional tests

### DIFF
--- a/contacts-jquerymobile/functional-tests/pom.xml
+++ b/contacts-jquerymobile/functional-tests/pom.xml
@@ -47,7 +47,7 @@
         <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
+        <version.jboss.bom.eap>7.0.0-build-7</version.jboss.bom.eap>
 
         <!-- other plug-in versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>

--- a/spring-greeter/functional-tests/pom.xml
+++ b/spring-greeter/functional-tests/pom.xml
@@ -47,7 +47,7 @@
         <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
+        <version.jboss.bom.eap>7.0.0-build-7</version.jboss.bom.eap>
 
         <!-- other plug-in versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>

--- a/spring-kitchensink-asyncrequestmapping/functional-tests/pom.xml
+++ b/spring-kitchensink-asyncrequestmapping/functional-tests/pom.xml
@@ -47,7 +47,7 @@
         <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
+        <version.jboss.bom.eap>7.0.0-build-7</version.jboss.bom.eap>
 
         <!-- other plug-in versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>

--- a/spring-kitchensink-controlleradvice/functional-tests/pom.xml
+++ b/spring-kitchensink-controlleradvice/functional-tests/pom.xml
@@ -47,7 +47,7 @@
         <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
+        <version.jboss.bom.eap>7.0.0-build-7</version.jboss.bom.eap>
 
         <!-- other plug-in versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>

--- a/spring-kitchensink-matrixvariables/functional-tests/pom.xml
+++ b/spring-kitchensink-matrixvariables/functional-tests/pom.xml
@@ -47,7 +47,7 @@
         <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
+        <version.jboss.bom.eap>7.0.0-build-7</version.jboss.bom.eap>
 
         <!-- other plug-in versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>

--- a/spring-kitchensink-springmvctest/functional-tests/pom.xml
+++ b/spring-kitchensink-springmvctest/functional-tests/pom.xml
@@ -47,7 +47,7 @@
         <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
+        <version.jboss.bom.eap>7.0.0-build-7</version.jboss.bom.eap>
 
         <!-- other plug-in versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>


### PR DESCRIPTION
Update to proper version of -with-tools BOM, so it is exactly like in all the other examples.
