### PR TITLE
JBEAP-6344: Do not use injected JMSContext in thread-racing quickstart

### DIFF
--- a/thread-racing/src/main/java/org/jboss/as/quickstarts/threadracing/stage/jms/JMSRaceStage.java
+++ b/thread-racing/src/main/java/org/jboss/as/quickstarts/threadracing/stage/jms/JMSRaceStage.java
@@ -20,7 +20,7 @@ import org.jboss.as.quickstarts.threadracing.Race;
 import org.jboss.as.quickstarts.threadracing.stage.RaceStage;
 
 import javax.annotation.Resource;
-import javax.inject.Inject;
+import javax.jms.ConnectionFactory;
 import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
 import javax.jms.Queue;
@@ -39,30 +39,29 @@ public class JMSRaceStage implements RaceStage {
      */
     @Resource(lookup = JMSRaceStageMessageListener.REQUEST_QUEUE)
     private Queue requestQueue;
-
-    /**
-     * CDI injection of a JMS context
-     */
-    @Inject
-    private JMSContext jmsContext;
+    @Resource(lookup = "java:comp/DefaultJMSConnectionFactory")
+    private ConnectionFactory cf;
 
     @Override
     public void run(Race.Registration registration) throws Exception {
-        // create response tmp queue
-        final TemporaryQueue responseQueue = jmsContext.createTemporaryQueue();
-        // send request
-        final String request = UUID.randomUUID().toString();
-        jmsContext.createProducer()
-            .setJMSReplyTo(responseQueue)
-            .send(requestQueue, request);
-        // receive response
-        try (JMSConsumer consumer = jmsContext.createConsumer(responseQueue)) {
-            String response = consumer.receiveBody(String.class);
-            if (response == null) {
-                registration.aborted(new IllegalStateException("Message processing timed out"));
-            } else if (!response.equals(request)) {
-                registration.aborted(new IllegalStateException("Response content does not match the request. Response: " + response + ", request: " + request));
+        try (JMSContext jmsContext = cf.createContext()) {
+            // create response tmp queue
+            final TemporaryQueue responseQueue = jmsContext.createTemporaryQueue();
+            // send request
+            final String request = UUID.randomUUID().toString();
+            jmsContext.createProducer()
+                    .setJMSReplyTo(responseQueue)
+                    .send(requestQueue, request);
+            // receive response
+            try (JMSConsumer consumer = jmsContext.createConsumer(responseQueue)) {
+                String response = consumer.receiveBody(String.class);
+                if (response == null) {
+                    registration.aborted(new IllegalStateException("Message processing timed out"));
+                } else if (!response.equals(request)) {
+                    registration.aborted(new IllegalStateException("Response content does not match the request. Response: " + response + ", request: " + request));
+                }
             }
         }
     }
 }
+


### PR DESCRIPTION
Injected JMSContext are not supported when call is coming from a
WebSocket endpoint as they do not define CDI scope for managed bean (as
reported in https://issues.jboss.org/browse/CDI-370 and
https://java.net/jira/browse/WEBSOCKET_SPEC-196).

Instead, look up the default JMS ConnectionFactory and create an
application-managed JMSContext in a try-with-resources block.
