### PR TITLE
[JBEAP-1434] Use early access maven repo URL for alpha and beta

### DIFF
--- a/app-client/pom.xml
+++ b/app-client/pom.xml
@@ -60,7 +60,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -83,7 +83,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/batch-processing/pom.xml
+++ b/batch-processing/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/bean-validation-custom-constraint/pom.xml
+++ b/bean-validation-custom-constraint/pom.xml
@@ -56,7 +56,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -79,7 +79,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -56,7 +56,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -79,7 +79,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/bmt/pom.xml
+++ b/bmt/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/cdi-alternative/pom.xml
+++ b/cdi-alternative/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/cdi-decorator/pom.xml
+++ b/cdi-decorator/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/cdi-injection/pom.xml
+++ b/cdi-injection/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/cdi-interceptors/pom.xml
+++ b/cdi-interceptors/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/cdi-portable-extension/pom.xml
+++ b/cdi-portable-extension/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/cdi-stereotype/pom.xml
+++ b/cdi-stereotype/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/cdi-veto/pom.xml
+++ b/cdi-veto/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/cluster-ha-singleton/pom.xml
+++ b/cluster-ha-singleton/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/contacts-jquerymobile/pom.xml
+++ b/contacts-jquerymobile/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-asynchronous/pom.xml
+++ b/ejb-asynchronous/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-in-ear/pom.xml
+++ b/ejb-in-ear/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-in-war/pom.xml
+++ b/ejb-in-war/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-multi-server/app-main/ear/pom.xml
+++ b/ejb-multi-server/app-main/ear/pom.xml
@@ -63,7 +63,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -86,7 +86,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-multi-server/app-main/ejb/pom.xml
+++ b/ejb-multi-server/app-main/ejb/pom.xml
@@ -60,7 +60,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -83,7 +83,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-multi-server/app-main/web/pom.xml
+++ b/ejb-multi-server/app-main/web/pom.xml
@@ -60,7 +60,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -83,7 +83,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-multi-server/app-one/ear/pom.xml
+++ b/ejb-multi-server/app-one/ear/pom.xml
@@ -59,7 +59,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -82,7 +82,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-multi-server/app-one/ejb/pom.xml
+++ b/ejb-multi-server/app-one/ejb/pom.xml
@@ -60,7 +60,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -83,7 +83,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-multi-server/app-two/ear/pom.xml
+++ b/ejb-multi-server/app-two/ear/pom.xml
@@ -59,7 +59,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -82,7 +82,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-multi-server/app-two/ejb/pom.xml
+++ b/ejb-multi-server/app-two/ejb/pom.xml
@@ -60,7 +60,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -83,7 +83,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-multi-server/pom.xml
+++ b/ejb-multi-server/pom.xml
@@ -59,7 +59,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -82,7 +82,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-remote/pom.xml
+++ b/ejb-remote/pom.xml
@@ -55,7 +55,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -78,7 +78,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-security-interceptors/pom.xml
+++ b/ejb-security-interceptors/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-security/pom.xml
+++ b/ejb-security/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-throws-exception/pom.xml
+++ b/ejb-throws-exception/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ejb-timer/pom.xml
+++ b/ejb-timer/pom.xml
@@ -58,7 +58,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -81,7 +81,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/greeter/pom.xml
+++ b/greeter/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/helloworld-html5/functional-tests/pom.xml
+++ b/helloworld-html5/functional-tests/pom.xml
@@ -64,7 +64,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -97,7 +97,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/helloworld-html5/pom.xml
+++ b/helloworld-html5/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/helloworld-mbean/pom.xml
+++ b/helloworld-mbean/pom.xml
@@ -56,7 +56,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -79,7 +79,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/helloworld-mdb-propertysubstitution/pom.xml
+++ b/helloworld-mdb-propertysubstitution/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/helloworld-mdb/pom.xml
+++ b/helloworld-mdb/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/helloworld-rs/pom.xml
+++ b/helloworld-rs/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/helloworld-singleton/pom.xml
+++ b/helloworld-singleton/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/helloworld-ws/pom.xml
+++ b/helloworld-ws/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/helloworld/pom.xml
+++ b/helloworld/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/hibernate5/pom.xml
+++ b/hibernate5/pom.xml
@@ -56,7 +56,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -79,7 +79,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/inter-app/pom.xml
+++ b/inter-app/pom.xml
@@ -67,7 +67,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -100,7 +100,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -59,7 +59,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -82,7 +82,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/jaxws-addressing/pom.xml
+++ b/jaxws-addressing/pom.xml
@@ -59,7 +59,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -82,7 +82,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/jaxws-ejb/pom.xml
+++ b/jaxws-ejb/pom.xml
@@ -59,7 +59,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -82,7 +82,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/jaxws-pojo/pom.xml
+++ b/jaxws-pojo/pom.xml
@@ -59,7 +59,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -82,7 +82,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/jaxws-retail/pom.xml
+++ b/jaxws-retail/pom.xml
@@ -59,7 +59,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -82,7 +82,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/jsonp/pom.xml
+++ b/jsonp/pom.xml
@@ -58,7 +58,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -81,7 +81,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/jta-crash-rec/pom.xml
+++ b/jta-crash-rec/pom.xml
@@ -56,7 +56,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -79,7 +79,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/jts/pom.xml
+++ b/jts/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/kitchensink-ear/pom.xml
+++ b/kitchensink-ear/pom.xml
@@ -56,7 +56,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -79,7 +79,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/kitchensink-html5-mobile/pom.xml
+++ b/kitchensink-html5-mobile/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/kitchensink-ml-ear/pom.xml
+++ b/kitchensink-ml-ear/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/kitchensink-ml/pom.xml
+++ b/kitchensink-ml/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/log4j/pom.xml
+++ b/log4j/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/logging-tools/pom.xml
+++ b/logging-tools/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/managed-executor-service/pom.xml
+++ b/managed-executor-service/pom.xml
@@ -59,7 +59,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -82,7 +82,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/numberguess/pom.xml
+++ b/numberguess/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/payment-cdi-event/pom.xml
+++ b/payment-cdi-event/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/picketlink-sts/pom.xml
+++ b/picketlink-sts/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -87,7 +87,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/resteasy-jaxrs-client/pom.xml
+++ b/resteasy-jaxrs-client/pom.xml
@@ -56,7 +56,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -79,7 +79,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/servlet-async/pom.xml
+++ b/servlet-async/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/servlet-filterlistener/pom.xml
+++ b/servlet-filterlistener/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/servlet-security/pom.xml
+++ b/servlet-security/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/shopping-cart/pom.xml
+++ b/shopping-cart/pom.xml
@@ -56,7 +56,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -79,7 +79,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/shrinkwrap-resolver/pom.xml
+++ b/shrinkwrap-resolver/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-greeter/functional-tests/pom.xml
+++ b/spring-greeter/functional-tests/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-greeter/pom.xml
+++ b/spring-greeter/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-kitchensink-asyncrequestmapping/functional-tests/pom.xml
+++ b/spring-kitchensink-asyncrequestmapping/functional-tests/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-kitchensink-asyncrequestmapping/pom.xml
+++ b/spring-kitchensink-asyncrequestmapping/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-kitchensink-basic/functional-tests/pom.xml
+++ b/spring-kitchensink-basic/functional-tests/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-kitchensink-basic/pom.xml
+++ b/spring-kitchensink-basic/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-kitchensink-controlleradvice/functional-tests/pom.xml
+++ b/spring-kitchensink-controlleradvice/functional-tests/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-kitchensink-controlleradvice/pom.xml
+++ b/spring-kitchensink-controlleradvice/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-kitchensink-matrixvariables/functional-tests/pom.xml
+++ b/spring-kitchensink-matrixvariables/functional-tests/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-kitchensink-matrixvariables/pom.xml
+++ b/spring-kitchensink-matrixvariables/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-kitchensink-springmvctest/functional-tests/pom.xml
+++ b/spring-kitchensink-springmvctest/functional-tests/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-kitchensink-springmvctest/pom.xml
+++ b/spring-kitchensink-springmvctest/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-petclinic/pom.xml
+++ b/spring-petclinic/pom.xml
@@ -83,7 +83,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -116,7 +116,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/spring-resteasy/pom.xml
+++ b/spring-resteasy/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/tasks-jsf/pom.xml
+++ b/tasks-jsf/pom.xml
@@ -56,7 +56,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -79,7 +79,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/tasks-rs/pom.xml
+++ b/tasks-rs/pom.xml
@@ -56,7 +56,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -79,7 +79,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/tasks/pom.xml
+++ b/tasks/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/temperature-converter/pom.xml
+++ b/temperature-converter/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/websocket-endpoint/pom.xml
+++ b/websocket-endpoint/pom.xml
@@ -56,7 +56,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -79,7 +79,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/websocket-hello/pom.xml
+++ b/websocket-hello/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/xml-dom4j/pom.xml
+++ b/xml-dom4j/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/xml-jaxp/pom.xml
+++ b/xml-jaxp/pom.xml
@@ -57,7 +57,7 @@
         </repository>
         <repository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -80,7 +80,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
+            <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>


### PR DESCRIPTION
The early access maven repo url should be used until after Beta
https://maven.repository.redhat.com/earlyaccess/all/

After the Beta release we can change it back to the GA repo URL
https://maven.repository.redhat.com/ga/
