### PR TITLE
spring-resteasy updated to use httpcomponents and dependency cleanup

### DIFF
--- a/spring-resteasy/pom.xml
+++ b/spring-resteasy/pom.xml
@@ -103,12 +103,7 @@
         <version.jboss.bom.eap>7.0.0-build-7</version.jboss.bom.eap>
 
         <!-- Other dependency versions -->
-<!--         <version.org.apache.httpcomponents>4.1.4</version.org.apache.httpcomponents> -->
-        <version.org.apache.httpcomponents>3.1</version.org.apache.httpcomponents>
-        <version.commons.logging>1.1.1</version.commons.logging>
-
-        <!-- RESTEasy Version -->
-<!--         <version.springframework>3.2.7.RELEASE</version.springframework> -->
+        <version.org.apache.httpcomponents>4.5</version.org.apache.httpcomponents>
 
         <!-- Maven Plug-in Versions -->
         <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
@@ -146,30 +141,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <dependency>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
-                <version>${version.commons.logging}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-httpclient</groupId>
-                <artifactId>commons-httpclient</artifactId>
-                <version>${version.org.apache.httpcomponents}</version>
-            </dependency>
-
-            <!-- Spring -->
-<!--             <dependency> -->
-<!--                 <groupId>org.springframework</groupId> -->
-<!--                 <artifactId>spring-context</artifactId> -->
-<!--                 <version>${version.springframework}</version> -->
-<!--             </dependency> -->
-<!--             <dependency> -->
-<!--                 <groupId>org.springframework</groupId> -->
-<!--                 <artifactId>spring-web</artifactId> -->
-<!--                 <version>${version.springframework}</version> -->
-<!--             </dependency> -->
-
         </dependencies>
     </dependencyManagement>
 
@@ -182,28 +153,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-spring</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>activation</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.resteasy</groupId>
-                    <artifactId>resteasy-jaxrs</artifactId>
-                </exclusion>
-                <exclusion>
-                     <groupId>org.jboss.resteasy</groupId>
-                     <artifactId>jaxrs-api</artifactId>
-                </exclusion>
-                <exclusion>
-                     <groupId>org.jboss.resteasy</groupId>
-                     <artifactId>resteasy-jettison-provider</artifactId>
-                </exclusion>
-                <exclusion>
-                     <groupId>org.jboss.spec.javax.annotation</groupId>
-                     <artifactId>jboss-annotations-api_1.1_spec</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
@@ -216,8 +166,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${version.org.apache.httpcomponents}</version>
             <scope>test</scope>
         </dependency>
 
@@ -225,26 +176,27 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-<!--             <version>${version.springframework}</version> -->
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-<!--             <version>${version.springframework}</version> -->
         </dependency>
 
         <!-- Bring in the Servlet jars to avoid errors while compiling with jdt. -->
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
             <artifactId>jboss-jsp-api_2.3_spec</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
             <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>

--- a/spring-resteasy/src/test/java/org/jboss/as/quickstarts/resteasyspring/test/ResteasySpringTest.java
+++ b/spring-resteasy/src/test/java/org/jboss/as/quickstarts/resteasyspring/test/ResteasySpringTest.java
@@ -16,11 +16,16 @@
  */
 package org.jboss.as.quickstarts.resteasyspring.test;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.NameValuePair;
-import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.httpclient.methods.PutMethod;
-import org.apache.commons.httpclient.methods.StringRequestEntity;
+import java.net.URI;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.jboss.resteasy.util.HttpResponseCodes;
@@ -33,106 +38,176 @@ public class ResteasySpringTest
     @Test
     public void testHelloSpringResource() throws Exception
     {
-        HttpClient client = new HttpClient();
-
-        {
-            GetMethod method = new GetMethod("http://localhost:8080/jboss-spring-resteasy/hello");
-            NameValuePair[] params = { new NameValuePair("name", "JBoss Developer") };
-            method.setQueryString(params);
-            int status = client.executeMethod(method);
-            Assert.assertEquals(HttpResponseCodes.SC_OK, status);
-            Assert.assertTrue(method.getResponseBodyAsString().contains("JBoss Developer"));
-            method.releaseConnection();
-        }
-        {
-            GetMethod method = new GetMethod("http://localhost:8080/jboss-spring-resteasy/basic");
-            int status = client.executeMethod(method);
-            Assert.assertEquals(HttpResponseCodes.SC_OK, status);
-            Assert.assertEquals("basic", method.getResponseBodyAsString());
-            method.releaseConnection();
-        }
-        {
-            PutMethod method = new PutMethod("http://localhost:8080/jboss-spring-resteasy/basic");
-            method.setRequestEntity(new StringRequestEntity("basic", "text/plain", null));
-            int status = client.executeMethod(method);
-            Assert.assertEquals(204, status);
-            method.releaseConnection();
-        }
-        {
-            GetMethod method = new GetMethod("http://localhost:8080/jboss-spring-resteasy/queryParam");
-            NameValuePair[] params = { new NameValuePair("param", "hello world") };
-            method.setQueryString(params);
-            int status = client.executeMethod(method);
-            Assert.assertEquals(HttpResponseCodes.SC_OK, status);
-            Assert.assertEquals("hello world", method.getResponseBodyAsString());
-            method.releaseConnection();
-        }
-        {
-            GetMethod method = new GetMethod("http://localhost:8080/jboss-spring-resteasy/matrixParam;param=matrix");
-            int status = client.executeMethod(method);
-            Assert.assertEquals(HttpResponseCodes.SC_OK, status);
-            Assert.assertEquals("matrix", method.getResponseBodyAsString());
-            method.releaseConnection();
-        }
-        {
-            GetMethod method = new GetMethod("http://localhost:8080/jboss-spring-resteasy/uriParam/1234");
-            int status = client.executeMethod(method);
-            Assert.assertEquals(HttpResponseCodes.SC_OK, status);
-            Assert.assertEquals("1234", method.getResponseBodyAsString());
-            method.releaseConnection();
+        CloseableHttpClient client = HttpClients.createDefault();
+        try {
+            {
+                URI uri = new URIBuilder()
+                    .setScheme("http")
+                    .setHost("localhost:8080")
+                    .setPath("/jboss-spring-resteasy/hello")
+                    .setParameter("name", "JBoss Developer")
+                    .build();
+                HttpGet method = new HttpGet(uri);
+                CloseableHttpResponse response = client.execute(method);
+                try {
+                    Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatusLine().getStatusCode());
+                    Assert.assertTrue(EntityUtils.toString(response.getEntity()).contains("JBoss Developer"));
+                } finally {
+                    response.close();
+                    method.releaseConnection();
+                }
+            }
+            {
+                HttpGet method = new HttpGet("http://localhost:8080/jboss-spring-resteasy/basic");
+                CloseableHttpResponse response = client.execute(method);
+                try {
+                    Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatusLine().getStatusCode());
+                    Assert.assertTrue(EntityUtils.toString(response.getEntity()).contains("basic"));
+                } finally {
+                    response.close();
+                    method.releaseConnection();
+                }
+            }
+            {
+                HttpPut method = new HttpPut("http://localhost:8080/jboss-spring-resteasy/basic");
+                method.setEntity(new StringEntity("basic", ContentType.TEXT_PLAIN));
+                CloseableHttpResponse response = client.execute(method);
+                try {
+                    Assert.assertEquals(HttpResponseCodes.SC_NO_CONTENT, response.getStatusLine().getStatusCode());
+                } finally {
+                    response.close();
+                    method.releaseConnection();
+                }
+            }
+            {
+                URI uri = new URIBuilder()
+                    .setScheme("http")
+                    .setHost("localhost:8080")
+                    .setPath("/jboss-spring-resteasy/queryParam")
+                    .setParameter("param", "hello world")
+                    .build();
+                HttpGet method = new HttpGet(uri);
+                CloseableHttpResponse response = client.execute(method);
+                try {
+                    Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatusLine().getStatusCode());
+                    Assert.assertTrue(EntityUtils.toString(response.getEntity()).contains("hello world"));
+                } finally {
+                    response.close();
+                    method.releaseConnection();
+                }
+            }
+            {
+                HttpGet method = new HttpGet("http://localhost:8080/jboss-spring-resteasy/matrixParam;param=matrix");
+                CloseableHttpResponse response = client.execute(method);
+                try {
+                    Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatusLine().getStatusCode());
+                    Assert.assertTrue(EntityUtils.toString(response.getEntity()).equals("matrix"));
+                } finally {
+                    response.close();
+                    method.releaseConnection();
+                }
+            }
+            {
+                HttpGet method = new HttpGet("http://localhost:8080/jboss-spring-resteasy/uriParam/1234");
+                CloseableHttpResponse response = client.execute(method);
+                try {
+                    Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatusLine().getStatusCode());
+                    Assert.assertTrue(EntityUtils.toString(response.getEntity()).equals("1234"));
+                } finally {
+                    response.close();
+                    method.releaseConnection();
+                }
+            }
+        } finally {
+            client.close();
         }
     }
 
     @Test
     public void testLocatingResource() throws Exception
     {
-        HttpClient client = new HttpClient();
-
-        {
-            GetMethod method = new GetMethod("http://localhost:8080/jboss-spring-resteasy/locating/hello");
-            NameValuePair[] params = { new NameValuePair("name", "JBoss Developer") };
-            method.setQueryString(params);
-            int status = client.executeMethod(method);
-            Assert.assertEquals(HttpResponseCodes.SC_OK, status);
-            Assert.assertTrue(method.getResponseBodyAsString().contains("JBoss Developer"));
-            method.releaseConnection();
-        }
-        {
-            GetMethod method = new GetMethod("http://localhost:8080/jboss-spring-resteasy/locating/basic");
-            int status = client.executeMethod(method);
-            Assert.assertEquals(HttpResponseCodes.SC_OK, status);
-            Assert.assertEquals("basic", method.getResponseBodyAsString());
-            method.releaseConnection();
-        }
-        {
-            PutMethod method = new PutMethod("http://localhost:8080/jboss-spring-resteasy/locating/basic");
-            method.setRequestEntity(new StringRequestEntity("basic", "text/plain", null));
-            int status = client.executeMethod(method);
-            Assert.assertEquals(204, status);
-            method.releaseConnection();
-        }
-        {
-            GetMethod method = new GetMethod("http://localhost:8080/jboss-spring-resteasy/locating/queryParam");
-            NameValuePair[] params = { new NameValuePair("param", "hello world") };
-            method.setQueryString(params);
-            int status = client.executeMethod(method);
-            Assert.assertEquals(HttpResponseCodes.SC_OK, status);
-            Assert.assertEquals("hello world", method.getResponseBodyAsString());
-            method.releaseConnection();
-        }
-        {
-            GetMethod method = new GetMethod("http://localhost:8080/jboss-spring-resteasy/locating/matrixParam;param=matrix");
-            int status = client.executeMethod(method);
-            Assert.assertEquals(HttpResponseCodes.SC_OK, status);
-            Assert.assertEquals("matrix", method.getResponseBodyAsString());
-            method.releaseConnection();
-        }
-        {
-            GetMethod method = new GetMethod("http://localhost:8080/jboss-spring-resteasy/locating/uriParam/1234");
-            int status = client.executeMethod(method);
-            Assert.assertEquals(HttpResponseCodes.SC_OK, status);
-            Assert.assertEquals("1234", method.getResponseBodyAsString());
-            method.releaseConnection();
+        CloseableHttpClient client = HttpClients.createDefault();
+        try {
+            {
+                URI uri = new URIBuilder()
+                    .setScheme("http")
+                    .setHost("localhost:8080")
+                    .setPath("/jboss-spring-resteasy/locating/hello")
+                    .setParameter("name", "JBoss Developer")
+                    .build();
+                HttpGet method = new HttpGet(uri);
+                CloseableHttpResponse response = client.execute(method);
+                try {
+                    Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatusLine().getStatusCode());
+                    Assert.assertTrue(EntityUtils.toString(response.getEntity()).contains("JBoss Developer"));
+                } finally {
+                    response.close();
+                    method.releaseConnection();
+                }
+            }
+            {
+                HttpGet method = new HttpGet("http://localhost:8080/jboss-spring-resteasy/locating/basic");
+                CloseableHttpResponse response = client.execute(method);
+                try {
+                    Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatusLine().getStatusCode());
+                    Assert.assertTrue(EntityUtils.toString(response.getEntity()).contains("basic"));
+                } finally {
+                    response.close();
+                    method.releaseConnection();
+                }
+            }
+            {
+                HttpPut method = new HttpPut("http://localhost:8080/jboss-spring-resteasy/locating/basic");
+                method.setEntity(new StringEntity("basic", ContentType.TEXT_PLAIN));
+                CloseableHttpResponse response = client.execute(method);
+                try {
+                    Assert.assertEquals(HttpResponseCodes.SC_NO_CONTENT, response.getStatusLine().getStatusCode());
+                } finally {
+                    response.close();
+                    method.releaseConnection();
+                }
+            }
+            {
+                URI uri = new URIBuilder()
+                    .setScheme("http")
+                    .setHost("localhost:8080")
+                    .setPath("/jboss-spring-resteasy/locating/queryParam")
+                    .setParameter("param", "hello world")
+                    .build();
+                HttpGet method = new HttpGet(uri);
+                CloseableHttpResponse response = client.execute(method);
+                try {
+                    Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatusLine().getStatusCode());
+                    Assert.assertTrue(EntityUtils.toString(response.getEntity()).contains("hello world"));
+                } finally {
+                    response.close();
+                    method.releaseConnection();
+                }
+            }
+            {
+                HttpGet method = new HttpGet("http://localhost:8080/jboss-spring-resteasy/locating/matrixParam;param=matrix");
+                CloseableHttpResponse response = client.execute(method);
+                try {
+                    Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatusLine().getStatusCode());
+                    Assert.assertTrue(EntityUtils.toString(response.getEntity()).equals("matrix"));
+                } finally {
+                    response.close();
+                    method.releaseConnection();
+                }
+            }
+            {
+                HttpGet method = new HttpGet("http://localhost:8080/jboss-spring-resteasy/locating/uriParam/1234");
+                CloseableHttpResponse response = client.execute(method);
+                try {
+                    Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatusLine().getStatusCode());
+                    Assert.assertTrue(EntityUtils.toString(response.getEntity()).equals("1234"));
+                } finally {
+                    response.close();
+                    method.releaseConnection();
+                }
+            }
+        } finally {
+            client.close();
         }
     }
 


### PR DESCRIPTION
The commons-httpclient project has been EOL'ed. The Apache HttpComponents project should be used instead, see http://hc.apache.org/httpclient-3.x/ The `/ResteasySpringTest.java` test class has been updated accordingly.
The Java EE 7 specification dependencies and spring-resteasy dependency are shipped with EAP 7 as static modules thus should be of `provided` scope.
