### PR TITLE
JBEAP-5489: Update protocol for thread-racing and websocket-endpoint quickstarts

### DIFF
--- a/thread-racing/src/main/webapp/index.html
+++ b/thread-racing/src/main/webapp/index.html
@@ -43,7 +43,8 @@
         } else {
             host = window.location.host;
         }
-        var url = 'ws://' + host + window.location.pathname + 'race';
+        var wsProtocol = window.location.protocol == "https:" ? "wss" : "ws";
+        var url = wsProtocol + '://' + host + window.location.pathname + 'race';
         var ws = new WebSocket(url);
         ws.onmessage = function (message) {
             output.innerHTML += message.data;

--- a/websocket-endpoint/src/main/webapp/resources/js/javascript.js
+++ b/websocket-endpoint/src/main/webapp/resources/js/javascript.js
@@ -110,7 +110,8 @@ function openWebSocket() {
     if (loc.hostname.indexOf('rhcloud.com', 0) > 0) {
         port = 8000;
     }
-    var wsurl = "ws://" + loc.hostname + ':' + port + loc.pathname
+    var wsProtocol = window.location.protocol == "https:" ? "wss" : "ws";
+    var wsurl = wsProtocol + "://" + loc.hostname + ':' + port + loc.pathname
             + "/../bidsocket";
     wsocket = new WebSocket(wsurl);
     wsocket.onmessage = function(evt) {


### PR DESCRIPTION
Based on thiis pull request [1] from @chrisruffalo , I discovered other cases where the code should be updated to handle secure connections. This fixes 2 of the 3. I am waiting on websocket-client because it is currently not working.

[1] https://github.com/jboss-developer/jboss-eap-quickstarts/pull/1982
