### PR TITLE
JBEAP-4296: Remove references to warnings about using JBDS 9.0 becaus…

### DIFF
--- a/cmt/README.md
+++ b/cmt/README.md
@@ -119,10 +119,6 @@ You can also start the server and deploy the quickstarts or run the Arquillian t
 
 _NOTE:_ Within JBoss Developer Studio, be sure to define a server runtime environment that uses the `standalone-full.xml` configuration file.
 
-You may see the following warning when you import this quickstart into JBoss Developer Studio 9.0 or earlier. You can ignore this warning.
-
-        No grammar constraints (DTD or XML Schema) referenced in the document.
-
 
 Debug the Application
 ------------------------------------

--- a/helloworld-mdb-propertysubstitution/README.md
+++ b/helloworld-mdb-propertysubstitution/README.md
@@ -182,10 +182,6 @@ You can also start the server and deploy the quickstarts or run the Arquillian t
 * Within JBoss Developer Studio, be sure to define a server runtime environment that uses the `standalone-full.xml` configuration file.
 * Be sure to [Restore the JBoss EAP Server Configuration](#restore-the-jboss-eap-server-configuration) when you have completed testing this quickstart.
 
-You may see the following warning when you import this quickstart into JBoss Developer Studio 9.0 or earlier. You can ignore this warning.
-
-        No grammar constraints (DTD or XML Schema) referenced in the document.
-
 
 Debug the Application
 ------------------------------------

--- a/jta-crash-rec/README.md
+++ b/jta-crash-rec/README.md
@@ -186,9 +186,6 @@ You can also start the server and deploy the quickstarts or run the Arquillian t
 
 _NOTE:_ Within JBoss Developer Studio, be sure to define a server runtime environment that uses the `standalone-full.xml` configuration file.
 
-You may see the following warning when you import this quickstart into JBoss Developer Studio 9.0 or earlier. You can ignore this warning.
-
-        No grammar constraints (DTD or XML Schema) referenced in the document.
 
 Debug the Application
 ------------------------------------


### PR DESCRIPTION
…e it is not supported
