### PR TITLE
JBEAP-5796: Remove wildfly-maven-plugin from the default profile to f…

### DIFF
--- a/cdi-portable-extension/pom.xml
+++ b/cdi-portable-extension/pom.xml
@@ -169,9 +169,9 @@
 
     <profiles>
         <profile>
-            <!-- The default profile skips all tests, though you can tune it 
+            <!-- The default profile skips all tests, though you can tune it
                  to run just unit tests based on a custom pattern.
-                 Separate profiles are provided for running all tests, including 
+                 Separate profiles are provided for running all tests, including
                  Arquillian tests that execute in the specified container -->
             <id>default</id>
             <activation>
@@ -186,20 +186,13 @@
                             <skip>true</skip>
                         </configuration>
                     </plugin>
-                    <!-- The WildFly plug-in deploys the WAR to a local JBoss EAP container -->
-                    <!-- To use, run: mvn package wildfly:deploy -->
-                    <plugin>
-                        <groupId>org.wildfly.plugins</groupId>
-                        <artifactId>wildfly-maven-plugin</artifactId>
-                        <version>${version.wildfly.maven.plugin}</version>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
 
         <profile>
             <!-- An optional Arquillian testing profile that executes tests in your JBoss EAP instance.
-                 This profile will start a new JBoss EAP instance, and execute the test, shutting it down when done. 
+                 This profile will start a new JBoss EAP instance, and execute the test, shutting it down when done.
                  Run with: mvn clean test -Parq-wildfly-managed -->
              <id>arq-wildfly-managed</id>
             <dependencies>

--- a/cdi-veto/pom.xml
+++ b/cdi-veto/pom.xml
@@ -92,7 +92,7 @@
 
     <properties>
         <!-- Explicitly declaring the source encoding eliminates the following
-            message: [WARNING] Using platform encoding (UTF-8 actually) to copy 
+            message: [WARNING] Using platform encoding (UTF-8 actually) to copy
             filtered resources, i.e. build is platform dependent! -->
          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -178,9 +178,9 @@
 
     <profiles>
         <profile>
-            <!-- The default profile skips all tests, though you can tune it 
+            <!-- The default profile skips all tests, though you can tune it
                  to run just unit tests based on a custom pattern.
-                 Separate profiles are provided for running all tests, including 
+                 Separate profiles are provided for running all tests, including
                  Arquillian tests that execute in the specified container -->
             <id>default</id>
             <activation>
@@ -195,13 +195,6 @@
                             <skip>true</skip>
                         </configuration>
                     </plugin>
-                    <!-- The WildFly plug-in deploys the WAR to a local JBoss EAP container.
-                         To use, run: mvn package wildfly:deploy -->
-                    <plugin>
-                        <groupId>org.wildfly.plugins</groupId>
-                        <artifactId>wildfly-maven-plugin</artifactId>
-                        <version>${version.wildfly.maven.plugin}</version>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -209,7 +202,7 @@
         <profile>
 
             <!-- An optional Arquillian testing profile that executes tests in your JBoss EAP instance.
-                 This profile will start a new JBoss EAP instance, and execute the test, shutting it down when done. 
+                 This profile will start a new JBoss EAP instance, and execute the test, shutting it down when done.
                  Run with: mvn clean test -Parq-wildfly-managed -->
             <id>arq-wildfly-managed</id>
             <dependencies>


### PR DESCRIPTION
…ix broken builds for cdi-portable-extension and cdi-veto quickstarts
