### PR TITLE
added support for secure web sockets with the protocol is https

### DIFF
--- a/websocket-hello/src/main/webapp/index.html
+++ b/websocket-hello/src/main/webapp/index.html
@@ -23,7 +23,8 @@
             var websocket = null;
 
             function connect() {
-                var wsURI = 'ws://' + window.location.host + '/jboss-websocket-hello/websocket/helloName';
+                var wsProtocol = window.location.protocol == "https:" ? "wss" : "ws";
+                var wsURI = wsProtocol + '://' + window.location.host + '/jboss-websocket-hello/websocket/helloName';
                 websocket = new WebSocket(wsURI);
 
                 websocket.onopen = function() {


### PR DESCRIPTION
I had the need to test an environment that was running on HTTPS with this quickstart to make sure that WebSockets was being proxied correctly. The quickstart did not work out-of-the-box with this setup so I added this change for it to work correctly.
