### PR TITLE
spring-kitchensink-controlleradvice dependency cleanup

### DIFF
--- a/spring-kitchensink-controlleradvice/functional-tests/pom.xml
+++ b/spring-kitchensink-controlleradvice/functional-tests/pom.xml
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20090211</version>
+            <version>20141113</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring-kitchensink-controlleradvice/pom.xml
+++ b/spring-kitchensink-controlleradvice/pom.xml
@@ -108,12 +108,7 @@
         <version.maven.war>2.3</version.maven.war>
 
         <!-- Third Party Spring dependencies -->
-        <version.standard.taglibs>1.1.2</version.standard.taglibs>
-        <version.commons.logging>1.1.1</version.commons.logging>
-        <version.cglib>2.2</version.cglib>
-        <version.h2db>1.3.165</version.h2db>
-        <version.jackson>2.4.3</version.jackson>
-        <version.slf4j>1.7.5</version.slf4j>
+        <version.h2db>1.3.173</version.h2db>
     </properties>
 
     <dependencyManagement>
@@ -143,25 +138,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <dependency>
-                <groupId>taglibs</groupId>
-                <artifactId>standard</artifactId>
-                <version>${version.standard.taglibs}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
-                <version>${version.commons.logging}</version>
-            </dependency>
-
-            <!-- Add cglib for the MemberDaoTest -->
-            <dependency>
-                <groupId>cglib</groupId>
-                <artifactId>cglib-nodep</artifactId>
-                <version>${version.cglib}</version>
-            </dependency>
-
             <!-- Add H2 dependency for embedded testing database -->
             <dependency>
                 <groupId>com.h2database</groupId>
@@ -169,22 +145,6 @@
                 <version>${version.h2db}</version>
             </dependency>
 
-            <!-- Add JSON dependency, specified in jboss-deployment-structure.xml -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${version.slf4j}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -203,12 +163,6 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -229,14 +183,17 @@
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
             <artifactId>jboss-jsp-api_2.3_spec</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
             <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Import Spring dependencies -->
@@ -291,32 +248,10 @@
             <artifactId>spring-webmvc</artifactId>
         </dependency>
 
-        <!-- Other community dependencies -->
-        <dependency>
-            <groupId>aopalliance</groupId>
-            <artifactId>aopalliance</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>taglibs</groupId>
-            <artifactId>standard</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-        </dependency>
-
         <!-- Needed for running tests (you may also use TestNG) -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-
-        <!-- Add cglib for the MemberDaoTest -->
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -327,21 +262,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Add JSON dependency, specified in jboss-deployment-structure.xml -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
The `taglib:standad` dependency must not be used. It contains JSTL, we use `jboss-jstl-api_1.2_spec` shipped with EAP instead.
The `commons-logging` and `aopalliance` dependencies don't have to be specified, they are transitively fetched anyway.
The `cglib` dependency is not required as of Spring 3.2, see http://docs.spring.io/spring/docs/3.2.x/spring-framework-reference/html/migration-3.2.html
The `jackson` dependencies don't need to be explicitly specified, they are automatically provided by EAP7 as static modules
Java EE 7 specifications are shipped with EAP, thus their scope should be `provided`
The `slf4j-simple` dependency is not used by the example, can be safely removed.
