### PR TITLE
Trim dependency tree a bit

### DIFF
--- a/bean-validation-custom-constraint/pom.xml
+++ b/bean-validation-custom-constraint/pom.xml
@@ -122,14 +122,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
-            <!-- Manage the version of jboss-common-beans to prevent hibernate from
-                 bringing in an older version -->
-            <dependency>
-                <groupId>org.jboss.common</groupId>
-                <artifactId>jboss-common-beans</artifactId>
-                <version>2.0.0.Final</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -168,12 +160,9 @@
         </dependency>
 
         <!-- Now we declare any tools needed -->
-
-        <!-- Needed for Hibernate Annotations -->
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Needed for running tests (you may also use TestNG) -->

--- a/ejb-security-interceptors/pom.xml
+++ b/ejb-security-interceptors/pom.xml
@@ -135,12 +135,88 @@
         <dependency>
             <groupId>org.jboss.eap</groupId>
             <artifactId>wildfly-security-api</artifactId>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.wildfly.core</groupId>
+                        <artifactId>wildfly-domain-management</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.wildfly.core</groupId>
+                        <artifactId>wildfly-server</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.wildfly.core</groupId>
+                        <artifactId>wildfly-controller</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.eap</groupId>
+                        <artifactId>wildfly-naming</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.eap</groupId>
+                        <artifactId>wildfly-clustering-infinispan-spi</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.eap</groupId>
+                        <artifactId>wildfly-transactions</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.eap</groupId>
+                        <artifactId>wildfly-ee</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.msc</groupId>
+                        <artifactId>jboss-msc</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.security</groupId>
+                        <artifactId>jboss-negotiation-extras</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.security</groupId>
+                        <artifactId>jboss-negotiation-spnego</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.picketbox</groupId>
+                        <artifactId>picketbox-infinispan</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.security.jacc</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-cli</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.wildfly.checkstyle</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.wildfly.security</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.interceptor</groupId>
+            <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
+            <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.picketbox</groupId>
-            <artifactId>picketbox-commons</artifactId>
-        </dependency>
 
         <!-- Include the ejb client jars -->
         <dependency>

--- a/jaxws-ejb/pom.xml
+++ b/jaxws-ejb/pom.xml
@@ -152,6 +152,7 @@
                 <artifactId>istack-commons-runtime</artifactId>
                 <version>${version.istack.commons.runtime}</version>
             </dependency>
+            <!-- TODO this is beyond wrong -->
             <dependency>
                 <groupId>org.jboss</groupId>
                 <artifactId>jbossxb</artifactId>


### PR DESCRIPTION
 I will follow up with more PRs on this topic.

This trims dep tree quite a bit, as removes need for half of EAP & wildfly core to be present to build ejb-security-interceptor QS
