### PR TITLE
Minor fixes to make qstool maven plugin check happy

### DIFF
--- a/helloworld-html5/src/main/webapp/index.html
+++ b/helloworld-html5/src/main/webapp/index.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,6 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
+<!DOCTYPE html>
 <html>
 <head>
 <title>HTML5 + REST Hello World</title>

--- a/shrinkwrap-resolver/README.md
+++ b/shrinkwrap-resolver/README.md
@@ -3,7 +3,7 @@ shrinkwrap-resolver: Demonstrates Usage of Shrinkwrap Resolver
 Author: Rafael Benevides  
 Level: Intermediate  
 Technologies: CDI, Arquillian, Shrinkwrap  
-Summary: The `shrinkwrap-resolver` quickstart demonstrates 3 common use cases for ShrinkWrap Resolver.   
+Summary: The `shrinkwrap-resolver` quickstart demonstrates three common use cases for ShrinkWrap Resolver in Red Hat JBoss Enterprise Application Platform.  
 Target Product: JBoss EAP  
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 

--- a/spring-kitchensink-asyncrequestmapping/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/asyncrequestmapping/test/MemberDaoTest.java
+++ b/spring-kitchensink-asyncrequestmapping/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/asyncrequestmapping/test/MemberDaoTest.java
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml",
-    "classpath:/META-INF/spring/applicationContext.xml" })
+        "classpath:/META-INF/spring/applicationContext.xml" })
 @Transactional
 @Rollback
 public class MemberDaoTest {

--- a/spring-kitchensink-basic/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/basic/test/MemberDaoTest.java
+++ b/spring-kitchensink-basic/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/basic/test/MemberDaoTest.java
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml",
-    "classpath:/META-INF/spring/applicationContext.xml" })
+        "classpath:/META-INF/spring/applicationContext.xml" })
 @Transactional
 @Rollback
 public class MemberDaoTest {

--- a/spring-kitchensink-controlleradvice/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/controlleradvice/test/MemberDaoTest.java
+++ b/spring-kitchensink-controlleradvice/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/controlleradvice/test/MemberDaoTest.java
@@ -34,7 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml",
-    "classpath:/META-INF/spring/applicationContext.xml" })
+        "classpath:/META-INF/spring/applicationContext.xml" })
 @Transactional
 @Rollback
 public class MemberDaoTest {

--- a/spring-kitchensink-matrixvariables/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/matrixvariables/test/MemberDaoTest.java
+++ b/spring-kitchensink-matrixvariables/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/matrixvariables/test/MemberDaoTest.java
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml",
-    "classpath:/META-INF/spring/applicationContext.xml" })
+        "classpath:/META-INF/spring/applicationContext.xml" })
 @Transactional
 @Rollback
 public class MemberDaoTest {

--- a/spring-kitchensink-springmvctest/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/springmvctest/test/MemberDaoTest.java
+++ b/spring-kitchensink-springmvctest/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/springmvctest/test/MemberDaoTest.java
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml",
-    "classpath:/META-INF/spring/applicationContext.xml" })
+        "classpath:/META-INF/spring/applicationContext.xml" })
 @Transactional
 @Rollback
 public class MemberDaoTest {

--- a/spring-kitchensink-springmvctest/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/springmvctest/test/MemberMockMVCTest.java
+++ b/spring-kitchensink-springmvctest/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/springmvctest/test/MemberMockMVCTest.java
@@ -43,7 +43,7 @@ import org.springframework.web.context.WebApplicationContext;
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
 @ContextConfiguration(locations = { "classpath:test-context.xml",
-    "classpath:/META-INF/spring/applicationContext.xml" })
+        "classpath:/META-INF/spring/applicationContext.xml" })
 public class MemberMockMVCTest {
 
     @Autowired

--- a/spring-resteasy/pom.xml
+++ b/spring-resteasy/pom.xml
@@ -141,6 +141,12 @@
                 <scope>import</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${version.org.apache.httpcomponents}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -168,7 +174,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>${version.org.apache.httpcomponents}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Indentation issues, one summary fix - was too short, and specifying dependency version via dependencyManagement rather than having in in dependencies.
