### PR TITLE
Updated ContactRESTService and enabled JAX-RS 2.0 tests

### DIFF
--- a/contacts-jquerymobile/functional-tests/pom.xml
+++ b/contacts-jquerymobile/functional-tests/pom.xml
@@ -33,6 +33,63 @@
         </license>
     </licenses>
 
+    <!-- Activate JBoss Product Maven repository.
+
+        NOTE: Configuring the Maven repository in the pom.xml file is not a recommended procedure
+        and is only done here to make it easier to use the quickstarts.
+
+        For more information about how to configure Maven for your application,
+        see the section entitled 'Use the Maven Repository'
+        in the Development Guide for Red Hat JBoss Enterprise Application Platform located here:
+
+        https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/
+    -->
+    <repositories>
+        <repository>
+            <id>jboss-developer-staging-repository</id>
+            <url>http://jboss-developer.github.io/temp-maven-repo/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>redhat-ga-repository</id>
+            <url>https://maven.repository.redhat.com/ga/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jboss-developer-staging-repository</id>
+            <url>http://jboss-developer.github.io/temp-maven-repo/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>redhat-ga-repository</id>
+            <url>https://maven.repository.redhat.com/ga/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <properties>
         <!-- Explicitly declaring the source encoding eliminates the following
                                  message: -->

--- a/contacts-jquerymobile/functional-tests/src/test/java/org/jboss/as/quickstarts/contacts/test/RESTTest.java
+++ b/contacts-jquerymobile/functional-tests/src/test/java/org/jboss/as/quickstarts/contacts/test/RESTTest.java
@@ -109,7 +109,7 @@ public class RESTTest {
 
         HttpResponse response = httpClient.execute(post);
 
-        assertEquals(200, response.getStatusLine().getStatusCode());
+        assertEquals(201, response.getStatusLine().getStatusCode());
     }
 
     @Test

--- a/contacts-jquerymobile/pom.xml
+++ b/contacts-jquerymobile/pom.xml
@@ -105,11 +105,11 @@
         <version.jboss.bom.eap>7.0.0-build-9</version.jboss.bom.eap>
 
         <!-- Other dependency versions -->
-        <version.ro.isdc.wro4j>1.7.8</version.ro.isdc.wro4j>
+        <version.ro.isdc.wro4j>1.7.9</version.ro.isdc.wro4j>
 
         <!-- other plug-in versions -->
-        <version.surefire.plugin>2.10</version.surefire.plugin>
-        <version.war.plugin>2.2</version.war.plugin>
+        <version.surefire.plugin>2.18.1</version.surefire.plugin>
+        <version.war.plugin>2.6</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -134,6 +134,16 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.1</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.4</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -145,10 +155,6 @@
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
         </dependency>
 
         <!-- Import the Common Annotations API (JSR-250), we use provided scope as the API is included in EAP -->
@@ -230,35 +236,28 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Test dependencies required for testing REST services -->
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Optional, but highly recommended -->
         <!-- Arquillian allows you to test enterprise code such as EJBs and Transactional(JTA) JPA from JUnit/TestNG -->
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-container-test-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.shrinkwrap</groupId>
-            <artifactId>shrinkwrap-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/contacts-jquerymobile/src/test/resources/arquillian.xml
+++ b/contacts-jquerymobile/src/test/resources/arquillian.xml
@@ -20,13 +20,13 @@
    xsi:schemaLocation="http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+   <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
+   <defaultProtocol type="Servlet 3.0" />
+
    <!-- Uncomment to have test archives exported to the file system for inspection -->
 <!--    <engine>  -->
 <!--       <property name="deploymentExportPath">target/</property>  -->
 <!--    </engine> -->
-
-   <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
-   <defaultProtocol type="Servlet 3.0" />
 
    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform or AS 7 instance -->
    <container qualifier="jboss" default="true">

--- a/contacts-jquerymobile/src/test/resources/jboss-web.xml
+++ b/contacts-jquerymobile/src/test/resources/jboss-web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!DOCTYPE jboss-web>
+<jboss-web xmlns="http://www.jboss.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.jboss.org/schema/jbossas
+    http://www.jboss.org/schema/jbossas/jboss-web_7_2.xsd">
+
+    <context-root>test</context-root>
+
+</jboss-web>


### PR DESCRIPTION
To explain proposed modifications:
1. Added required repositories to functional tests.
2. Returned HTTP CREATED (201) when successfully created contact and updated tests accordingly with URI location of created contact
3. removed returning HTTP NOT_FOUND in retrieveAllContacts if no contact exists, this caused errors if last contact was deleted
4. enabling commented JAX-RS 2.0 tests
5. adding required test dependencies, updates of maven plugin versions a bit of pom.xml cleanup
