### PR TITLE
Minor fixes of arquillian.xml files

### DIFF
--- a/contacts-jquerymobile/functional-tests/src/test/resources/arquillian.xml
+++ b/contacts-jquerymobile/functional-tests/src/test/resources/arquillian.xml
@@ -20,7 +20,7 @@
 
     <defaultProtocol type="Servlet 3.0" />
 
-    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform or AS 7 instance -->
+    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform instance -->
     <container qualifier="jboss" default="true">
         <!-- By default, Arquillian will use the JBOSS_HOME environment variable.
             Alternatively, the configuration below can be uncommented. -->
@@ -36,8 +36,7 @@
         <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
         <property name="browser">firefox</property>
         <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. These tests are verified to be functioning
-            with Firefox 23. -->
+            will use the default one in your system otherwise. -->
         <!--
         <property name="firefox_binary">/path/to/firefox/binary</property>
         -->

--- a/contacts-jquerymobile/src/test/resources/arquillian.xml
+++ b/contacts-jquerymobile/src/test/resources/arquillian.xml
@@ -28,7 +28,7 @@
 <!--       <property name="deploymentExportPath">target/</property>  -->
 <!--    </engine> -->
 
-   <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform or AS 7 instance -->
+   <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform instance -->
    <container qualifier="jboss" default="true">
         <!-- By default, arquillian will use the JBOSS_HOME environment variable.  Alternatively, the configuration below can be uncommented. -->
         <!--<configuration> -->

--- a/helloworld-html5/functional-tests/src/test/resources/arquillian.xml
+++ b/helloworld-html5/functional-tests/src/test/resources/arquillian.xml
@@ -36,8 +36,7 @@
         <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
         <property name="browser">firefox</property>
         <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. These tests are verified to be functioning
-            with Firefox 23. -->
+            will use the default one in your system otherwise. -->
         <!--
         <property name="firefox_binary">/path/to/firefox/binary</property>
         -->

--- a/kitchensink-angularjs/functional-tests/src/test/resources/arquillian.xml
+++ b/kitchensink-angularjs/functional-tests/src/test/resources/arquillian.xml
@@ -20,7 +20,7 @@
 
     <defaultProtocol type="Servlet 3.0" />
 
-    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform 7 instance -->
+    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform instance -->
     <container qualifier="jboss" default="true">
         <!-- By default, Arquillian will use the JBOSS_HOME environment variable.
             Alternatively, the configuration below can be uncommented. -->
@@ -34,8 +34,7 @@
         <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
         <property name="browser">firefox</property>
         <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. These tests are verified to be functioning
-            with Firefox 23. -->
+            will use the default one in your system otherwise. -->
         <!--
         <property name="firefox_binary">/path/to/firefox/binary</property>
         -->

--- a/kitchensink-html5-mobile/src/test/resources/arquillian.xml
+++ b/kitchensink-html5-mobile/src/test/resources/arquillian.xml
@@ -20,15 +20,15 @@
    xsi:schemaLocation="http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+   <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
+   <defaultProtocol type="Servlet 3.0" />
+
    <!-- Uncomment to have test archives exported to the file system for inspection -->
 <!--    <engine>  -->
 <!--       <property name="deploymentExportPath">target/</property>  -->
 <!--    </engine> -->
 
-   <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
-   <defaultProtocol type="Servlet 3.0" />
-
-   <!-- Example configuration for a remote JBoss EAP 7 instance -->
+   <!-- Example configuration for a remote JBoss EAP instance -->
    <container qualifier="jboss" default="true">
         <!-- By default, arquillian will use the JBOSS_HOME environment variable.  Alternatively, the configuration below can be uncommented. -->
         <!--<configuration> -->

--- a/shrinkwrap-resolver/src/test/resources/arquillian.xml
+++ b/shrinkwrap-resolver/src/test/resources/arquillian.xml
@@ -20,15 +20,15 @@
    xsi:schemaLocation="http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+   <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
+   <defaultProtocol type="Servlet 3.0" />
+
    <!-- Uncomment to have test archives exported to the file system for inspection -->
 <!--    <engine>  -->
 <!--       <property name="deploymentExportPath">target/</property>  -->
 <!--    </engine> -->
 
-   <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
-   <defaultProtocol type="Servlet 3.0" />
-
-     <!-- Example configuration for a remote JBoss EAP instance -->
+   <!-- Example configuration for a remote JBoss EAP instance -->
    <container qualifier="jboss" default="true">
         <!-- By default, arquillian will use the JBOSS_HOME environment variable.  Alternatively, the configuration below can be uncommented. -->
         <!--<configuration> -->

--- a/spring-greeter/functional-tests/src/test/resources/arquillian.xml
+++ b/spring-greeter/functional-tests/src/test/resources/arquillian.xml
@@ -20,7 +20,7 @@
 
     <defaultProtocol type="Servlet 3.0" />
 
-    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform or AS 7 instance -->
+    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform instance -->
     <container qualifier="jboss" default="true">
         <!-- By default, Arquillian will use the JBOSS_HOME environment variable.
             Alternatively, the configuration below can be uncommented. -->
@@ -36,8 +36,7 @@
         <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
         <property name="browser">firefox</property>
         <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. These tests are verified to be functioning
-            with Firefox 23. -->
+            will use the default one in your system otherwise. -->
         <!--
         <property name="firefox_binary">/path/to/firefox/binary</property>
         -->

--- a/spring-kitchensink-asyncrequestmapping/functional-tests/src/test/resources/arquillian.xml
+++ b/spring-kitchensink-asyncrequestmapping/functional-tests/src/test/resources/arquillian.xml
@@ -20,7 +20,7 @@
 
     <defaultProtocol type="Servlet 3.0" />
 
-    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform or AS 7 instance -->
+    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform instance -->
     <container qualifier="jboss" default="true">
         <!-- By default, Arquillian will use the JBOSS_HOME environment variable.
             Alternatively, the configuration below can be uncommented. -->
@@ -36,8 +36,7 @@
         <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
         <property name="browser">firefox</property>
         <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. These tests are verified to be functioning
-            with Firefox 23. -->
+            will use the default one in your system otherwise. -->
         <!--
         <property name="firefox_binary">/path/to/firefox/binary</property>
         -->

--- a/spring-kitchensink-basic/functional-tests/src/test/resources/arquillian.xml
+++ b/spring-kitchensink-basic/functional-tests/src/test/resources/arquillian.xml
@@ -20,7 +20,7 @@
 
     <defaultProtocol type="Servlet 3.0" />
 
-    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform or AS 7 instance -->
+    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform instance -->
     <container qualifier="jboss" default="true">
         <!-- By default, Arquillian will use the JBOSS_HOME environment variable.
             Alternatively, the configuration below can be uncommented. -->
@@ -36,8 +36,7 @@
         <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
         <property name="browser">firefox</property>
         <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. These tests are verified to be functioning
-            with Firefox 23. -->
+            will use the default one in your system otherwise. -->
         <!--
         <property name="firefox_binary">/path/to/firefox/binary</property>
         -->

--- a/spring-kitchensink-controlleradvice/functional-tests/src/test/resources/arquillian.xml
+++ b/spring-kitchensink-controlleradvice/functional-tests/src/test/resources/arquillian.xml
@@ -20,7 +20,7 @@
 
     <defaultProtocol type="Servlet 3.0" />
 
-    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform or AS 7 instance -->
+    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform instance -->
     <container qualifier="jboss" default="true">
         <!-- By default, Arquillian will use the JBOSS_HOME environment variable.
             Alternatively, the configuration below can be uncommented. -->
@@ -36,8 +36,7 @@
         <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
         <property name="browser">firefox</property>
         <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. These tests are verified to be functioning
-            with Firefox 23. -->
+            will use the default one in your system otherwise. -->
         <!--
         <property name="firefox_binary">/path/to/firefox/binary</property>
         -->

--- a/spring-kitchensink-matrixvariables/functional-tests/src/test/resources/arquillian.xml
+++ b/spring-kitchensink-matrixvariables/functional-tests/src/test/resources/arquillian.xml
@@ -20,7 +20,7 @@
 
     <defaultProtocol type="Servlet 3.0" />
 
-    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform or AS 7 instance -->
+    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform instance -->
     <container qualifier="jboss" default="true">
         <!-- By default, Arquillian will use the JBOSS_HOME environment variable.
             Alternatively, the configuration below can be uncommented. -->
@@ -36,8 +36,7 @@
         <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
         <property name="browser">firefox</property>
         <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. These tests are verified to be functioning
-            with Firefox 23. -->
+            will use the default one in your system otherwise. -->
         <!--
         <property name="firefox_binary">/path/to/firefox/binary</property>
         -->

--- a/spring-kitchensink-springmvctest/functional-tests/src/test/resources/arquillian.xml
+++ b/spring-kitchensink-springmvctest/functional-tests/src/test/resources/arquillian.xml
@@ -20,7 +20,7 @@
 
     <defaultProtocol type="Servlet 3.0" />
 
-    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform or AS 7 instance -->
+    <!-- Example configuration for a remote Red Hat JBoss Enterprise Application Platform instance -->
     <container qualifier="jboss" default="true">
         <!-- By default, Arquillian will use the JBOSS_HOME environment variable.
             Alternatively, the configuration below can be uncommented. -->
@@ -36,8 +36,7 @@
         <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
         <property name="browser">firefox</property>
         <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. These tests are verified to be functioning
-            with Firefox 23. -->
+            will use the default one in your system otherwise. -->
         <!--
         <property name="firefox_binary">/path/to/firefox/binary</property>
         -->

--- a/spring-petclinic/functional-tests/src/test/resources/arquillian.xml
+++ b/spring-petclinic/functional-tests/src/test/resources/arquillian.xml
@@ -37,8 +37,7 @@
         <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
         <property name="browser">firefox</property>
         <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. These tests are verified to be functioning
-            with Firefox 23. -->
+            will use the default one in your system otherwise. -->
         <!--
         <property name="firefox_binary">/path/to/firefox/binary</property>
         -->


### PR DESCRIPTION
Fixes of comments in arquillian.xml files - maily version removals. It is not required there and it is difficult to maintain.

Element engine must be placed after element defaultProtocol
