### PR TITLE
JBEAP-1122 Use default for use-ccm

### DIFF
--- a/jta-crash-rec/README.md
+++ b/jta-crash-rec/README.md
@@ -167,7 +167,6 @@ Server Log: Expected warnings and errors
 _Note:_ You will see the following warnings in the server log. You can ignore these warnings. The `IJ000407: No lazy enlistment available for JTACrashRecQuickstart` warning appears because the `use-ccm` (cache connection manager) is set to "false" in the `jta-crash-rec-quickstart-ds.xml` file. 
 
     WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in a future version.
-    WARN [org.jboss.jca.core.connectionmanager.pool.strategy.OnePool] (ServerService Thread Pool – 70) IJ000407: No lazy enlistment available for JTACrashRecQuickstart
     HHH000431: Unable to determine H2 database version, certain features may not work
 
 

--- a/jta-crash-rec/src/main/webapp/WEB-INF/jta-crash-rec-quickstart-ds.xml
+++ b/jta-crash-rec/src/main/webapp/WEB-INF/jta-crash-rec-quickstart-ds.xml
@@ -22,7 +22,7 @@
 <datasources xmlns="http://www.jboss.org/ironjacamar/schema"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.jboss.org/ironjacamar/schema http://docs.jboss.org/ironjacamar/schema/datasources_1_0.xsd">
-    <xa-datasource jndi-name="java:jboss/datasources/JTACrashRecQuickstartDS" pool-name="JTACrashRecQuickstart" enabled="true" use-ccm="false">
+    <xa-datasource jndi-name="java:jboss/datasources/JTACrashRecQuickstartDS" pool-name="JTACrashRecQuickstart" enabled="true">
         <xa-datasource-property name="URL">
             jdbc:h2:file:~/jta-crash-rec-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1
         </xa-datasource-property>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-1122

The server startup message is saying that lazy enlistment isn't available because use-ccm is set to false. This is is just a warning during deployment and the actual quickstart obtains the connection inside a transaction.
I have updated the datasource definition (and README) to force the use of the default setting for this attribute.
