### PR TITLE
Comment out example configuration in kitchensink-angularjs

### DIFF
--- a/kitchensink-angularjs/functional-tests/src/test/resources/arquillian.xml
+++ b/kitchensink-angularjs/functional-tests/src/test/resources/arquillian.xml
@@ -24,9 +24,11 @@
     <container qualifier="jboss" default="true">
         <!-- By default, Arquillian will use the JBOSS_HOME environment variable.
             Alternatively, the configuration below can be uncommented. -->
+        <!--
         <configuration>
-            <property name="jbossHome">${jboss.home}</property>
+            <property name="jbossHome">/path/to/jboss/as</property>
         </configuration>
+        -->
     </container>
 
     <!-- WebDriver extension -->


### PR DESCRIPTION
This is commented out in all other quickstarts having functional tests, like spring-kitchensink-\* or contacts-jquerymobile.
