### PR TITLE
JBEAP-1022: Change zipcode to string and fix apartement number in jsonp quickstart.

### DIFF
--- a/jsonp/README.md
+++ b/jsonp/README.md
@@ -41,7 +41,7 @@ Build and Deploy the Quickstart
 2. Open a command line and navigate to the root directory of this quickstart.
 3. Type this command to build and deploy the archive:
 
-        mvn package wildfly:deploy
+        mvn clean package wildfly:deploy
 4. This will deploy `target/jboss-jsonp` to the running instance of the server.
  
 

--- a/jsonp/src/main/java/org/jboss/as/quickstarts/jsonp/Person.java
+++ b/jsonp/src/main/java/org/jboss/as/quickstarts/jsonp/Person.java
@@ -37,7 +37,7 @@ public class Person {
 
     private String addressCity = "Raleigh, NC";
 
-    private Integer addressZip = 27123;
+    private String addressZip = "27123";
 
     public String getName() {
         return name;
@@ -103,11 +103,11 @@ public class Person {
         this.addressCity = addressCity;
     }
 
-    public Integer getAddressZip() {
+    public String getAddressZip() {
         return addressZip;
     }
 
-    public void setAddressZip(Integer addressZip) {
+    public void setAddressZip(String addressZip) {
         this.addressZip = addressZip;
     }
 

--- a/jsonp/src/main/webapp/jsonp.xhtml
+++ b/jsonp/src/main/webapp/jsonp.xhtml
@@ -32,13 +32,11 @@
             Phone 2: <h:inputText value="#{person.phone2}" /><br/>
             <strong>Address:</strong><br/>
             Street: <h:inputText value="#{person.addressStreet}" /><br/>
-            Apto: <h:inputText value="#{person.addressApt}" id="apt" >
+            Apartment Number: <h:inputText value="#{person.addressApt}" id="apt" >
                 <f:convertNumber integerOnly="true" maxIntegerDigits="3" type="number" />
             </h:inputText><h:message for="apt"/><br/>
             City: <h:inputText value="#{person.addressCity}" /><br/>
-            Zip: <h:inputText value="#{person.addressZip}" id="zip">
-                <f:convertNumber integerOnly="true" minIntegerDigits="5" maxIntegerDigits="5" />
-            </h:inputText><h:message for="zip"/><br/>
+            Zip Code: <h:inputText value="#{person.addressZip}" id="zip"/><br/>
             <hr />
             <h:commandButton action="#{jsonController.generateJson()}" value="Generate JSON String from Personal Data" />
             <br />


### PR DESCRIPTION
The zip code is actually a string. It can have a dash and have up to 10 digits, for example: '12345-9876'
