### PR TITLE
Added Themes menu item to all menus in contacts-jquerymobile

### DIFF
--- a/contacts-jquerymobile/src/main/webapp/index.html
+++ b/contacts-jquerymobile/src/main/webapp/index.html
@@ -15,22 +15,6 @@
     limitations under the License.
 -->
 <!DOCTYPE html>
-<!--JBoss, Home of Professional Open Source
-    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
-    contributors by the @authors tag. See the copyright.txt in the
-    distribution for a full listing of individual contributors.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
--->
-
 <html>
 <head>
     <meta charset="ISO-8859-1">
@@ -147,6 +131,7 @@
                 <li><a href="#contacts-add-page">Add Contact</a></li>
                 <li><a href="#contacts-list-page">List view</a></li>
                 <li><a href="#about-page">About</a></li>
+                <li><a href="#contacts-theming-dialog" data-rel="popup" data-position-to="window">Themes</a></li>
             </ul>
         </div>
         <div data-role="header" data-position="fixed" >
@@ -175,6 +160,7 @@
                 <li><a href="#contacts-add-page">Add Contact</a></li>
                 <li><a href="#contacts-list-page">List view</a></li>
                 <li><a href="#about-page">About</a></li>
+                <li><a href="#contacts-theming-dialog" data-rel="popup" data-position-to="window">Themes</a></li>
             </ul>
         </div>
         <div data-role="header" data-position="fixed" >
@@ -196,6 +182,7 @@
             <ul data-role="listview" id="contacts-add-page-menu-panel-listview">
                 <li><a href="#contacts-list-page">List view</a></li>
                 <li><a href="#about-page">About</a></li>
+                <li><a href="#contacts-theming-dialog" data-rel="popup" data-position-to="window">Themes</a></li>
             </ul>
         </div>
         <div data-role="header" data-position="fixed" >
@@ -204,7 +191,7 @@
         </div>
         <div role="main" class="ui-content">
             <!--
-                In order to catch server side errors we need to disable the automatic page tranisition when the form is
+                In order to catch server side errors we need to disable the automatic page transition when the form is
                   submitted.  This done is by adding data-ajax="false" to the form element.  We then manually change the page
                   in the function that handles form submission. Thus allowing us to control when the form transitions to
                   another page.
@@ -261,6 +248,7 @@
                 <li><a href="#contacts-add-page">Add Contact</a></li>
                 <li><a href="#contacts-list-page">List view</a></li>
                 <li><a href="#about-page">About</a></li>
+                <li><a href="#contacts-theming-dialog" data-rel="popup" data-position-to="window">Themes</a></li>
             </ul>
         </div>
         <div data-role="header" data-position="fixed" >
@@ -273,7 +261,7 @@
                 PUT and DELETE are not supported in an HTML form, you must use POST.
                   Please see http://www.w3.org/TR/2010/WD-html5-diff-20101019/#changes-2010-06-24
 
-                In order to catch server side errors we need to disable the automatic page tranisition when the form is
+                In order to catch server side errors we need to disable the automatic page transition when the form is
                   submitted.  This done is by adding data-ajax="false" to the form element.  We then manually change the page
                   in the function that handles form submission. Thus allowing us to control when the form transitions to
                   another page.


### PR DESCRIPTION
There is no reason why to have "Themes" menu item only in one of the menu, apart of this menu item all the menus are almost the same.

Together with "Themes" menu item addition also two typos were fixed and one redundant license comment was removed.
