### PR TITLE
mvnmvn JBEAP-1388: Minor issues in jaxws-retail quickstart

### DIFF
--- a/jaxws-retail/README.md
+++ b/jaxws-retail/README.md
@@ -10,7 +10,7 @@ Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>
 What is it?
 -----------
 
-The `jaxws-retail` quickstart demonstrates the use of *JAX-WS* in Red Hat JBoss Enterprise Application Platform as a simple profile management application.
+The `jaxws-retail` quickstart demonstrates the use of *JAX-WS* in Red Hat JBoss Enterprise Application Platform as a simple profile management application. It also demonstrates usage of wsconsume to generate classes from WSDL file.
 
 System requirements
 -------------------
@@ -19,8 +19,6 @@ The application this project produces is designed to be run on Red Hat JBoss Ent
 
 All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.1.1 or later. See [Configure Maven for JBoss EAP 7](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONFIGURE_MAVEN_JBOSS_EAP7.md#configure-maven-to-build-and-deploy-the-quickstarts) to make sure you are configured correctly for testing the quickstarts.
 
-To build this sample with Java SDK 1.8, file jaxws-retail/jaxp.properties must be installed
-in ${JDK-8-PATH}/jre/lib/jaxp.properties.  (see http://docs.oracle.com/javase/7/docs/api/javax/xml/XMLConstants.html#ACCESS_EXTERNAL_SCHEMA)
 
 Use of EAP7_HOME
 ---------------

--- a/jaxws-retail/pom.xml
+++ b/jaxws-retail/pom.xml
@@ -104,10 +104,10 @@
       <version.exec.plugin>1.2.1</version.exec.plugin>
       <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
       <version.jboss.bom.eap>7.0.0-build-9</version.jboss.bom.eap>
-      <version.maven-jaxws-tools-plugin>1.1.2.Final</version.maven-jaxws-tools-plugin>
+      <version.jaxws-tools-maven-plugin>1.2.0.Final</version.jaxws-tools-maven-plugin>
       <version.war.plugin>2.1.1</version.war.plugin>
       <version.jboss-ejb-api>1.0.2.Final</version.jboss-ejb-api>
-      <version.jbossws-cxf-client>4.2.3.Final</version.jbossws-cxf-client>
+      <version.jbossws-cxf-client>5.1.0.Beta1</version.jbossws-cxf-client>
    </properties>
 
     <modules>
@@ -128,7 +128,7 @@
          any version of JBoss EAP that implements Java EE. -->
          <dependency>
             <groupId>org.jboss.bom</groupId>
-            <artifactId>jboss-eap-javaee7-with-tools</artifactId>
+            <artifactId>jboss-eap-javaee7</artifactId>
             <version>${version.jboss.bom.eap}</version>
             <type>pom</type>
             <scope>import</scope>

--- a/jaxws-retail/service/pom.xml
+++ b/jaxws-retail/service/pom.xml
@@ -22,9 +22,7 @@
       <groupId>org.jboss.quickstarts.eap</groupId>
       <artifactId>jboss-jaxws-retail</artifactId>
       <version>7.0.0-SNAPSHOT</version>
-     <!-- -->
       <relativePath>../pom.xml</relativePath>
-
    </parent>
     <artifactId>jboss-jaxws-retail-service</artifactId>
     <packaging>war</packaging>
@@ -44,6 +42,7 @@
          <groupId>org.jboss.spec.javax.ejb</groupId>
          <artifactId>jboss-ejb-api_3.1_spec</artifactId>
       </dependency>
+      <!-- used to pull correct dependencies for jaxws-tools-maven-plugin  -->
       <dependency>
          <groupId>org.jboss.ws.cxf</groupId>
          <artifactId>jbossws-cxf-client</artifactId>
@@ -75,20 +74,11 @@
             </configuration>
          </plugin>
 
-         <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-               <compilerArguments>
-                  <endorseddirs>${project.build.directory}/endorsed
-                  </endorseddirs>
-               </compilerArguments>
-            </configuration>
-         </plugin>
          <!-- (wsconsume) generate classes from wsdl -->
          <plugin>
             <groupId>org.jboss.ws.plugins</groupId>
-            <artifactId>maven-jaxws-tools-plugin</artifactId>
-            <version>${version.maven-jaxws-tools-plugin}</version>
+            <artifactId>jaxws-tools-maven-plugin</artifactId>
+            <version>${version.jaxws-tools-maven-plugin}</version>
             <configuration>
                <wsdls>
                   <wsdl>${basedir}/src/main/webapp/WEB-INF/wsdl/ProfileMgmtService.wsdl</wsdl>
@@ -96,6 +86,10 @@
                <extension>true</extension>
                <verbose>true</verbose>
                <endpointClass/>
+               <!-- some JDK implementations forbid file access for external schema,
+                    see http://docs.oracle.com/javase/8/docs/api/javax/xml/XMLConstants.html#ACCESS_EXTERNAL_SCHEMA -->
+               <argLine>-Djavax.xml.accessExternalSchema=all</argLine>
+               <fork>true</fork>
                <targetPackage>org.jboss.quickstarts.ws.jaxws.samples.retail.profile</targetPackage>
             </configuration>
             <executions>

--- a/jaxws-retail/service/src/main/java/org/jboss/quickstarts/ws/jaxws/samples/retail/profile/ProfileMgmtBean.java
+++ b/jaxws-retail/service/src/main/java/org/jboss/quickstarts/ws/jaxws/samples/retail/profile/ProfileMgmtBean.java
@@ -16,9 +16,6 @@
  */
 package org.jboss.quickstarts.ws.jaxws.samples.retail.profile;
 
-import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.DiscountRequest;
-import org.jboss.quickstarts.ws.jaxws.samples.retail.profile.DiscountResponse;
-
 import javax.ejb.Stateless;
 import javax.jws.WebService;
 import javax.jws.WebMethod;

--- a/jaxws-retail/service/src/main/webapp/WEB-INF/wsdl/ProfileMgmtService.wsdl
+++ b/jaxws-retail/service/src/main/webapp/WEB-INF/wsdl/ProfileMgmtService.wsdl
@@ -79,9 +79,9 @@
    </binding>
    <service name='ProfileMgmtService'>
       <port binding='tns:ProfileMgmtBinding' name='ProfileMgmtPort'>
- 
-         <soap:address
-             location='SERVER:PORT/jboss-jaxws-retail/ProfileMgmtBean'/>
+
+         <!-- service address will be rewritten to actual one when WSDL is requested from running server -->
+         <soap:address location='http://SERVER:PORT/jboss-jaxws-retail/ProfileMgmtBean'/>
       </port>
    </service>
 </definitions>	


### PR DESCRIPTION
- use new jbossws client
- maven-jaxws-tools-plugin was renamned
- remove jaxp.properties requirement by
  specifying the needed property in forked wsconsume
- readme update
- some cleanup
- added jboss public repository
