### PR TITLE
Replaced deprecated annotation from Spring quickstarts

### DIFF
--- a/spring-kitchensink-asyncrequestmapping/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/asyncrequestmapping/test/MemberDaoTest.java
+++ b/spring-kitchensink-asyncrequestmapping/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/asyncrequestmapping/test/MemberDaoTest.java
@@ -26,16 +26,16 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml",
     "classpath:/META-INF/spring/applicationContext.xml" })
 @Transactional
-@TransactionConfiguration(defaultRollback = true)
+@Rollback
 public class MemberDaoTest {
     @Autowired
     private MemberDao memberDao;

--- a/spring-kitchensink-basic/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/basic/test/MemberDaoTest.java
+++ b/spring-kitchensink-basic/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/basic/test/MemberDaoTest.java
@@ -26,16 +26,16 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml",
     "classpath:/META-INF/spring/applicationContext.xml" })
 @Transactional
-@TransactionConfiguration(defaultRollback = true)
+@Rollback
 public class MemberDaoTest {
     @Autowired
     private MemberDao memberDao;

--- a/spring-kitchensink-controlleradvice/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/controlleradvice/test/MemberDaoTest.java
+++ b/spring-kitchensink-controlleradvice/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/controlleradvice/test/MemberDaoTest.java
@@ -27,16 +27,16 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml",
     "classpath:/META-INF/spring/applicationContext.xml" })
 @Transactional
-@TransactionConfiguration(defaultRollback = true)
+@Rollback
 public class MemberDaoTest {
     @Autowired
     private MemberDao memberDao;

--- a/spring-kitchensink-matrixvariables/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/matrixvariables/test/MemberDaoTest.java
+++ b/spring-kitchensink-matrixvariables/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/matrixvariables/test/MemberDaoTest.java
@@ -26,16 +26,16 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml",
     "classpath:/META-INF/spring/applicationContext.xml" })
 @Transactional
-@TransactionConfiguration(defaultRollback = true)
+@Rollback
 public class MemberDaoTest {
     @Autowired
     private MemberDao memberDao;

--- a/spring-kitchensink-springmvctest/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/springmvctest/test/MemberDaoTest.java
+++ b/spring-kitchensink-springmvctest/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/springmvctest/test/MemberDaoTest.java
@@ -26,16 +26,16 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml",
     "classpath:/META-INF/spring/applicationContext.xml" })
 @Transactional
-@TransactionConfiguration(defaultRollback = true)
+@Rollback
 public class MemberDaoTest {
     @Autowired
     private MemberDao memberDao;


### PR DESCRIPTION
@TransactionConfiguration has beed deprecated in Spring 4.2, in this particular case it  can be replaced with @Rollback
