### PR TITLE
JBEAP-5240: Restore wildfly-maven-plugin in managed-executor POM file…

### DIFF
--- a/cdi-portable-extension/pom.xml
+++ b/cdi-portable-extension/pom.xml
@@ -76,10 +76,6 @@
         resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- JBoss dependency versions -->
-
-        <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
-
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <version.jboss.bom.eap>7.1.0-SNAPSHOT</version.jboss.bom.eap>
 
@@ -147,12 +143,6 @@
                     <!-- Java EE doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
-            </plugin>
-            <!-- WildFly plug-in to deploy the WAR -->
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <version>${version.wildfly.maven.plugin}</version>
             </plugin>
         </plugins>
     </build>

--- a/cdi-veto/pom.xml
+++ b/cdi-veto/pom.xml
@@ -76,10 +76,6 @@
             filtered resources, i.e. build is platform dependent! -->
          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- JBoss dependency versions -->
-
-        <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
-
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <version.jboss.bom.eap>7.1.0-SNAPSHOT</version.jboss.bom.eap>
 
@@ -156,12 +152,6 @@
                     <!-- Java EE doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
-            </plugin>
-            <!-- WildFly plug-in to deploy the WAR -->
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <version>${version.wildfly.maven.plugin}</version>
             </plugin>
         </plugins>
     </build>

--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -79,9 +79,6 @@
         <!-- EAP component version management BOM -->
         <version.jboss.bom.eap>7.1.0-SNAPSHOT</version.jboss.bom.eap>
 
-        <!-- WildFly Maven plug-in to deploy your WAR to a local JBoss EAP container -->
-        <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
-
         <!-- other plug-in versions -->
         <version.jar.plugin>2.2</version.jar.plugin>
         <version.exec.plugin>1.2.1</version.exec.plugin>
@@ -169,12 +166,6 @@
                 <version>${version.jar.plugin}</version>
                 <configuration>
                 </configuration>
-            </plugin>
-            <!-- WildFly plug-in to deploy the WAR -->
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <version>${version.wildfly.maven.plugin}</version>
             </plugin>
         </plugins>
     </build>

--- a/managed-executor-service/pom.xml
+++ b/managed-executor-service/pom.xml
@@ -78,6 +78,9 @@
             filtered resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- JBoss dependency versions -->
+        <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
+
         <!-- Define the version of the JBoss BOMs we want to import to specify
             tested stacks. -->
         <version.jboss.bom.eap>7.1.0-SNAPSHOT</version.jboss.bom.eap>
@@ -284,6 +287,13 @@
                     <!-- Java EE doesn't require web.xml, Maven needs to catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
+            </plugin>
+            <!-- The WildFly plug-in deploys the WAR to a local JBoss EAP container.
+                 To use, run: mvn package wildfly:deploy -->
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.maven.plugin}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
… and remove it from cdi-veto, cdi-portable-extension, and helloworld-jms
