### PR TITLE
Fill in date first when registering in spring controlleradvice test

### DIFF
--- a/spring-kitchensink-controlleradvice/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/page/RegistrationFormPageFragment.java
+++ b/spring-kitchensink-controlleradvice/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/page/RegistrationFormPageFragment.java
@@ -104,12 +104,6 @@ public class RegistrationFormPageFragment {
     private WebElement today;
 
     public void register(Member member, boolean fillDate) {
-        nameField.clear();
-        nameField.sendKeys(member.getName());
-        emailField.clear();
-        emailField.sendKeys(member.getEmail());
-        phoneField.clear();
-        phoneField.sendKeys(member.getPhoneNumber());
         if (fillDate) {
             registrationForm.click();
             javascript.executeScript("document.getElementById('datepicker').focus()");
@@ -118,6 +112,14 @@ public class RegistrationFormPageFragment {
             today.click();
             javascript.executeScript("document.getElementById('datepicker').blur()");
         }
+        nameField.click();
+        nameField.clear();
+        nameField.sendKeys(member.getName());
+        emailField.clear();
+        emailField.sendKeys(member.getEmail());
+        phoneField.clear();
+        phoneField.sendKeys(member.getPhoneNumber());
+
         guardHttp(registerButton).click();
     }
 


### PR DESCRIPTION
I came across  "element not clickable" error if using newer version of selenium 2.50.\* in this functional test. The problem is that when filling in date, calendar pops up and hides the "register" button.

Filling in date first and the filling in other info (name, email, ...) is much more stable.
