### PR TITLE
JBEAP-4296: Remove references to warnings about using JBDS 9.0 becaus…

### DIFF
--- a/cmt/README.html
+++ b/cmt/README.html
@@ -115,9 +115,6 @@ that the method logCreateCustomer in the EJB LogMessageManagerEJB is decorated w
 
 <p><em>NOTE:</em> Within JBoss Developer Studio, be sure to define a server runtime environment that uses the <code>standalone-full.xml</code> configuration file.</p>
 
-<p>You may see the following warning when you import this quickstart into JBoss Developer Studio 9.0 or earlier. You can ignore this warning.</p>
-<div class="highlight"><pre>    <span class="n">No</span> <span class="n">grammar</span> <span class="n">constraints</span> <span class="p">(</span><span class="n">DTD</span> <span class="n">or</span> <span class="n">XML</span> <span class="n">Schema</span><span class="p">)</span> <span class="n">referenced</span> <span class="n">in</span> <span class="n">the</span> <span class="n">document</span><span class="p">.</span>
-</pre></div>
 <h2><a id="debug-the-application" class="anchor" href="#debug-the-application"><span class="anchor-icon"></span></a>Debug the Application</h2>
 
 <p>If you want to debug the source code of any library in the project, run the following command to pull the source into your local repository. The IDE should then detect it.</p>

--- a/cmt/README.md
+++ b/cmt/README.md
@@ -119,10 +119,6 @@ You can also start the server and deploy the quickstarts or run the Arquillian t
 
 _NOTE:_ Within JBoss Developer Studio, be sure to define a server runtime environment that uses the `standalone-full.xml` configuration file.
 
-You may see the following warning when you import this quickstart into JBoss Developer Studio 9.0 or earlier. You can ignore this warning.
-
-        No grammar constraints (DTD or XML Schema) referenced in the document.
-
 
 Debug the Application
 ------------------------------------

--- a/helloworld-mdb-propertysubstitution/README.html
+++ b/helloworld-mdb-propertysubstitution/README.html
@@ -178,9 +178,6 @@ INFO  [org.jboss.as.ejb3] (MSC service thread 1-6) WFLYEJB0042: Started message 
 <li>Be sure to <a href="#restore-the-jboss-eap-server-configuration">Restore the JBoss EAP Server Configuration</a> when you have completed testing this quickstart.</li>
 </ul>
 
-<p>You may see the following warning when you import this quickstart into JBoss Developer Studio 9.0 or earlier. You can ignore this warning.</p>
-<div class="highlight"><pre>    <span class="n">No</span> <span class="n">grammar</span> <span class="n">constraints</span> <span class="p">(</span><span class="n">DTD</span> <span class="n">or</span> <span class="n">XML</span> <span class="n">Schema</span><span class="p">)</span> <span class="n">referenced</span> <span class="n">in</span> <span class="n">the</span> <span class="n">document</span><span class="p">.</span>
-</pre></div>
 <h2><a id="debug-the-application" class="anchor" href="#debug-the-application"><span class="anchor-icon"></span></a>Debug the Application</h2>
 
 <p>If you want to debug the source code of any library in the project, run the following command to pull the source into your local repository. The IDE should then detect it.</p>

--- a/helloworld-mdb-propertysubstitution/README.md
+++ b/helloworld-mdb-propertysubstitution/README.md
@@ -182,10 +182,6 @@ You can also start the server and deploy the quickstarts or run the Arquillian t
 * Within JBoss Developer Studio, be sure to define a server runtime environment that uses the `standalone-full.xml` configuration file.
 * Be sure to [Restore the JBoss EAP Server Configuration](#restore-the-jboss-eap-server-configuration) when you have completed testing this quickstart.
 
-You may see the following warning when you import this quickstart into JBoss Developer Studio 9.0 or earlier. You can ignore this warning.
-
-        No grammar constraints (DTD or XML Schema) referenced in the document.
-
 
 Debug the Application
 ------------------------------------

--- a/jta-crash-rec/README.html
+++ b/jta-crash-rec/README.html
@@ -178,9 +178,6 @@ Source: <a href="https://github.com/jboss-developer/jboss-eap-quickstarts/">http
 
 <p><em>NOTE:</em> Within JBoss Developer Studio, be sure to define a server runtime environment that uses the <code>standalone-full.xml</code> configuration file.</p>
 
-<p>You may see the following warning when you import this quickstart into JBoss Developer Studio 9.0 or earlier. You can ignore this warning.</p>
-<div class="highlight"><pre>    <span class="n">No</span> <span class="n">grammar</span> <span class="n">constraints</span> <span class="p">(</span><span class="n">DTD</span> <span class="n">or</span> <span class="n">XML</span> <span class="n">Schema</span><span class="p">)</span> <span class="n">referenced</span> <span class="n">in</span> <span class="n">the</span> <span class="n">document</span><span class="p">.</span>
-</pre></div>
 <h2><a id="debug-the-application" class="anchor" href="#debug-the-application"><span class="anchor-icon"></span></a>Debug the Application</h2>
 
 <p>If you want to debug the source code of any library in the project, run the following command to pull the source into your local repository. The IDE should then detect it.</p>

--- a/jta-crash-rec/README.md
+++ b/jta-crash-rec/README.md
@@ -186,9 +186,6 @@ You can also start the server and deploy the quickstarts or run the Arquillian t
 
 _NOTE:_ Within JBoss Developer Studio, be sure to define a server runtime environment that uses the `standalone-full.xml` configuration file.
 
-You may see the following warning when you import this quickstart into JBoss Developer Studio 9.0 or earlier. You can ignore this warning.
-
-        No grammar constraints (DTD or XML Schema) referenced in the document.
 
 Debug the Application
 ------------------------------------


### PR DESCRIPTION
…e it is not supported
