### PR TITLE
Removed JBoss Forge version

### DIFF
--- a/forge-from-scratch/README.md
+++ b/forge-from-scratch/README.md
@@ -3,14 +3,14 @@ forge-from-scratch: Shows How Forge Can Generate an Application
 Author: Lincoln Baxter, Matej Briskar  
 Level: Intermediate  
 Technologies: Forge  
-Summary: The `forge-from-scratch` quickstart demonstrates how *JBoss Forge 2* can generate a Java EE (JPA, EJB, JAX-RS, JSF) web-enabled database application.   
+Summary: The `forge-from-scratch` quickstart demonstrates how *JBoss Forge* can generate a Java EE (JPA, EJB, JAX-RS, JSF) web-enabled database application.   
 Target Product: JBoss EAP  
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 
 What is it?
 -----------
 
-The `forge-from-scratch` quickstart demonstrates how to create a fully **Java EE compliant** project using **JBoss Forge 2** and **Red Hat JBoss Developer Studio 9** or later and deploy it to **Red Hat JBoss Enterprise Application Platform 7** or later. 
+The `forge-from-scratch` quickstart demonstrates how to create a fully **Java EE compliant** project using **JBoss Forge** and **Red Hat JBoss Developer Studio 9** or later and deploy it to **Red Hat JBoss Enterprise Application Platform 7** or later. 
 
 Once generated, the sample project will be a standard Maven 3, Java Web project with **JPA, EJB, CDI, JSF** with complete **JAX-RS** endpoints for all data Entities. It will also provide views to Create, Read, Update, and Delete records.
 


### PR DESCRIPTION
JBoss Forge is now at version 3 and is usually known without the version (Forge 1.x is long gone)

Feel free to close this PR if it doesn't make sense
