### PR TITLE
Update of EAP BOMs to 7.0.0-build-7 in functional tests

### DIFF
--- a/spring-petclinic/functional-tests/pom.xml
+++ b/spring-petclinic/functional-tests/pom.xml
@@ -48,7 +48,7 @@
         <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.eap>6.3.2.GA</version.jboss.bom.eap>
+        <version.jboss.bom.eap>7.0.0-build-7</version.jboss.bom.eap>
 
         <!-- other plug-in versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>


### PR DESCRIPTION
This version is used in all the other functional test's pom.xml files
