### PR TITLE
Added JTA API dependency for tests to Spring Quickstarts

### DIFF
--- a/spring-kitchensink-asyncrequestmapping/pom.xml
+++ b/spring-kitchensink-asyncrequestmapping/pom.xml
@@ -262,6 +262,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Add JTA API for tests -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/spring-kitchensink-basic/pom.xml
+++ b/spring-kitchensink-basic/pom.xml
@@ -262,6 +262,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Add JTA API for tests -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/spring-kitchensink-controlleradvice/pom.xml
+++ b/spring-kitchensink-controlleradvice/pom.xml
@@ -262,6 +262,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Add JTA API for tests -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/spring-kitchensink-matrixvariables/pom.xml
+++ b/spring-kitchensink-matrixvariables/pom.xml
@@ -262,6 +262,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Add JTA API for tests -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/spring-kitchensink-springmvctest/pom.xml
+++ b/spring-kitchensink-springmvctest/pom.xml
@@ -303,6 +303,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Add JTA API for tests -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
Hibernate 5.0.5 no longer transitively depends on JTA API so it needs to be added explicitly.
