### PR TITLE
[JBEAP-696] Add @Produces content type on the rest endpoints.

### DIFF
--- a/logging-tools/src/main/java/org/jboss/as/quickstarts/loggingToolsQS/DateService.java
+++ b/logging-tools/src/main/java/org/jboss/as/quickstarts/loggingToolsQS/DateService.java
@@ -16,11 +16,10 @@
  */
 package org.jboss.as.quickstarts.loggingToolsQS;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -34,9 +33,8 @@ import org.jboss.as.quickstarts.loggingToolsQS.loggers.DateLogger;
 
 /**
  * A simple REST service which returns the number of days until a date and provides localised logging of the activity
- * 
+ *
  * @author dmison@me.com
- * 
  */
 
 @Path("dates")
@@ -45,38 +43,32 @@ public class DateService {
     @GET
     @Path("daysuntil/{targetdate}")
     @Produces(MediaType.TEXT_PLAIN)
-    public int showDaysUntil(@PathParam("targetdate") String targetdate) {
-        DateLogger.LOGGER.logDaysUntilRequest(targetdate);
+    public long showDaysUntil(@PathParam("targetdate") String targetDate) {
+        DateLogger.LOGGER.logDaysUntilRequest(targetDate);
 
-        DateFormat df = new SimpleDateFormat("dd-MM-yyyy");
-        Date target = null;
-        Date now = new Date();
-
-        float days = 0;
+        final long days;
 
         try {
-            df.setLenient(false);               //make sure no invalid dates sneak through
-            target = df.parse(targetdate);
-            days = (float) target.getTime() - now.getTime();
-            days = days / (1000 * 60 * 60 * 24); // turn milliseconds into days
-        } catch (ParseException ex) {
+            final LocalDate date = LocalDate.parse(targetDate, DateTimeFormatter.ISO_DATE);
+            days = ChronoUnit.DAYS.between(LocalDate.now(), date);
+        } catch (DateTimeParseException ex) {
             // ** DISCLAIMER **
             // This example is contrived and overly verbose for the purposes of showing the
             // different logging methods. It's generally not recommended to recreate exceptions
             // or log exceptions that are being thrown.
 
             // create localized ParseException using method from bundle with details from ex
-            ParseException nex = DateExceptionsBundle.EXCEPTIONS.targetDateStringDidntParse(targetdate, ex.getErrorOffset());
+            DateTimeParseException nex = DateExceptionsBundle.EXCEPTIONS.targetDateStringDidntParse(targetDate, ex.getParsedString(), ex.getErrorIndex());
 
             // log a message using nex as the cause
-            DateLogger.LOGGER.logStringCouldntParseAsDate(targetdate, nex);
+            DateLogger.LOGGER.logStringCouldntParseAsDate(targetDate, nex);
 
             // throw a WebApplicationException (400) with the localized message from nex
             throw new WebApplicationException(Response.status(400).entity(nex.getLocalizedMessage()).type(MediaType.TEXT_PLAIN)
                     .build());
         }
 
-        return Math.round(days);
+        return days;
     }
 
 }

--- a/logging-tools/src/main/java/org/jboss/as/quickstarts/loggingToolsQS/DateService.java
+++ b/logging-tools/src/main/java/org/jboss/as/quickstarts/loggingToolsQS/DateService.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -43,6 +44,7 @@ public class DateService {
 
     @GET
     @Path("daysuntil/{targetdate}")
+    @Produces(MediaType.TEXT_PLAIN)
     public int showDaysUntil(@PathParam("targetdate") String targetdate) {
         DateLogger.LOGGER.logDaysUntilRequest(targetdate);
 

--- a/logging-tools/src/main/java/org/jboss/as/quickstarts/loggingToolsQS/GreeterService.java
+++ b/logging-tools/src/main/java/org/jboss/as/quickstarts/loggingToolsQS/GreeterService.java
@@ -21,6 +21,8 @@ import java.util.Locale;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 import org.jboss.as.quickstarts.loggingToolsQS.exceptions.GreeterExceptionBundle;
 import org.jboss.as.quickstarts.loggingToolsQS.loggers.GreeterLogger;
@@ -41,6 +43,7 @@ public class GreeterService {
     // Hello "name"!
     @GET
     @Path("{name}")
+    @Produces(MediaType.TEXT_PLAIN)
     public String getHelloName(@PathParam("name") String name) {
         GreeterLogger.LOGGER.logHelloMessageSent();
         return GreetingMessagesBundle.MESSAGES.helloToYou(name);
@@ -50,6 +53,7 @@ public class GreeterService {
     // Hello "name" in language
     @GET
     @Path("{locale}/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
     public String getHelloNameForLocale(@PathParam("name") String name, @PathParam("locale") String locale) {
         String[] locale_parts = locale.split("-");
         Locale newLocale = null;
@@ -78,6 +82,7 @@ public class GreeterService {
     // the throwing of a localized exception with another exception as the cause. 
     @GET
     @Path("crashme")
+    @Produces(MediaType.TEXT_PLAIN)
     public String crashMe() throws Exception {
         int value = 0;
 

--- a/logging-tools/src/main/java/org/jboss/as/quickstarts/loggingToolsQS/exceptions/DateExceptionsBundle.java
+++ b/logging-tools/src/main/java/org/jboss/as/quickstarts/loggingToolsQS/exceptions/DateExceptionsBundle.java
@@ -16,7 +16,7 @@
  */
 package org.jboss.as.quickstarts.loggingToolsQS.exceptions;
 
-import java.text.ParseException;
+import java.time.format.DateTimeParseException;
 
 import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Message;
@@ -28,6 +28,6 @@ public interface DateExceptionsBundle {
     DateExceptionsBundle EXCEPTIONS = Messages.getBundle(DateExceptionsBundle.class);
 
     @Message(id = 7, value = "The date you sent me isn't valid, '%s'.  Sorry.")
-    ParseException targetDateStringDidntParse(String dateString, @Param int errorOffset);
+    DateTimeParseException targetDateStringDidntParse(String dateString, @Param String parsedData, @Param int errorOffset);
 
 }

--- a/logging-tools/src/main/java/org/jboss/as/quickstarts/loggingToolsQS/loggers/DateLogger.java
+++ b/logging-tools/src/main/java/org/jboss/as/quickstarts/loggingToolsQS/loggers/DateLogger.java
@@ -32,7 +32,7 @@ public interface DateLogger extends BasicLogger {
 
     @LogMessage(level = Level.ERROR)
     @Message(id = 3, value = "Invalid date passed as string: %s")
-    void logStringCouldntParseAsDate(String datestring, @Cause ParseException exception);
+    void logStringCouldntParseAsDate(String dateString, @Cause Throwable exception);
 
     @LogMessage
     @Message(id = 4, value = "Requested number of days until '%s'")

--- a/logging-tools/src/main/webapp/index.html
+++ b/logging-tools/src/main/webapp/index.html
@@ -100,9 +100,9 @@
     			<br />
     		</li>
     		<li>
-    		    <code>rest/dates/daysuntil/<b>targetdate</b></code>
+    		    <code>rest/dates/daysuntil/<b>targetDate</b></code>
     			<p>
-    			Example: <a href="rest/dates/daysuntil/25-12-2020">rest/dates/daysuntil/25-12-2020</a>
+    			Example: <a href="rest/dates/daysuntil/2020-12-25">rest/dates/daysuntil/2020-12-25</a>
     			</p>
     			<p>
     			Demonstrates how to pass parameters through to the constructor of a localized exception, and
@@ -110,14 +110,14 @@
     			</p>
     			<ul>
     				<li>
-    				Attempts to turn the `targetdate` URL component into a date object using the format
+    				Attempts to turn the `targetDate` URL component into a date object using the format
                     `dd-MM-yyyy`.
     				</li>
     				<li>
     				Returns number of days (as an integer) until that date.
     				</li>
     				<li>
-    				If the `targetdate` is invalid, for example, <a href="rest/dates/daysuntil/31-02-2015">rest/dates/daysuntil/31-02-2015</a>:
+    				If the `targetDate` is invalid, for example, <a href="rest/dates/daysuntil/2015-02-31">rest/dates/daysuntil/2015-02-31</a>:
     				<ul>
     				    <li>
     				    Catches the `ParseException`.


### PR DESCRIPTION
If I'm reading the [JSR-336](https://jcp.org/en/jsr/detail?id=339) section 4..2.4 indicates that numeric return types need a `text/plain` content type. When no `@Prodcues` annotation is present the content type is `*/*` which results in a return type of `int` not being able to find a `MessageBodyWriter`. Adding the `@Prodcues(MediaType.TEXT_PLAIN)` fixes the issue.

I also made some minor changes to use the new date-time API in Java 8.
