### PR TITLE
fix-issue-2109

### DIFF
--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/FacesConfiguration.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/FacesConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.tasksJsf;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.faces.annotation.FacesConfig;
+
+/**
+ * This class is needed to activate JSF-specific injections like FacesContext, ExternalContext, etc.
+ *
+ * @author Rene Fischer
+ */
+@FacesConfig(version = FacesConfig.Version.JSF_2_3)
+@ApplicationScoped
+public class FacesConfiguration {
+}

--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/Resources.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/Resources.java
@@ -22,7 +22,6 @@ import javax.ejb.Stateful;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.InjectionPoint;
-import javax.faces.context.FacesContext;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.PersistenceContextType;
@@ -55,10 +54,5 @@ public class Resources {
     public Logger getLogger(InjectionPoint ip) {
         String category = ip.getMember().getDeclaringClass().getName();
         return Logger.getLogger(category);
-    }
-
-    @Produces
-    public FacesContext getFacesContext() {
-        return FacesContext.getCurrentInstance();
     }
 }


### PR DESCRIPTION
in this PR a dedicated configuration class is used to activate JSF 2.3 features in JBoss EAP 7.3
Injection points like FacesContext and ExternalContext work out of the box in JBoss EAP 7.3 with this class.

No manual CDI Produces are necessary and JSF 2.3 works like described in the JSF docs.