### PR TITLE
Various fixes and updates of README in contacts-jquerymobile

### DIFF
--- a/contacts-jquerymobile/README.md
+++ b/contacts-jquerymobile/README.md
@@ -15,8 +15,8 @@ mobile web applications with Java EE 7 in Red Hat JBoss Enterprise Application P
 application using HTML5, jQuery Mobile, JAX-RS, CDI, EJB, JPA and Bean Validation 1.0. It includes a 
 persistence unit and some sample persistence and transaction code to help you get your feet wet with database access in enterprise Java.
 
-This application is built using a HTML5 + REST approach.  This uses a pure HTML client that interacts with with the 
-application server via restful end-points (JAX-RS).  This application also uses some of the latest HTML5 features and 
+This application is built using a HTML5 + REST approach. This uses a pure HTML client that interacts with with the 
+application server via restful end-points (JAX-RS). This application also uses some of the latest HTML5 features and 
 advanced JAX-RS. And since testing is just as important with client side as it is server side, this application uses 
 QUnit to show you how to unit test your JavaScript.
 
@@ -31,19 +31,13 @@ the ability to:
 
 * **Delete** a contact.
 
-**Validation** is an important part of an application.  Typically in an HTML5 app you can let the built-in HTML5 form validation
-do the work for you.  However in a mobile app it doesn't work, the mobile browsers just don't support it at this time. 
+**Validation** is an important part of an application. Typically in an HTML5 app you can let the built-in HTML5 form validation
+do the work for you. However in a mobile app it doesn't work, the mobile browsers just don't support it at this time. 
 In order to validate the forms we added a plugin, jquery.validate. We provide both client-side and server-side validation 
-through this plugin.  Over AJAX, if there is an error, the error is returned and displayed in the form.  You can see an 
-example of this in the Edit form if you enter an email that is already in use.  There will be 3 errors on the screen; 
-1 in the 'email' field and 2 at the top of the screen.  The application will attempt to insert the error message into a 
-field if that field exists.  If the field does not exist then it display it at the top. In addition, there are 
-[qunit tests](#run-the-qunit-tests) for every form of validation.  
-
-_Note: This quickstart uses the Jackson libraries, which are not supported for development or production use in JBoss EAP. 
-For more information, see [JBoss Enterprise Application Platform Component Details](https://access.redhat.com/articles/112673) 
-and [Does JBoss EAP support the use of Jackson libraries?](https://access.redhat.com/articles/1265083)._
-
+through this plugin. Over AJAX, if there is an error, the error is returned and displayed in the form. You can see an 
+example of this in the Edit form if you enter an email that is already in use. The application will attempt to insert the error message into a 
+field if that field exists. If the field does not exist then it display it at the top. In addition, there are 
+[qunit tests](#run-the-qunit-tests) for every form of validation.
 
 System requirements
 -------------------
@@ -55,11 +49,10 @@ All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven
 An HTML5 compatible browser such as Chrome, Safari 5+, Firefox 5+, or IE 9+ are required. and note that some behaviors 
 will vary slightly (ex. validations) based on browser support, especially IE 9.
 
-Mobile web support is limited to Android and iOS devices.  It should run on HP, and Black Berry devices as well.  
-Windows Phone, and others will be supported as  jQuery Mobile announces support.
+Mobile web support is limited to Android and iOS devices. It should run on HP, and Black Berry devices as well. 
+Windows Phone, and others will be supported as jQuery Mobile announces support.
  
 With the prerequisites out of the way, you're ready to build and deploy.
-
 
 Start the JBoss EAP Server
 -----------------------
@@ -77,7 +70,6 @@ Start the JBoss EAP Server
         For Linux:   EAP7_HOME/bin/standalone.sh -b 0.0.0.0
         For Windows: EAP7_HOME\bin\standalone.bat -b 0.0.0.0
 
-
 Build and Deploy the Quickstart
 -------------------------------
 
@@ -88,7 +80,6 @@ Build and Deploy the Quickstart
         mvn clean package wildfly:deploy
 
 4. This deploys `target/jboss-contacts-jquerymobile.war` to the running instance of the server.
-
 
 Access the application
 ----------------------
@@ -128,17 +119,6 @@ The app is made up of the following pages:
 * Same as Add form
 * Delete button will delete the contact currently viewed and return you to the Main page
 
-FAQ
---------------------
-
-1) Why can't I enter a date in the birthdate field?
-
-  * Chrome has a [bug](https://code.google.com/p/chromium/issues/detail?id=232296) in it
-    * Use the arrow keys to change the date: up arrow key, tab to day, up arrow key, tab to year, up arrow key
-    * Use the date picker: a large black down arrow between the up/down arrows and the big X on the right side.
-  * Firefox, IE, and Safari require strict formatting of YYYY-DD-MM, *Note:* It must be a dash and not a slash
-
-
 Undeploy the Archive
 --------------------
 
@@ -148,36 +128,9 @@ Undeploy the Archive
 
         mvn wildfly:undeploy
 
-
-Run the Arquillian Functional Tests
------------------------------------
-
-This quickstart provides Arquillian functional tests. They are located under the directory "functional-tests". Functional tests verify that your application behaves correctly from the user's point of view - simulating clicking around the page as a normal user would do.
-
-To run these tests, you must build the main project as described above.
-
-1. Open a command line and navigate to the root directory of this quickstart.
-2. Build the quickstart WAR using the following command:
-
-        mvn clean package
-
-3. Navigate to the functional-tests/ directory in this quickstart.
-4. If you have a running instance of the JBoss EAP server, as described above, run the remote tests by typing the following command:
-
-        mvn clean verify -Parq-wildfly-remote
-
-5. If you prefer to run the functional tests using managed instance of the JBoss EAP server, meaning the tests will start the server for you, type the following command:
-
-_NOTE: For this to work, Arquillian needs to know the location of the JBoss EAP server. This can be declared through the `JBOSS_HOME` environment variable or the `jbossHome` property in `arquillian.xml`. See [Run the Arquillian Tests](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/RUN_ARQUILLIAN_TESTS.md#run-the-arquillian-tests) for complete instructions and additional options._
-
-        mvn clean verify -Parq-wildfly-managed
-
-
-
 Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 -------------------------------------
 You can also start the server and deploy the quickstarts or run the Arquillian tests from Eclipse using JBoss tools. For more information, see [Use JBoss Developer Studio or Eclipse to Run the Quickstarts](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/USE_JBDS.md#use-jboss-developer-studio-or-eclipse-to-run-the-quickstarts) 
-
 
 <!-- Build and Deploy the Quickstart to OpenShift - Coming soon! -->
 
@@ -210,7 +163,7 @@ Run the Arquillian tests
 ------------------------
 
 By default, tests are configured to be skipped. The reason is that the sample test is an Arquillian test, which requires 
-the use of a container. You can activate this test by selecting one of the container configuration provided  for JBoss.
+the use of a container. You can activate this test by selecting one of the container configuration provided for JBoss.
 
 To run the test in JBoss, first start the container instance. Then, run the test goal with the following profile activated:
 
@@ -223,7 +176,6 @@ QUnit is a JavaScript unit testing framework used and built by jQuery. Because J
 application, this quickstart provides a set of QUnit tests that automate testing of this code in various browsers. Executing 
 QUnit test cases are quite easy. 
 
-
 Simply load the following HTML in the browser you wish to test.
 
         QUICKSTART_HOME/contacts-jquerymobile/src/test/qunit/index.html
@@ -232,8 +184,30 @@ _Note:_ If you use **Chrome**, some date tests fail. These are false failures an
 
 You can also display the tests using the Eclipse built-in browser.
 
-For more information on QUnit tests see http://docs.jquery.com/QUnit
+For more information on QUnit tests see http://qunitjs.com/
 
+Run the Arquillian Functional Tests
+-----------------------------------
+
+This quickstart provides Arquillian functional tests. They are located under the directory "functional-tests". Functional tests verify that your application behaves correctly from the user's point of view - simulating clicking around the page as a normal user would do.
+
+To run these tests, you must build the main project as described above.
+
+1. Open a command line and navigate to the root directory of this quickstart.
+2. Build the quickstart WAR using the following command:
+
+        mvn clean package
+
+3. Navigate to the functional-tests/ directory in this quickstart.
+4. If you have a running instance of the JBoss EAP server, as described above, run the remote tests by typing the following command:
+
+        mvn clean verify -Parq-wildfly-remote
+
+5. If you prefer to run the functional tests using managed instance of the JBoss EAP server, meaning the tests will start the server for you, type the following command:
+
+_NOTE: For this to work, Arquillian needs to know the location of the JBoss EAP server. This can be declared through the `JBOSS_HOME` environment variable or the `jbossHome` property in `arquillian.xml`. See [Run the Arquillian Tests](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/RUN_ARQUILLIAN_TESTS.md#run-the-arquillian-tests) for complete instructions and additional options._
+
+        mvn clean verify -Parq-wildfly-managed
 
 Import the Project into an IDE
 --------------------------------


### PR DESCRIPTION
Obsolete content and some useless whitespace characters removed. Furthermore the section `Run the Arquillian Functional tests` has been moved below `Run the QUnit tests` section so that all sections about testing are next to each other. I think it's better this way.
