### PR TITLE
ShrinkWrap Resolver quickstart update

### DIFF
--- a/shrinkwrap-resolver/README.md
+++ b/shrinkwrap-resolver/README.md
@@ -13,7 +13,7 @@ What is it?
 
 This quickstart demonstrates the use of ShrinkWrap Resolver in Red Hat JBoss Enterprise Application Platform.
 
-With the advent of Maven and other build systems, typically thirdparty libraries and our own dependent modules are obtained from a backing software repository. In this case we supply a series of coordinates which uniquely identifies an artifact in the repository, and resolve the target files from there.
+With the advent of Maven and other build systems, typically third party libraries and our own dependent modules are obtained from a backing software repository. In this case we supply a series of coordinates which uniquely identifies an artifact in the repository, and resolve the target files from there.
 
 That is precisely the aim of the ShrinkWrap Resolver project; it is a Java API to obtain artifacts from a repository system. 
 
@@ -30,7 +30,7 @@ The `shrinkwrap-resolver` quickstart demonstrates various use cases for ShrinkWr
   
 * ShrinkwrapResolveGAPCVCustomRepoWithoutCentralTest
   - resolve an artifact via G:A:P:C:V without transitive dependencies 
-  - resolve an artifact with classifer
+  - resolve an artifact with classifier
   - disabling Maven Central
   - loading settings.xml from file (with custom repository)
   - return resolution results as a java.io.File array
@@ -66,7 +66,7 @@ This quickstart provides Arquillian tests. By default, these tests are configure
 
 _NOTE: If you plan to use a custom settings file, add the Maven settings command line argument and pass an additional argument to allow ShrinkWrap Resolver to function properly:_
 
-    mvn clean test -Parq-wildfly-remote -s /path/to/custom/settings.xml -Dorg.apache.maven.user-settings=/path/to/custom/settings.xml
+    mvn clean test -Parq-wildfly-remote -s /path/to/custom/settings.xml
 
 
 Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse

--- a/shrinkwrap-resolver/src/test/java/org/jboss/as/quickstarts/shrinkwrap/resolver/ShrinkwrapImportFromPomTest.java
+++ b/shrinkwrap-resolver/src/test/java/org/jboss/as/quickstarts/shrinkwrap/resolver/ShrinkwrapImportFromPomTest.java
@@ -46,7 +46,7 @@ public class ShrinkwrapImportFromPomTest {
     @Deployment
     public static Archive<?> createTestArchive() {
 
-        File[] libs = Maven.resolver()
+        File[] libs = Maven.configureResolver()
             // This will load the pom.xml file. For example purpose, the pom file had the arq-wildfly-remote profile
             // activated and default profile deactivated (which was active by default)
             .loadPomFromFile("pom.xml", "arq-wildfly-remote", "!default")

--- a/shrinkwrap-resolver/src/test/java/org/jboss/as/quickstarts/shrinkwrap/resolver/ShrinkwrapResolveGAVWithoutTransitiveDepsTest.java
+++ b/shrinkwrap-resolver/src/test/java/org/jboss/as/quickstarts/shrinkwrap/resolver/ShrinkwrapResolveGAVWithoutTransitiveDepsTest.java
@@ -37,7 +37,6 @@ import org.junit.runner.RunWith;
  * single file
  *
  * @author Rafael Benevides
- *
  */
 @RunWith(Arquillian.class)
 public class ShrinkwrapResolveGAVWithoutTransitiveDepsTest {
@@ -45,7 +44,8 @@ public class ShrinkwrapResolveGAVWithoutTransitiveDepsTest {
     @Deployment
     public static Archive<?> createTestArchive() {
 
-        File lib = Maven.resolver().resolve("org.apache.commons:commons-lang3:3.1").withoutTransitivity().asSingleFile();
+        File lib = Maven.configureResolver().resolve("org.apache.commons:commons-lang3:3.1").withoutTransitivity()
+            .asSingleFile();
 
         return ShrinkWrap.create(WebArchive.class, "test.war")
             .addClasses(MyBean.class)


### PR DESCRIPTION
ShrinkwrapImportFromPomTest
ShrinkwrapResolveGAVWithoutTransitiveDepsTest
    - updated to newer API: Maven.configureResolver()

README.md
    - fixed typos
    - removed the property "-Dorg.apache.maven.user-settings" as it is related only to maven 2 (correct me if I am wrong)
