### PR TITLE
Adjusts to solve JAX-WS 2.2 issue.

### DIFF
--- a/wsat-simple/src/main/java/org/jboss/as/quickstarts/wsat/simple/jaxws/RestaurantServiceATService.java
+++ b/wsat-simple/src/main/java/org/jboss/as/quickstarts/wsat/simple/jaxws/RestaurantServiceATService.java
@@ -53,6 +53,10 @@ public class RestaurantServiceATService extends Service {
         super(wsdlLocation, serviceName);
     }
 
+    public RestaurantServiceATService(URL wsdlLocation, QName serviceName, WebServiceFeature... features) {
+        super(wsdlLocation, serviceName, features);
+    }
+
     public RestaurantServiceATService() {
         super(RESTAURANTSERVICEATSERVICE_WSDL_LOCATION, new QName(
             "http://www.jboss.org/jboss-jdf/jboss-as-quickstart/wsat/simple/Restaurant", "RestaurantServiceATService"));


### PR DESCRIPTION
Included method to solve WSFException. "Caused by: org.jboss.wsf.spi.WSFException: JBWS024104: Service class org.jboss.as.quickstarts.wsat.simple.jaxws.RestaurantServiceATService is missing required JAX-WS 2.2 additional constructors" and "Caused by: java.lang.NoSuchMethodException: org.jboss.as.quickstarts.wsat.simple.jaxws.RestaurantServiceATService.<init>(java.net.URL, javax.xml.namespace.QName, [Ljavax.xml.ws.WebServiceFeature;)"