### PR TITLE
Removed hard-coded version in kitchensink-angularjs functional tests

### DIFF
--- a/kitchensink-angularjs/functional-tests/pom.xml
+++ b/kitchensink-angularjs/functional-tests/pom.xml
@@ -203,26 +203,24 @@
 
     <profiles>
         <profile>
-            <!-- Profile that executes tests in managed JBoss AS instance. -->
+            <!-- Profile that executes tests in managed JBoss EAP instance. -->
             <id>arq-wildfly-managed</id>
             <dependencies>
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>1.0.0.Final</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
         </profile>
 
         <profile>
-            <!-- Profile that executes tests in remote JBoss AS instance. -->
+            <!-- Profile that executes tests in remote JBoss EAP instance. -->
             <id>arq-wildfly-remote</id>
             <dependencies>
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-remote</artifactId>
-                    <version>1.0.0.Final</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
Version should be resolved using EAP7 -with-tools BOM.
