### PR TITLE
[JBEAP-6228] Replace WildFly artifacts with EAP ones

### DIFF
--- a/app-client/client-simple/pom.xml
+++ b/app-client/client-simple/pom.xml
@@ -40,7 +40,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
             <scope>provided</scope>

--- a/app-client/ejb/pom.xml
+++ b/app-client/ejb/pom.xml
@@ -39,7 +39,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
             <scope>provided</scope>

--- a/cluster-ha-singleton/service/pom.xml
+++ b/cluster-ha-singleton/service/pom.xml
@@ -60,7 +60,7 @@
         <!-- Import JBoss EAP Clustering Singleton, to allow us to create
             a singleton service -->
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-clustering-singleton-api</artifactId>
         </dependency>
     </dependencies>

--- a/ejb-asynchronous/client/pom.xml
+++ b/ejb-asynchronous/client/pom.xml
@@ -54,7 +54,7 @@
 
         <!-- Include the ejb client jars -->
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
             <scope>runtime</scope>

--- a/ejb-multi-server/app-main/ear/pom.xml
+++ b/ejb-multi-server/app-main/ear/pom.xml
@@ -109,7 +109,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <scope>provided</scope>
             <type>pom</type>

--- a/ejb-multi-server/app-main/ejb/pom.xml
+++ b/ejb-multi-server/app-main/ejb/pom.xml
@@ -96,7 +96,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
             <scope>provided</scope>

--- a/ejb-multi-server/app-main/web/pom.xml
+++ b/ejb-multi-server/app-main/web/pom.xml
@@ -96,7 +96,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
             <scope>provided</scope>

--- a/ejb-multi-server/app-one/ear/pom.xml
+++ b/ejb-multi-server/app-one/ear/pom.xml
@@ -101,7 +101,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <scope>provided</scope>
             <type>pom</type>

--- a/ejb-multi-server/app-one/ejb/pom.xml
+++ b/ejb-multi-server/app-one/ejb/pom.xml
@@ -101,7 +101,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
         </dependency>

--- a/ejb-multi-server/app-two/ear/pom.xml
+++ b/ejb-multi-server/app-two/ear/pom.xml
@@ -101,7 +101,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <scope>provided</scope>
             <type>pom</type>

--- a/ejb-multi-server/app-two/ejb/pom.xml
+++ b/ejb-multi-server/app-two/ejb/pom.xml
@@ -101,7 +101,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
         </dependency>

--- a/ejb-multi-server/app-web/pom.xml
+++ b/ejb-multi-server/app-web/pom.xml
@@ -41,7 +41,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
             <scope>provided</scope>

--- a/ejb-multi-server/client/pom.xml
+++ b/ejb-multi-server/client/pom.xml
@@ -47,7 +47,7 @@
 
         <!-- Include the ejb client jars -->
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
             <scope>compile</scope>

--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -88,7 +88,7 @@
 
         <!-- Include the ejb client jars -->
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
             <scope>compile</scope>

--- a/ejb-security-interceptors/pom.xml
+++ b/ejb-security-interceptors/pom.xml
@@ -133,7 +133,7 @@
     <dependencies>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-security-api</artifactId>
         </dependency>
 
@@ -144,7 +144,7 @@
 
         <!-- Include the ejb client jars -->
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
             <scope>compile</scope>

--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -127,7 +127,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-jms-client-bom</artifactId>
             <type>pom</type>
         </dependency>

--- a/shopping-cart/client/pom.xml
+++ b/shopping-cart/client/pom.xml
@@ -49,7 +49,7 @@
             client API isn't directly used in this example. We just need it in our runtime
             classpath -->
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <scope>runtime</scope>
             <type>pom</type>

--- a/spring-kitchensink-springmvctest/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/springmvctest/test/MemberMockMVCTest.java
+++ b/spring-kitchensink-springmvctest/src/test/java/org/jboss/as/quickstarts/kitchensink/spring/springmvctest/test/MemberMockMVCTest.java
@@ -76,7 +76,7 @@ public class MemberMockMVCTest {
     @Test
     public void getAccount() throws Exception {
         this.mockMvc.perform(get("/rest/members/0").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
             .andExpect(jsonPath("$.name").value("John Smith"));
     }
 }


### PR DESCRIPTION
use following command to run with clean local maven repo to prevent resolution errors
use maven 3.3.9 as some older versions have dependency resolution problems

mvn -Dmaven.repo.local=/tmp/zz-repo clean install '-Pdefault,!complex-dependencies' 2>&1 | tee /tmp/log.txt
