### PR TITLE
Configure Undertow MIME-type mapping to be compatible with Spring MVC

### DIFF
--- a/spring-petclinic/src/main/webapp/WEB-INF/web.xml
+++ b/spring-petclinic/src/main/webapp/WEB-INF/web.xml
@@ -131,4 +131,10 @@
     		<mvc:view-controller path="/" view-name="welcome" /> 
     -->
 
+    <!-- Required due to https://issues.jboss.org/browse/UNDERTOW-553 -->
+    <mime-mapping>
+        <extension>xml</extension>
+        <mime-type>application/xml</mime-type>
+    </mime-mapping>
+
 </web-app>


### PR DESCRIPTION
This configuration will become unnecessary when Undertow 1.3.0.CR3 or later will be used in EAP 7
