### PR TITLE
[BZ-1335495] Clustering quickstart race condition

### DIFF
--- a/cluster-ha-singleton/service/src/main/java/org/jboss/as/quickstarts/cluster/hasingleton/service/ejb/HATimerServiceActivator.java
+++ b/cluster-ha-singleton/service/src/main/java/org/jboss/as/quickstarts/cluster/hasingleton/service/ejb/HATimerServiceActivator.java
@@ -47,6 +47,7 @@ public class HATimerServiceActivator implements ServiceActivator {
         ServiceName factoryServiceName = SingletonServiceName.BUILDER.getServiceName("server", "default");
         ServiceController<?> factoryService = context.getServiceRegistry().getRequiredService(factoryServiceName);
         SingletonServiceBuilderFactory factory = (SingletonServiceBuilderFactory) factoryService.getValue();
+        ServiceName ejbComponentService = ServiceName.of("jboss", "deployment", "unit", "jboss-cluster-ha-singleton-service.jar", "component", "SchedulerBean", "START");
         factory.createSingletonServiceBuilder(HATimerService.SINGLETON_SERVICE_NAME, service)
             /*
              * The NamePreference is a combination of the node name (-Djboss.node.name) and the name of
@@ -58,11 +59,13 @@ public class HATimerServiceActivator implements ServiceActivator {
              *   - To pass a list of more than one node, comment the first line and uncomment the
              * second line below.
              */
+
             .electionPolicy(new PreferredSingletonElectionPolicy(new SimpleSingletonElectionPolicy(), new NamePreference("node1/singleton")))
             //singleton.setElectionPolicy(new PreferredSingletonElectionPolicy(new SimpleSingletonElectionPolicy(), new NamePreference("node1/singleton"), new NamePreference("node2/singleton")));
 
             .build(new DelegatingServiceContainer(context.getServiceTarget(), context.getServiceRegistry()))
             .setInitialMode(ServiceController.Mode.ACTIVE)
+            .addDependency(ejbComponentService)
             .install();
     }
 }


### PR DESCRIPTION
this avoid the ejb being stopped before the the activator service causing a race condition and some stacktraces.

more info in 6.4.z: https://bugzilla.redhat.com/show_bug.cgi?id=1335495
