### PR TITLE
JBEAP-677  ejb-remote; ejb-security-interceptors; ejb-asychronous -- correct maven dependencies for client applicaton

### DIFF
--- a/ejb-asynchronous/client/pom.xml
+++ b/ejb-asynchronous/client/pom.xml
@@ -64,12 +64,19 @@
             <type>ejb-client</type>
         </dependency>
         
+        <!-- Include the EJB API -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Include the ejb client jars -->
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
 
     </dependencies>

--- a/ejb-asynchronous/ejb/pom.xml
+++ b/ejb-asynchronous/ejb/pom.xml
@@ -39,6 +39,7 @@
     </licenses>
     
     <dependencies>
+        <!-- Import the EJB API, we use provided scope as the API is included in JBoss EAP -->
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>
             <artifactId>jboss-ejb-api_3.2_spec</artifactId>

--- a/ejb-asynchronous/pom.xml
+++ b/ejb-asynchronous/pom.xml
@@ -144,15 +144,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <dependencies>
-        <!-- Import the EJB API, we use provided scope as the API is included in JBoss EAP -->
-        <dependency>
-            <groupId>org.jboss.spec.javax.ejb</groupId>
-            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
-
     <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>

--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -110,7 +110,7 @@
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
 
     </dependencies>

--- a/ejb-security-interceptors/pom.xml
+++ b/ejb-security-interceptors/pom.xml
@@ -147,7 +147,7 @@
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-677

maven dependencies are not set correct, so the client is missing some libraries
