### PR TITLE
Small fixes for qstools check to pass in kitchensink-html5-mobile

### DIFF
--- a/kitchensink-html5-mobile/pom.xml
+++ b/kitchensink-html5-mobile/pom.xml
@@ -103,7 +103,6 @@
         <version.jboss.bom.eap>7.0.0-build-9</version.jboss.bom.eap>
 
         <!-- Other dependency versions -->
-        <version.org.eclipse.m2e>1.0.0</version.org.eclipse.m2e>
         <version.ro.isdc.wro4j>1.7.8</version.ro.isdc.wro4j>
 
         <!-- other plugin versions -->

--- a/kitchensink-html5-mobile/src/main/webapp/WEB-INF/wro.xml
+++ b/kitchensink-html5-mobile/src/main/webapp/WEB-INF/wro.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
@@ -16,6 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
+<!DOCTYPE xml>
 <groups xmlns="http://www.isdc.ro/wro">
 
     <group name="app.min">

--- a/kitchensink-html5-mobile/src/main/webapp/index.html
+++ b/kitchensink-html5-mobile/src/main/webapp/index.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,6 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
+<!DOCTYPE html>
 <html>
 <head>
     <title>HTML5 QuickStart</title>


### PR DESCRIPTION
Removal of unused property in pom.xml; moving DOCTYPE header after licence comment in two xml files.
